### PR TITLE
api: modify create analysis endpoint

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -118,7 +118,7 @@
           "application/json"
         ],
         "responses": {
-          "200": {
+          "201": {
             "description": "Request succeeded. The workflow has been created.",
             "examples": {
               "application/json": {
@@ -140,6 +140,12 @@
           },
           "400": {
             "description": "Request failed. The incoming data specification seems malformed"
+          },
+          "500": {
+            "description": "Request failed. Internal controller error."
+          },
+          "501": {
+            "description": "Request failed. Not implemented."
           }
         },
         "summary": "Creates a new workflow based on a REANA specification file."

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -80,7 +80,7 @@
         "consumes": [
           "application/json"
         ],
-        "description": "This resource is expecting JSON data with all the necessary information to instantiate a yadage workflow.",
+        "description": "This resource is expecting a REANA specification in JSON format with all the necessary information to instantiate a workflow.",
         "operationId": "create_analysis",
         "parameters": [
           {
@@ -119,10 +119,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Request succeeded. The workflow has been instantiated.",
+            "description": "Request succeeded. The workflow has been created.",
             "examples": {
               "application/json": {
-                "message": "Analysis successfully launched",
+                "message": "The workflow has been successfully created.",
                 "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
               }
             },
@@ -142,7 +142,7 @@
             "description": "Request failed. The incoming data specification seems malformed"
           }
         },
-        "summary": "Creates a new yadage workflow."
+        "summary": "Creates a new workflow based on a REANA specification file."
       }
     },
     "/api/analyses/{analysis_id}/workspace": {

--- a/reana_server/openapi_connections/reana_workflow_controller.json
+++ b/reana_server/openapi_connections/reana_workflow_controller.json
@@ -150,8 +150,8 @@
           "application/json"
         ],
         "responses": {
-          "200": {
-            "description": "Request succeeded. The file has been added to the workspace.",
+          "201": {
+            "description": "Request succeeded. The workflow has been created along with its workspace",
             "examples": {
               "application/json": {
                 "message": "Workflow workspace has been created.",

--- a/reana_server/openapi_connections/reana_workflow_controller.json
+++ b/reana_server/openapi_connections/reana_workflow_controller.json
@@ -85,6 +85,14 @@
           "400": {
             "description": "Request failed. The incoming data specification seems malformed."
           },
+          "404": {
+            "description": "Request failed. User doesn't exist.",
+            "examples": {
+              "application/json": {
+                "message": "User 00000000-0000-0000-0000-000000000000 doesn't exist"
+              }
+            }
+          },
           "500": {
             "description": "Request failed. Internal controller error.",
             "examples": {
@@ -95,6 +103,86 @@
           }
         },
         "summary": "Returns all workflows."
+      },
+      "post": {
+        "description": "This resource expects a POST call to create a new workflow workspace.",
+        "operationId": "create_workflow",
+        "parameters": [
+          {
+            "description": "Required. Organization which the worklow belongs to.",
+            "in": "query",
+            "name": "organization",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "JSON object including workflow parameters and workflow specification in JSON format (`yadageschemas.load()` output) with necessary data to instantiate a yadage workflow.",
+            "in": "body",
+            "name": "workflow",
+            "required": true,
+            "schema": {
+              "properties": {
+                "parameters": {
+                  "description": "Workflow parameters.",
+                  "type": "object"
+                },
+                "specification": {
+                  "description": "Yadage specification in JSON format.",
+                  "type": "object"
+                },
+                "type": {
+                  "description": "Workflow type.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The file has been added to the workspace.",
+            "examples": {
+              "application/json": {
+                "message": "Workflow workspace has been created.",
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed"
+          },
+          "404": {
+            "description": "Request failed. User doesn't exist.",
+            "examples": {
+              "application/json": {
+                "message": "User 00000000-0000-0000-0000-000000000000 doesn't exist"
+              }
+            }
+          }
+        },
+        "summary": "Create workflow and its workspace."
       }
     },
     "/api/workflows/{workflow_id}/workspace": {
@@ -149,8 +237,7 @@
             "description": "Request succeeded. The file has been added to the workspace.",
             "examples": {
               "application/json": {
-                "message": "Workflow has been added to the workspace",
-                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+                "message": "The file input.csv has been successfully transferred."
               }
             },
             "schema": {
@@ -167,6 +254,9 @@
           },
           "400": {
             "description": "Request failed. The incoming data specification seems malformed"
+          },
+          "500": {
+            "description": "Request failed. Internal controller error."
           }
         },
         "summary": "Adds a file to the workflow workspace."

--- a/reana_server/rest/analyses.py
+++ b/reana_server/rest/analyses.py
@@ -110,10 +110,10 @@ def create_analysis():  # noqa
 
     ---
     post:
-      summary: Creates a new yadage workflow.
+      summary: Creates a new workflow based on a REANA specification file.
       description: >-
-        This resource is expecting JSON data with all the necessary
-        information to instantiate a yadage workflow.
+        This resource is expecting a REANA specification in JSON format with
+        all the necessary information to instantiate a workflow.
       operationId: create_analysis
       consumes:
         - application/json
@@ -146,7 +146,7 @@ def create_analysis():  # noqa
       responses:
         200:
           description: >-
-            Request succeeded. The workflow has been instantiated.
+            Request succeeded. The workflow has been created.
           schema:
             type: object
             properties:
@@ -157,7 +157,7 @@ def create_analysis():  # noqa
           examples:
             application/json:
               {
-                "message": "Analysis successfully launched",
+                "message": "The workflow has been successfully created.",
                 "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
               }
         400:
@@ -165,35 +165,30 @@ def create_analysis():  # noqa
             Request failed. The incoming data specification seems malformed
     """
     try:
-        reana_spec_file = None
-        reana_spec_url = None
         if request.json:
             # validate against schema
-            reana_spec = request.json
-            workflow_engine = reana_spec['workflow']['type']
+            reana_spec_file = request.json
+            workflow_engine = reana_spec_file['workflow']['type']
         elif request.args.get('spec'):
-            # TODO implement load workflow engine from remote
+            # TODO implement load reana spec from remote
             return jsonify('Not implemented'), 501
         else:
             raise Exception('Either remote repository or a reana spec need to \
             be provided')
 
         if workflow_engine not in app.config['AVAILABLE_WORKFLOW_ENGINES']:
-            raise Exception('Unknown workflow engine')
+            raise Exception('Unknown workflow type.')
 
-        if workflow_engine == 'yadage':
-            if reana_spec_file:
-                # From spec file
-                (response, status_code) = \
-                    rwc_api_client.api.run_yadage_workflow_from_spec(
-                        workflow={
-                            'parameters': reana_spec['parameters'],
-                            'workflow_spec': reana_spec['workflow']['spec'],
-                        },
-                        user=request.args.get('user'),
-                        organization=request.args.get('organization')).result()
+        response, status_code = rwc_api_client.api.create_workflow(
+            workflow={
+                'parameters': reana_spec_file['parameters'],
+                'specification': reana_spec_file['workflow']['spec'],
+                'type': reana_spec_file['workflow']['type'],
+            },
+            user=request.args.get('user'),
+            organization=request.args.get('organization')).result()
 
-            return jsonify(response), status_code
+        return jsonify(response), status_code
     except KeyError as e:
         return jsonify({"message": str(e)}), 400
     except Exception as e:

--- a/reana_server/rest/analyses.py
+++ b/reana_server/rest/analyses.py
@@ -96,10 +96,10 @@ def get_analyses():  # noqa
               }
     """
     try:
-        response, status_code = rwc_api_client.api.get_workflows(
+        response, http_response = rwc_api_client.api.get_workflows(
             organization='default',
             user='00000000-0000-0000-0000-000000000000').result()
-        return jsonify(response), status_code
+        return jsonify(response), http_response.status_code
     except Exception as e:
         return jsonify({"message": str(e)}), 500
 
@@ -144,7 +144,7 @@ def create_analysis():  # noqa
           schema:
             type: object
       responses:
-        200:
+        201:
           description: >-
             Request succeeded. The workflow has been created.
           schema:
@@ -163,6 +163,12 @@ def create_analysis():  # noqa
         400:
           description: >-
             Request failed. The incoming data specification seems malformed
+        500:
+          description: >-
+            Request failed. Internal controller error.
+        501:
+          description: >-
+            Request failed. Not implemented.
     """
     try:
         if request.json:
@@ -179,7 +185,7 @@ def create_analysis():  # noqa
         if workflow_engine not in app.config['AVAILABLE_WORKFLOW_ENGINES']:
             raise Exception('Unknown workflow type.')
 
-        response, status_code = rwc_api_client.api.create_workflow(
+        response, http_response = rwc_api_client.api.create_workflow(
             workflow={
                 'parameters': reana_spec_file['parameters'],
                 'specification': reana_spec_file['workflow']['spec'],
@@ -188,7 +194,7 @@ def create_analysis():  # noqa
             user=request.args.get('user'),
             organization=request.args.get('organization')).result()
 
-        return jsonify(response), status_code
+        return jsonify(response), http_response.status_code
     except KeyError as e:
         return jsonify({"message": str(e)}), 400
     except Exception as e:
@@ -257,14 +263,14 @@ def seed_analysis(analysis_id):  # noqa
     """
     try:
         file_ = request.files['file_content'].stream.read()
-        response, status_code = rwc_api_client.api.seed_workflow(
+        response, http_response = rwc_api_client.api.seed_workflow(
             user=request.args['user'],
             organization=request.args['organization'],
             workflow_id=analysis_id,
             file_content=file_,
             file_name=request.args['file_name']).result()
 
-        return jsonify(response), status_code
+        return jsonify(response), http_response.status_code
     except KeyError as e:
         return jsonify({"message": str(e)}), 400
     except Exception as e:


### PR DESCRIPTION
* Updates to lastest `rwc` OpenAPI version.

* Create analysis doens't start the workflow straight away, now it creates it in DB
  and bootstraps the working space.

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>