### PR TITLE
api: support specifying workflow run name

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -37,24 +37,28 @@
               "application/json": [
                 {
                   "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                  "name": "mytest-1",
                   "organization": "default_org",
                   "status": "running",
                   "user": "00000000-0000-0000-0000-000000000000"
                 },
                 {
                   "id": "3c9b117c-d40a-49e3-a6de-5f89fcada5a3",
+                  "name": "mytest-2",
                   "organization": "default_org",
                   "status": "finished",
                   "user": "00000000-0000-0000-0000-000000000000"
                 },
                 {
                   "id": "72e3ee4f-9cd3-4dc7-906c-24511d9f5ee3",
+                  "name": "mytest-3",
                   "organization": "default_org",
                   "status": "waiting",
                   "user": "00000000-0000-0000-0000-000000000000"
                 },
                 {
                   "id": "c4c0a1a6-beef-46c7-be04-bf4b3beca5a1",
+                  "name": "mytest-4",
                   "organization": "default_org",
                   "status": "waiting",
                   "user": "00000000-0000-0000-0000-000000000000"
@@ -65,6 +69,9 @@
               "items": {
                 "properties": {
                   "id": {
+                    "type": "string"
+                  },
+                  "name": {
                     "type": "string"
                   },
                   "organization": {
@@ -126,6 +133,13 @@
             "type": "string"
           },
           {
+            "description": "Name of the workflow to be created. If not provided name will be generated.",
+            "in": "query",
+            "name": "workflow_name",
+            "required": true,
+            "type": "string"
+          },
+          {
             "description": "Remote repository which contains a valid REANA specification.",
             "in": "query",
             "name": "spec",
@@ -151,7 +165,8 @@
             "examples": {
               "application/json": {
                 "message": "The workflow has been successfully created.",
-                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -160,6 +175,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -187,7 +205,7 @@
         "summary": "Creates a new workflow based on a REANA specification file."
       }
     },
-    "/api/analyses/{analysis_id}/logs": {
+    "/api/analyses/{analysis_id_or_name}/logs": {
       "get": {
         "description": "This resource reports the status of an analysis. Resource is expecting a analysis UUID.",
         "operationId": "get_analysis_logs",
@@ -207,9 +225,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Analysis UUID.",
+            "description": "Required. Analysis UUID or name.",
             "in": "path",
-            "name": "analysis_id",
+            "name": "analysis_id_or_name",
             "required": true,
             "type": "string"
           }
@@ -225,7 +243,8 @@
                 "logs": "<Workflow engine log output>",
                 "organization": "default_org",
                 "user": "00000000-0000-0000-0000-000000000000",
-                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1"
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -240,6 +259,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -277,7 +299,7 @@
         "summary": "Get workflow logs of an analysis."
       }
     },
-    "/api/analyses/{analysis_id}/status": {
+    "/api/analyses/{analysis_id_or_name}/status": {
       "get": {
         "description": "This resource reports the status of an analysis. Resource is expecting a analysis UUID.",
         "operationId": "get_analysis_status",
@@ -297,9 +319,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Analysis UUID.",
+            "description": "Required. Analysis UUID or name.",
             "in": "path",
-            "name": "analysis_id",
+            "name": "analysis_id_or_name",
             "required": true,
             "type": "string"
           }
@@ -313,6 +335,7 @@
             "examples": {
               "application/json": {
                 "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "name": "mytest-1",
                 "organization": "default_org",
                 "status": "created",
                 "user": "00000000-0000-0000-0000-000000000000"
@@ -321,6 +344,9 @@
             "schema": {
               "properties": {
                 "id": {
+                  "type": "string"
+                },
+                "name": {
                   "type": "string"
                 },
                 "organization": {
@@ -388,9 +414,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Analysis UUID.",
+            "description": "Required. Analysis UUID or name.",
             "in": "path",
-            "name": "analysis_id",
+            "name": "analysis_id_or_name",
             "required": true,
             "type": "string"
           },
@@ -414,9 +440,11 @@
             "examples": {
               "application/json": {
                 "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "message": "Workflow successfully launched",
                 "organization": "default_org",
                 "status": "created",
-                "user": "00000000-0000-0000-0000-000000000000"
+                "user": "00000000-0000-0000-0000-000000000000",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -434,6 +462,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -487,7 +518,7 @@
         "summary": "Set status of an analysis."
       }
     },
-    "/api/analyses/{analysis_id}/workspace/code": {
+    "/api/analyses/{analysis_id_or_name}/workspace/code": {
       "post": {
         "consumes": [
           "multipart/form-data"
@@ -510,9 +541,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Analysis UUID.",
+            "description": "Required. Analysis UUID or name.",
             "in": "path",
-            "name": "analysis_id",
+            "name": "analysis_id_or_name",
             "required": true,
             "type": "string"
           },
@@ -536,7 +567,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request succeeded. File successfully trasferred.",
+            "description": "Request succeeded. File successfully transferred.",
             "examples": {
               "application/json": {
                 "message": "File successfully transferred"
@@ -569,7 +600,7 @@
         "summary": "Seeds the analysis workspace with the provided file."
       }
     },
-    "/api/analyses/{analysis_id}/workspace/code/": {
+    "/api/analyses/{analysis_id_or_name}/workspace/code/": {
       "get": {
         "description": "This resource is expecting an analysis UUID to return its list of code files.",
         "operationId": "get_analysis_code",
@@ -589,9 +620,9 @@
             "type": "string"
           },
           {
-            "description": "Required. analysis UUID.",
+            "description": "Required. Analysis UUID or name.",
             "in": "path",
-            "name": "analysis_id",
+            "name": "analysis_id_or_name",
             "required": true,
             "type": "string"
           }
@@ -644,7 +675,7 @@
         "summary": "Returns the list of code files for a specific analysis."
       }
     },
-    "/api/analyses/{analysis_id}/workspace/inputs": {
+    "/api/analyses/{analysis_id_or_name}/workspace/inputs": {
       "post": {
         "consumes": [
           "multipart/form-data"
@@ -667,9 +698,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Analysis UUID.",
+            "description": "Required. Analysis UUID or name",
             "in": "path",
-            "name": "analysis_id",
+            "name": "analysis_id_or_name",
             "required": true,
             "type": "string"
           },
@@ -726,7 +757,7 @@
         "summary": "Seeds the analysis workspace with the provided file."
       }
     },
-    "/api/analyses/{analysis_id}/workspace/inputs/": {
+    "/api/analyses/{analysis_id_or_name}/workspace/inputs/": {
       "get": {
         "description": "This resource is expecting an analysis UUID to return its list of input files.",
         "operationId": "get_analysis_inputs",
@@ -746,9 +777,9 @@
             "type": "string"
           },
           {
-            "description": "Required. analysis UUID.",
+            "description": "Required. Analysis UUID or name.",
             "in": "path",
-            "name": "analysis_id",
+            "name": "analysis_id_or_name",
             "required": true,
             "type": "string"
           }
@@ -801,7 +832,7 @@
         "summary": "Returns the list of input files for a specific analysis."
       }
     },
-    "/api/analyses/{analysis_id}/workspace/outputs/": {
+    "/api/analyses/{analysis_id_or_name}/workspace/outputs/": {
       "get": {
         "description": "This resource is expecting an analysis UUID to return its list of output files.",
         "operationId": "get_analysis_outputs",
@@ -821,9 +852,9 @@
             "type": "string"
           },
           {
-            "description": "Required. analysis UUID.",
+            "description": "Required. Analysis UUID or name.",
             "in": "path",
-            "name": "analysis_id",
+            "name": "analysis_id_or_name",
             "required": true,
             "type": "string"
           }
@@ -876,7 +907,7 @@
         "summary": "Returns the list of output files for a specific analysis."
       }
     },
-    "/api/analyses/{analysis_id}/workspace/outputs/{file_name}": {
+    "/api/analyses/{analysis_id_or_name}/workspace/outputs/{file_name}": {
       "get": {
         "description": "This resource is expecting a workflow UUID and a file name to return its content.",
         "operationId": "get_analysis_outputs_file",
@@ -896,9 +927,9 @@
             "type": "string"
           },
           {
-            "description": "Required. analysis UUID.",
+            "description": "Required. analysis UUID or name.",
             "in": "path",
-            "name": "analysis_id",
+            "name": "analysis_id_or_name",
             "required": true,
             "type": "string"
           },

--- a/reana_server/openapi_connections/reana_workflow_controller.json
+++ b/reana_server/openapi_connections/reana_workflow_controller.json
@@ -65,7 +65,8 @@
             "examples": {
               "application/json": {
                 "message": "Workflow successfully launched",
-                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -74,6 +75,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -117,24 +121,28 @@
               "application/json": [
                 {
                   "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                  "name": "mytest-1",
                   "organization": "default_org",
                   "status": "running",
                   "user": "00000000-0000-0000-0000-000000000000"
                 },
                 {
                   "id": "3c9b117c-d40a-49e3-a6de-5f89fcada5a3",
+                  "name": "mytest-2",
                   "organization": "default_org",
                   "status": "finished",
                   "user": "00000000-0000-0000-0000-000000000000"
                 },
                 {
                   "id": "72e3ee4f-9cd3-4dc7-906c-24511d9f5ee3",
+                  "name": "mytest-3",
                   "organization": "default_org",
                   "status": "waiting",
                   "user": "00000000-0000-0000-0000-000000000000"
                 },
                 {
                   "id": "c4c0a1a6-beef-46c7-be04-bf4b3beca5a1",
+                  "name": "mytest-4",
                   "organization": "default_org",
                   "status": "waiting",
                   "user": "00000000-0000-0000-0000-000000000000"
@@ -145,6 +153,9 @@
               "items": {
                 "properties": {
                   "id": {
+                    "type": "string"
+                  },
+                  "name": {
                     "type": "string"
                   },
                   "organization": {
@@ -209,6 +220,10 @@
             "required": true,
             "schema": {
               "properties": {
+                "name": {
+                  "description": "Workflow name. If empty name will be generated.",
+                  "type": "string"
+                },
                 "parameters": {
                   "description": "Workflow parameters.",
                   "type": "object"
@@ -235,7 +250,8 @@
             "examples": {
               "application/json": {
                 "message": "Workflow workspace has been created.",
-                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -244,6 +260,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -265,7 +284,7 @@
         "summary": "Create workflow and its workspace."
       }
     },
-    "/api/workflows/{workflow_id}/logs": {
+    "/api/workflows/{workflow_id_or_name}/logs": {
       "get": {
         "description": "This resource is expecting a workflow UUID and a filename to return its outputs.",
         "operationId": "get_workflow_logs",
@@ -285,9 +304,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name.",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           }
@@ -303,14 +322,12 @@
                 "logs": "<Workflow engine log output>",
                 "organization": "default_org",
                 "user": "00000000-0000-0000-0000-000000000000",
-                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1"
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
               "properties": {
-                "id": {
-                  "type": "string"
-                },
                 "logs": {
                   "type": "string"
                 },
@@ -318,6 +335,12 @@
                   "type": "string"
                 },
                 "user": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -347,7 +370,7 @@
         "summary": "Returns logs of a specific workflow from a workflow engine."
       }
     },
-    "/api/workflows/{workflow_id}/status": {
+    "/api/workflows/{workflow_id_or_name}/status": {
       "get": {
         "description": "This resource reports the status of workflow.",
         "operationId": "get_workflow_status",
@@ -367,9 +390,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name.",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           }
@@ -383,6 +406,7 @@
             "examples": {
               "application/json": {
                 "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "name": "mytest-1",
                 "organization": "default_org",
                 "status": "running",
                 "user": "00000000-0000-0000-0000-000000000000"
@@ -391,6 +415,9 @@
             "schema": {
               "properties": {
                 "id": {
+                  "type": "string"
+                },
+                "name": {
                   "type": "string"
                 },
                 "organization": {
@@ -455,9 +482,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name.",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           },
@@ -484,7 +511,8 @@
                 "organization": "default_org",
                 "status": "running",
                 "user": "00000000-0000-0000-0000-000000000000",
-                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1"
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -502,6 +530,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -555,7 +586,7 @@
         "summary": "Set workflow status."
       }
     },
-    "/api/workflows/{workflow_id}/workspace": {
+    "/api/workflows/{workflow_id_or_name}/workspace": {
       "get": {
         "description": "This resource is expecting a workflow UUID and a filename to return its list of code|input|output files.",
         "operationId": "get_workflow_files",
@@ -575,9 +606,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name.",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           },
@@ -658,9 +689,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name.",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           },
@@ -701,9 +732,6 @@
               "properties": {
                 "message": {
                   "type": "string"
-                },
-                "workflow_id": {
-                  "type": "string"
                 }
               },
               "type": "object"
@@ -735,7 +763,7 @@
         "summary": "Adds a file to the workflow workspace."
       }
     },
-    "/api/workflows/{workflow_id}/workspace/outputs/{file_name}": {
+    "/api/workflows/{workflow_id_or_name}/workspace/outputs/{file_name}": {
       "get": {
         "description": "This resource is expecting a workflow UUID and a filename to return its content.",
         "operationId": "get_workflow_outputs_file",
@@ -755,9 +783,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           },
@@ -860,7 +888,8 @@
             "examples": {
               "application/json": {
                 "message": "Workflow successfully launched",
-                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -869,6 +898,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -933,7 +965,8 @@
             "examples": {
               "application/json": {
                 "message": "Workflow successfully launched",
-                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -942,6 +975,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2018 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# REANA is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# REANA; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+# Suite 330, Boston, MA 02111-1307, USA.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+"""REANA-Server utils."""
+
+from uuid import UUID
+
+
+def is_uuid_v4(uuid_or_name):
+    """Check if given string is a valid UUIDv4."""
+    # Based on https://gist.github.com/ShawnMilo/7777304
+    try:
+        uuid = UUID(uuid_or_name, version=4)
+    except Exception:
+        return False
+
+    return uuid.hex == uuid_or_name.replace('-', '')


### PR DESCRIPTION
* Add support for specifying a name for a workflow
  when creating the workflow.
  (closes reanahub/reana-client#70)

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>