### PR TITLE
api: send empty dict when there are no params

### DIFF
--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -259,11 +259,8 @@ def create_workflow():  # noqa
         workflow_dict = {'specification': reana_spec_file['workflow']['spec'],
                          'type': reana_spec_file['workflow']['type'],
                          'name': workflow_name}
-        parameters = None
-        if 'inputs' in reana_spec_file:
-            if 'parameters' in reana_spec_file['inputs']:
-                parameters = reana_spec_file['inputs']['parameters']
-        workflow_dict['parameters'] = parameters
+        workflow_dict['parameters'] = \
+            reana_spec_file.get('inputs', {}).get('parameters', {})
         response, http_response = rwc_api_client.api.create_workflow(
             workflow=workflow_dict,
             user=user_id).result()


### PR DESCRIPTION
* FIXES when sending empty parameters None was passed to Bravado,
  serializing the parameters field as None. An empty dict is passed
  instead.

Connects reanahub/reana-workflow-engine-serial#27.