### PR TITLE
docker: exit if database could not be created

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ ENV FLASK_APP=/code/reana_server/app.py
 
 EXPOSE 5000
 
-CMD flask db init && \
+CMD set -e && flask db init && \
     flask users create_default info@reana.io &&\
     uwsgi --module reana_server.app:app \
     --http-socket 0.0.0.0:5000 --master \


### PR DESCRIPTION
* In REANA v0.3.0, REANA Server has the responsibility of creating
  the database. Therefore, if the component can not create the
  database it should fail. It comes handy when deployed on Kubernetes,
  where the pod will restart until the database service is ready
  (closes #79).