### PR TITLE
installation: setup.py for REANA-Commons and REANA-DB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,6 @@ FROM python:3.6
 RUN apt-get update && \
     apt-get install -y vim-tiny
 
-RUN pip install -e git://github.com/reanahub/reana-commons.git@master#egg=reana-commons
-RUN pip install -e git://github.com/reanahub/reana-db.git@master#egg=reana-db
-
-
 COPY CHANGES.rst README.rst setup.py /code/
 COPY reana_server/version.py /code/reana_server/
 WORKDIR /code

--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,8 @@ install_requires = [
     'flask-cors>=3.0.6',
     'marshmallow>=2.13',
     'pyOpenSSL==17.3.0',  # FIXME remove once yadage-schemas solves deps.
-    'reana-commons>=0.3.0',
-    'reana-db>=0.3.0',
+    'reana-commons>=0.3.1,<0.4.0',
+    'reana-db>=0.3.0,<0.4.0',
     'requests==2.11.1',
     'rfc3987==1.3.7',  # FIXME remove once yadage-schemas solves deps.
     'strict-rfc3339==0.7',  # FIXME remove once yadage-schemas solves deps.


### PR DESCRIPTION
* Uses only `setup.py` to install REANA-Commons and REANA-DB dependencies and
  introduced upper boundary for their versions. (addresses reanahub/reana#80)

* Removes installation of their `master` versions from `Dockerfile`.
  (closes #85)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>