### PR TITLE
installation: more version limits

### DIFF
--- a/reana_server/version.py
+++ b/reana_server/version.py
@@ -27,4 +27,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.3.0"
+__version__ = "0.3.1.dev20180905"

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'bravado>=9.0.6',
+    'bravado>=9.0.6,<10.2',
     'click>=6.7',
     'Flask>=0.11',
     'fs>=2.0',


### PR DESCRIPTION
* Introduces more upper boundary limits for selected important
  dependencies (Bravado, Celery) for the cluster components.
  (addresses reanahub/reana#80)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>