### PR TITLE
Pass openapi specs to commons

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -485,6 +485,90 @@
         "summary": "Get workflow logs of a workflow."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/parameters": {
+      "get": {
+        "description": "This resource reports the input parameters of a workflow. Resource is expecting a workflow UUID.",
+        "operationId": "get_workflow_parameters",
+        "parameters": [
+          {
+            "description": "Required. Analysis UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. The API access_token of workflow owner.",
+            "in": "query",
+            "name": "access_token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. Workflow input parameters, including the status are returned.",
+            "examples": {
+              "application/json": {
+                "id": "dd4e93cf-e6d0-4714-a601-301ed97eec60",
+                "name": "workflow.24",
+                "parameters": {
+                  "helloworld": "code/helloworld.py",
+                  "inputfile": "data/names.txt",
+                  "outputfile": "results/greetings.txt",
+                  "sleeptime": 2
+                }
+              }
+            },
+            "schema": {
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "parameters": {
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming payload seems malformed.",
+            "examples": {
+              "application/json": {
+                "message": "Malformed request."
+              }
+            }
+          },
+          "403": {
+            "description": "Request failed. User is not allowed to access workflow.",
+            "examples": {
+              "application/json": {
+                "message": "User 00000000-0000-0000-0000-000000000000 is not allowed to access workflow 256b25f4-4cfb-4684-b7a8-73872ef455a1"
+              }
+            }
+          },
+          "404": {
+            "description": "Request failed. Either User or Analysis does not exist.",
+            "examples": {
+              "application/json": {
+                "message": "Analysis 256b25f4-4cfb-4684-b7a8-73872ef455a1 does not exist."
+              }
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error."
+          }
+        },
+        "summary": "Get parameters of a workflow."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/status": {
       "get": {
         "description": "This resource reports the status of a workflow. Resource is expecting a workflow UUID.",
@@ -628,7 +712,7 @@
             "type": "string"
           },
           {
-            "description": "Optional. Extra parameters for workflow status.",
+            "description": "Optional. Additional input and operational parameters.",
             "in": "body",
             "name": "parameters",
             "required": false,

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -528,7 +528,7 @@ def set_workflow_status(workflow_id_or_name):  # noqa
           type: string
         - name: parameters
           in: body
-          description: Optional. Extra parameters for workflow status.
+          description: Optional. Additional input and operational parameters.
           required: false
           schema:
             type: object
@@ -616,7 +616,6 @@ def set_workflow_status(workflow_id_or_name):  # noqa
             raise ValueError("workflow_id_or_name is not supplied")
         status = request.args.get('status')
         parameters = request.json
-
         response, http_response = current_rwc_api_client.api.\
             set_workflow_status(
                 user=user_id,
@@ -919,6 +918,109 @@ def get_files(workflow_id_or_name):  # noqa
                 workflow_id_or_name=workflow_id_or_name).result()
 
         return jsonify(http_response.json()), http_response.status_code
+    except HTTPError as e:
+        logging.error(traceback.format_exc())
+        return jsonify(e.response.json()), e.response.status_code
+    except ValueError as e:
+        logging.error(traceback.format_exc())
+        return jsonify({"message": str(e)}), 403
+    except Exception as e:
+        logging.error(traceback.format_exc())
+        return jsonify({"message": str(e)}), 500
+
+
+@blueprint.route('/workflows/<workflow_id_or_name>/parameters',
+                 methods=['GET'])
+def get_workflow_parameters(workflow_id_or_name):  # noqa
+    r"""Get workflow input parameters.
+
+    ---
+    get:
+      summary: Get parameters of a workflow.
+      description: >-
+        This resource reports the input parameters of a workflow.
+        Resource is expecting a workflow UUID.
+      operationId: get_workflow_parameters
+      produces:
+        - application/json
+      parameters:
+        - name: workflow_id_or_name
+          in: path
+          description: Required. Analysis UUID or name.
+          required: true
+          type: string
+        - name: access_token
+          in: query
+          description: Required. The API access_token of workflow owner.
+          required: true
+          type: string
+      responses:
+        200:
+          description: >-
+            Request succeeded. Workflow input parameters, including the status
+            are returned.
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              parameters:
+                type: object
+          examples:
+            application/json:
+              {
+                'id': 'dd4e93cf-e6d0-4714-a601-301ed97eec60',
+                'name': 'workflow.24',
+                'parameters': {'helloworld': 'code/helloworld.py',
+                               'inputfile': 'data/names.txt',
+                               'outputfile': 'results/greetings.txt',
+                               'sleeptime': 2}
+              }
+        400:
+          description: >-
+            Request failed. The incoming payload seems malformed.
+          examples:
+            application/json:
+              {
+                "message": "Malformed request."
+              }
+        403:
+          description: >-
+            Request failed. User is not allowed to access workflow.
+          examples:
+            application/json:
+              {
+                "message": "User 00000000-0000-0000-0000-000000000000
+                            is not allowed to access workflow
+                            256b25f4-4cfb-4684-b7a8-73872ef455a1"
+              }
+        404:
+          description: >-
+            Request failed. Either User or Analysis does not exist.
+          examples:
+            application/json:
+              {
+                "message": "Analysis 256b25f4-4cfb-4684-b7a8-73872ef455a1 does
+                            not exist."
+              }
+        500:
+          description: >-
+            Request failed. Internal controller error.
+    """
+    try:
+        user_id = get_user_from_token(request.args.get('access_token'))
+
+        if not workflow_id_or_name:
+            raise ValueError("workflow_id_or_name is not supplied")
+
+        response, http_response = current_rwc_api_client.api.\
+            get_workflow_parameters(
+                user=user_id,
+                workflow_id_or_name=workflow_id_or_name).result()
+
+        return jsonify(response), http_response.status_code
     except HTTPError as e:
         logging.error(traceback.format_exc())
         return jsonify(e.response.json()), e.response.status_code

--- a/scripts/generate_openapi_spec.py
+++ b/scripts/generate_openapi_spec.py
@@ -11,6 +11,7 @@
 
 import json
 import os
+import shutil
 
 import click
 from apispec import APISpec
@@ -35,8 +36,15 @@ __output_path__ = "temp_openapi.json"
 
 
 @click.command()
+@click.option(
+    '-d', '--dev',
+    multiple=True,
+    help='Optional parameters if set to TRUE, will pass generated and '
+         'validated openapi specifications to reana-commons module. '
+         'E.g. --dev=True.',
+)
 @with_appcontext
-def build_openapi_spec():
+def build_openapi_spec(dev):
     """Creates an OpenAPI definition of Flask application,
     check conformity of generated definition against OpenAPI 2.0 specification
     and writes it into a file."""
@@ -89,8 +97,35 @@ def build_openapi_spec():
         click.echo(
             click.style('OpenAPI specification validated successfully',
                         fg='green'))
+        copy_openapi_specs(dev)
 
     return spec.to_dict()
+
+
+def copy_openapi_specs(dev):
+    """Copy generated and validated openapi specs to reana-commons module."""
+    if dev:
+        if os.environ.get('REANA_SRCDIR'):
+            reana_srcdir = os.environ.get('REANA_SRCDIR')
+        else:
+            reana_srcdir = os.path.join('..')
+        try:
+            reana_commons_specs_path = os.path.join(
+                reana_srcdir,
+                'reana-commons',
+                'reana_commons',
+                'openapi_specifications')
+            if os.path.exists(reana_commons_specs_path):
+                if os.path.isfile(__output_path__):
+                    shutil.copy(__output_path__,
+                                os.path.join(reana_commons_specs_path,
+                                             'reana_server.json'))
+                    # copy openapi specs file as well to docs
+                    shutil.copy(__output_path__,
+                                os.path.join('docs', 'openapi.json'))
+        except Exception as e:
+            click.echo('Something went wrong, could not copy openapi '
+                       'specifications to reana-commons \n{0}'.format(e))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
After generating new OpenAPI specifications, developer needs manually copy them to reana-commons module and docs folder.

This PR introduces new flag `--dev`. If it is set to TRUE, generated and validated openapi specifications will be copied  to reana-commons module and docs folder.

Example of usage.

`$ FLASK_APP=reana_server/app.py python ./scripts/generate_openapi_spec.py --dev True`

