### PR TITLE
api: redirect to authentication temporary endpoint

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,6 +7,34 @@
   },
   "parameters": {},
   "paths": {
+    "/api/login": {
+      "get": {
+        "description": "This resource provides guidance to the user on how to access a file. It tells the user to add the access token as an URL param.",
+        "operationId": "user_login",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Message is displayed on the browser.",
+            "examples": {
+              "application/json": {
+                "message": "Add your REANA_ACCESS_TOKEN as a param."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "TEMPORARY displays a message about how to access a resource."
+      }
+    },
     "/api/ping": {
       "get": {
         "description": "Ping the server.",

--- a/reana_server/rest/users.py
+++ b/reana_server/rest/users.py
@@ -200,3 +200,36 @@ def create_user():  # noqa
     except Exception as e:
         logging.error(traceback.format_exc())
         return jsonify({"message": str(e)}), 500
+
+
+@blueprint.route('/login', methods=['GET'])
+def user_login():
+    r"""Endpoint to authenticate users.
+
+    ---
+    get:
+      summary: TEMPORARY displays a message about how to access a resource.
+      description: >-
+        This resource provides guidance to the user on how to access a file.
+        It tells the user to add the access token as an URL param.
+      operationId: user_login
+      produces:
+        - application/json
+      responses:
+        200:
+          description: >-
+            Message is displayed on the browser.
+          schema:
+              type: object
+              properties:
+                message:
+                  type: string
+          examples:
+            application/json:
+              {
+                "message": "Add your REANA_ACCESS_TOKEN as a param."
+              }
+    """
+    return jsonify({"message": "Add your REANA_ACCESS_TOKEN as a URL param " +
+                    "to access the resource. " +
+                    "RESOURCE_URL?access_token=REANA_ACCESS_TOKEN"}), 200

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -16,7 +16,7 @@ import fs
 from bravado.exception import HTTPError
 from flask import Blueprint
 from flask import current_app as app
-from flask import jsonify, request, send_file
+from flask import jsonify, redirect, request, send_file, url_for
 from reana_commons.config import INTERACTIVE_SESSION_TYPES
 from reana_commons.utils import get_workspace_disk_usage
 from reana_db.database import Session
@@ -1002,7 +1002,7 @@ def download_file(workflow_id_or_name, file_name):  # noqa
         return jsonify(e.response.json()), e.response.status_code
     except ValueError as e:
         logging.error(traceback.format_exc())
-        return jsonify({"message": str(e)}), 403
+        return redirect(url_for('users.user_login'))
     except Exception as e:
         logging.error(traceback.format_exc())
         return jsonify({"message": str(e)}), 500

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -273,7 +273,7 @@ def test_download_file(app, default_user):
                 query_string={"user_id": default_user.id_,
                               "file_name": "test_upload.txt"},
             )
-            assert res.status_code == 403
+            assert res.status_code == 302
 
             res = client.get(
                 url_for("workflows.download_file",
@@ -296,7 +296,7 @@ def test_delete_file(app, default_user):
                         workflow_id_or_name="1",
                         file_name="test_delete.txt"),
                 query_string={"user_id": default_user.id_})
-            assert res.status_code == 403
+            assert res.status_code == 302
 
             res = client.get(
                 url_for("workflows.delete_file",
@@ -390,6 +390,16 @@ def test_create_user(app, default_user):
                           "access_token": default_user.access_token},
         )
         assert res.status_code == 201
+
+
+def test_user_login(app, default_user):
+    """Test user_login view."""
+    with app.test_client() as client:
+        res = client.get(
+            url_for("users.user_login")
+        )
+        assert res.status_code == 200
+        assert json.loads(res.data)['message']
 
 
 def test_move_files(app, default_user):


### PR DESCRIPTION
Adds a temporary authentication endpoint.

Adds a redirection to the auth endpoint when the user tries to
download a resource without the access token.

Provides instruction to the user on how access resources.

Addresses #143

Signed-off-by: leticia <leticia.farias.wanderley@cern.ch>