### PR TITLE
config: remove allowed_hosts config

### DIFF
--- a/reana_server/cli.py
+++ b/reana_server/cli.py
@@ -51,26 +51,26 @@ With the administrator access token, new user creation is allowed with:
 
 .. code-block :: bash
 
-    $ flask  users create -e=<email> --admin-access-token=<token>
+    $ flask reana-users create -e=<email> --admin-access-token=<token>
 
 Similarly, to retrieve information for all users:
 
 .. code-block :: bash
 
-    $ flask users get --admin-access-token=<token>
+    $ flask reana-users get --admin-access-token=<token>
 
 To export all users in current REANA cluster you can use:
 
 .. code-block :: bash
 
     # users will be exported in CSV format
-    $ flask export --admin-access-token=<token> > users.csv
+    $ flask reana-users export --admin-access-token=<token> > users.csv
 
 And import them in a new cluster as follows:
 
 .. code-block :: bash
 
-    $ flask import --file users.csv --admin-access-token=<token>
+    $ flask reana-users import --file users.csv --admin-access-token=<token>
 """
 import logging
 import os

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -91,15 +91,15 @@ SESSION_COOKIE_SECURE = True
 #: provided, the allowed hosts variable is set to localhost. In production it
 #: should be set to the correct host and it is strongly recommended to only
 #: route correct hosts to the application.
-APP_ALLOWED_HOSTS = ['localhost', '127.0.0.1', REANA_URL]
+
+#: In production use the following configuration plus adding  the hostname/ip
+#: of the reverse proxy in front of REANA-Server.
+# APP_ALLOWED_HOSTS = [REANA_URL]
 
 # Security configuration
 # ======================
 APP_DEFAULT_SECURE_HEADERS["content_security_policy"] = {}
-APP_DEFAULT_SECURE_HEADERS["force_https"] = True
-APP_DEFAULT_SECURE_HEADERS["frame_options"] = "allowfrom"
-APP_DEFAULT_SECURE_HEADERS["frame_options_allow_from"] = "*"
-
+APP_HEALTH_BLUEPRINT_ENABLED = False
 
 # Flask-Breadcrumbs needs this variable set
 # =========================================

--- a/setup.py
+++ b/setup.py
@@ -59,16 +59,16 @@ install_requires = [
     'webcolors==1.7',
     # Invenio dependencies
     'Flask>=1.0.2',
-    'invenio-app>=1.1.0,<1.2.0',
-    'invenio-base>=1.0.2,<1.1.0',
+    'invenio-app>=1.2.0,<1.3.0',
+    'invenio-base>=1.1.0,<1.2.0',
     'invenio-cache>=1.0.0,<1.1.0',
-    'invenio-config>=1.0.1,<1.1.0',
+    'invenio-config>=1.0.2,<1.1.0',
     # From base bundle
-    'invenio-logging>=1.1.0,<1.2.0',
+    'invenio-logging>=1.1.0,<1.3.0',
     'invenio-mail>=1.0.2,<1.1.0',
-    'invenio-rest>=1.0.0,<1.1.0',
+    'invenio-rest>=1.1.0,<1.2.0',
     # From auth bundle
-    'invenio-accounts>=1.1.1',
+    'invenio-accounts>=1.1.1,<1.2.0',
     'invenio-oauth2server>=1.0.3,<1.1.0',
     'invenio-oauthclient>=1.1.2,<1.2.0',
     'invenio-userprofiles>=1.0.1,<1.1.0',


### PR DESCRIPTION
* All API calls are failing because the correct allowed host
  should be set in every installation. To facilitate development
  this configuration is not set, and documents that it should be
  used in production.

* Upgrades Invenio dependencies.

* Updates CLI documentation.