### PR TITLE
gitlab: redirect to projects page

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -76,6 +76,18 @@
         "summary": "Get access token from GitLab"
       }
     },
+    "/api/gitlab/connect": {
+      "get": {
+        "description": "Initiate connection to GitLab to authorize accessing the authenticated user's API.",
+        "operationId": "gitlab_connect",
+        "responses": {
+          "302": {
+            "description": "Redirection to GitLab site."
+          }
+        },
+        "summary": "Initiate connection to GitLab."
+      }
+    },
     "/api/gitlab/projects": {
       "get": {
         "description": "Retrieve projects from GitLab.",
@@ -202,7 +214,7 @@
             }
           }
         },
-        "summary": "Gets information from authenticated user."
+        "summary": "Gets information about authenticated user."
       }
     },
     "/api/ping": {

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -131,5 +131,3 @@ REANA_GITLAB_OAUTH_APP_SECRET = os.getenv('REANA_GITLAB_OAUTH_APP_SECRET',
                                           'CHANGE_ME')
 REANA_GITLAB_URL = 'https://{}'.format(os.getenv('REANA_GITLAB_HOST',
                                                  'CHANGE_ME'))
-REANA_GITLAB_OAUTH_REDIRECT_URL = os.getenv('REANA_GITLAB_OAUTH_REDIRECT_URL',
-                                            'CHANGE_ME')

--- a/reana_server/rest/gitlab.py
+++ b/reana_server/rest/gitlab.py
@@ -26,7 +26,6 @@ from reana_commons.k8s.secrets import REANAUserSecretsStore
 from reana_server.api_client import current_rwc_api_client
 from reana_server.config import (REANA_GITLAB_OAUTH_APP_ID,
                                  REANA_GITLAB_OAUTH_APP_SECRET,
-                                 REANA_GITLAB_OAUTH_REDIRECT_URL,
                                  REANA_GITLAB_URL, REANA_URL)
 from reana_server.utils import (_format_gitlab_secrets,
                                 _get_user_from_invenio_user,

--- a/reana_server/rest/gitlab.py
+++ b/reana_server/rest/gitlab.py
@@ -18,7 +18,6 @@ from flask_login import current_user
 from flask_login.utils import _create_identifier
 from itsdangerous import BadData, TimedJSONWebSignatureSerializer
 from werkzeug.local import LocalProxy
-
 from invenio_oauthclient.utils import get_safe_redirect_target
 
 from reana_commons.k8s.secrets import REANAUserSecretsStore

--- a/reana_server/rest/users.py
+++ b/reana_server/rest/users.py
@@ -244,7 +244,7 @@ def get_me():
 
     ---
     get:
-      summary: Gets information from authenticated user.
+      summary: Gets information about authenticated user.
       description: >-
         This resource provides basic information about an authenticated
         user based on the session cookie presence.

--- a/reana_server/rest/users.py
+++ b/reana_server/rest/users.py
@@ -13,6 +13,7 @@ import traceback
 
 from flask import Blueprint, jsonify, request, make_response, redirect
 from flask_login import current_user
+from invenio_oauthclient.utils import get_safe_redirect_target
 
 from reana_server.config import REANA_URL
 from reana_server.utils import (_create_user, _get_user_from_invenio_user,
@@ -295,7 +296,8 @@ def get_me():
 @blueprint.route('/logout', methods=['GET'])
 def _logout():
     if current_user.is_authenticated:
-        resp = make_response(redirect(request.args.get("next")))
+        next_url = get_safe_redirect_target()
+        resp = make_response(redirect(next_url))
         resp.delete_cookie('session')
         return resp
     else:


### PR DESCRIPTION
closes #175
related to https://github.com/reanahub/reana-ui/pull/44

<details>
<summary>Old approach</summary>

Probably not the most elegant solution.
Another solution would be having the redirect hardcoded like:
```python
...
return make_response(redirect("http://{}:3000/projects".format(REANA_URL)), 201
```
but it's not amazing either because of `http` and `:3000` bits.
Any ideas welcomed 🙏 

</details>

New solution: The backend is in charge of doing the redirection to GitLab firstly and once the authorization succeeded, redirect back to the UI.