### PR TITLE
installation: Python-3.6 cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-dist: xenial
-
 notifications:
   email: false
 

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python',
         'Programming Language :: Python',


### PR DESCRIPTION
* Declare supported Python-3.6 version only as this is the one used in
  Dockerfile and the one tested on Travis CI.

* Addresses reanahub/reana-client#329

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>