### PR TITLE
dockerfile: silence start-up logs from prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ENV FLASK_APP=/code/reana_server/app.py
 
 EXPOSE 5000
 
-CMD set -e && ./scripts/setup &&\
+CMD ./scripts/setup > /var/log/reana-server-init-output.log 2>&1 &&\
     uwsgi --module invenio_app.wsgi:application \
     --http-socket 0.0.0.0:5000 --master \
     --processes ${UWSGI_PROCESSES} --threads ${UWSGI_THREADS} \

--- a/scripts/setup
+++ b/scripts/setup
@@ -11,7 +11,7 @@ set -e
 # Create REANA DB
 echo 'Creating REANA database...'
 invenio reana-db init
-invenio reana-users create_default info@reana.io  > /dev/null 2>&1
+invenio reana-users create_default info@reana.io
 echo 'REANA database created.'
 
 # Create Invenio DB
@@ -19,9 +19,3 @@ echo 'Creating Invenio database...'
 invenio db init
 invenio db create
 echo 'Invenio database created.'
-
-# Create admin role to restrict access
-echo 'Creating admin role...'
-invenio roles create admin || echo "Admin role already exists"
-invenio access allow superuser-access role admin || echo "Admin role already has superuser-access"
-echo 'Admin role created.'


### PR DESCRIPTION
* Default Dockerfile command is used to run in production mode
  (uWSGI). We change the command to write the start-up logs to
  a file so we do not expose DB details on pod logs
  (closes #193).

* Removes access commands as we are not using Invenio-Access for
  speed up (closes #193).