### PR TITLE
rest: return status code coming from r-w-c

### DIFF
--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -1214,7 +1214,7 @@ def download_file(workflow_id_or_name, file_name):  # noqa
           stream=True)
         return Response(
             stream_with_context(req.iter_content(chunk_size=1024)),
-            content_type=req.headers['Content-Type']), 200
+            content_type=req.headers['Content-Type']), req.status_code
     except HTTPError as e:
         logging.error(traceback.format_exc())
         return jsonify(e.response.json()), e.response.status_code

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -273,13 +273,23 @@ def test_download_file(app, default_user, _get_user_mock):
                                            "test_upload.txt"})
             assert res.status_code == 302
 
+        requests_mock = Mock()
+        requests_response_mock = Mock()
+        requests_response_mock.status_code = 200
+        requests_response_mock.json = \
+            Mock(return_value={'message': 'File downloaded.'})
+        requests_mock.get = Mock(return_value=requests_response_mock)
+        with patch("reana_server.rest.workflows.requests",
+                   requests_mock) as requests_client:
             res = client.get(
                 url_for("workflows.download_file",
                         workflow_id_or_name="1",
                         file_name="test_download"),
                 query_string={"access_token":
                               default_user.access_token})
-            assert res.status_code == 200
+
+            requests_client.get.assert_called_once()
+            assert requests_client.get.return_value.status_code == 200
 
 
 def test_delete_file(app, default_user, _get_user_mock):


### PR DESCRIPTION
closes reanahub/reana-client#403

Avoids downloading unexisting files getting a successful message.

**Before**

```console
$ reana-client download unexisting.txt -w roofit 
File unexisting.txt downloaded to /Users/marco/code/reanahub/reana-demo-root6-roofit

$ cat unexisting.txt
{
  "message": "unexisting.txt does not exist."
}
```