### PR TITLE
migrate to python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   - pip
 
 python:
-  - "3.6"
+  - "3.8"
 
 services:
   - docker
@@ -24,6 +24,7 @@ before_install:
   - pip install -r requirements.txt
   - travis_retry pip install --upgrade pip setuptools py
   - travis_retry pip install twine wheel coveralls
+  - pip uninstall numpy -y
 
 install:
   - travis_retry pip install -e .[all]

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,6 +3,7 @@ Authors
 
 The list of contributors in alphabetical order:
 
+- `Adelina Lintuluoto <https://orcid.org/0000-0002-0726-1452>`_
 - `Anton Khodak <https://orcid.org/0000-0003-3263-4553>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version master (UNRELEASED)
 ---------------------------
 
+- Uses python3.8
 - Pins all Python dependencies allowing to easily rebuild component images at later times.
 - Adds new endpoint to request user tokens.
 - Adds email notifications on relevant events such as user token granted/revoked.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 # Install base image and its dependencies
-FROM python:3.6-slim
+FROM python:3.8-slim
 RUN apt-get update && \
     apt-get install -y \
       gcc \

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python",
         "Programming Language :: Python",


### PR DESCRIPTION
Closes reanahub/reana#352

Numpy seems to comes by default in the Travis builders but is not needed by any of the packages so is removed in Travis at `before_script`.