### PR TITLE
Allow restart with different languages in same workspace

### DIFF
--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -300,7 +300,7 @@ class RequestStreamWithLen(object):
         return self.limitedstream.limit
 
 
-def clone_workflow(workflow, reana_spec):
+def clone_workflow(workflow, reana_spec, restart_type):
     """Create a copy of workflow in DB for restarting."""
     try:
         cloned_workflow = Workflow(
@@ -308,7 +308,7 @@ def clone_workflow(workflow, reana_spec):
             name=workflow.name,
             owner_id=workflow.owner_id,
             reana_specification=reana_spec or workflow.reana_specification,
-            type_=workflow.type_,
+            type_=restart_type or workflow.type_,
             logs="",
             workspace_path=workflow.workspace_path,
             restart=True,


### PR DESCRIPTION
Adds reading the type of the workflow (Serial, CWL or Yadage) when restarting it

1. From reana specification if provided
2. From the original workflow

This allows you to restart workflow of different types in the same workspace.

Adds the operational option `accept_metadir ` which allow overwriting the yadage meta directory _yadage (necessary if you want to restart a yadage workflow in a yadage workspace).

closes reanahub/reana-server#293