### PR TITLE
setup: pin celery version <5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 alembic==1.4.2            # via flask-alembic, reana-db
 amqp==2.6.1               # via kombu
 appdirs==1.4.4            # via fs
+appnope==0.1.0            # via ipython
 attrs==19.3.0             # via jsonschema
 babel==2.8.0              # via flask-babelex
 backcall==0.2.0           # via ipython
@@ -15,7 +16,7 @@ blinker==1.4              # via flask-mail, flask-principal, invenio-base, inven
 bravado-core==5.17.0      # via bravado
 bravado==10.3.2           # via reana-commons
 cachetools==4.1.1         # via google-auth
-celery==4.4.7             # via flask-celeryext, invenio-celery
+celery==4.4.7             # via flask-celeryext, invenio-celery, reana-server (setup.py)
 certifi==2020.6.20        # via kubernetes, requests
 cffi==1.14.1              # via cryptography
 chardet==3.0.4            # via requests

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ install_requires = [
     "invenio-db[postgresql]>=1.0.5,<1.1.0",
     "SQLAlchemy-Utils[encrypted]>=0.33.0,<0.36.0",
     "six>=1.12.0",  # required by Flask-Breadcrumbs
+    "celery<5.0.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Celery 5.0.0+ requires kombu<6.0,>=5.0.0 and we have kombu pinned
in reana-commons to kombu>=4.6,<4.7.
https://github.com/reanahub/reana-commons/blob/c59decba74ed09161d0e0107c1cc34c22ca6cde0/setup.py#L47