### PR TITLE
templates: enriched instructions for granting user tokens

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes
 Version 0.7.3 (UNRELEASED)
 --------------------------
 - Adds email confirmation check after signing up.
-
+- Changes email notifications with enriched instructions on how to grant user tokens.
 
 Version 0.7.2 (2020-11-24)
 --------------------------

--- a/reana_server/templates/emails/token_request.txt
+++ b/reana_server/templates/emails/token_request.txt
@@ -4,6 +4,10 @@ There is a new access token request for {{ reana_hostname }}:
 
 {{ user_data }}
 
+To obtain administration credentials, please run:
+
+$ export REANA_ACCESS_TOKEN=$(kubectl get secret reana-admin-access-token -o json | jq -r '.data | map_values(@base64d) | .ADMIN_ACCESS_TOKEN')
+
 To grant the user token, please run:
 
 $ kubectl exec -i -t deployment/reana-server -- flask reana-admin token-grant -e {{ user_email }} --admin-access-token $REANA_ACCESS_TOKEN


### PR DESCRIPTION
Adds an explicit command how to obtain administration credentials when
granting/revoking user tokens.