### PR TITLE
cli: improved quota usage system status report

### DIFF
--- a/reana_server/reana_admin.py
+++ b/reana_server/reana_admin.py
@@ -336,8 +336,40 @@ def token_revoke(admin_access_token, id_, email):
 def status_report(types, email, admin_access_token):
     """Retrieve a status report summary of the REANA system."""
 
+    def _print_row(data, column_widths):
+        return (
+            "  {email:<{email_width}} | {used:>{used_width}} | {limit:>{limit_width}} "
+            "| {percentage:>{percentage_width}}\n".format(**data, **column_widths)
+        )
+
+    def _format_quota_statuses(type_, statuses):
+        formatted_statuses = type_.upper()
+        for status_name, data in statuses.items():
+            if not data:
+                continue
+            formatted_statuses += f"\n{status_name}:\n"
+            columns = {
+                "email": "EMAIL",
+                "used": "USED",
+                "limit": "LIMIT",
+                "percentage": "PERCENTAGE",
+            }
+            column_widths = {
+                "email_width": max([len(item["email"]) for item in data]),
+                "used_width": max([len(item["used"]) for item in data]),
+                "limit_width": max([len(item["limit"]) for item in data]),
+                "percentage_width": len("percentage"),
+            }
+            formatted_statuses += _print_row(columns, column_widths)
+            for row in data:
+                formatted_statuses += _print_row(row, column_widths)
+
+        return formatted_statuses
+
     def _format_statuses(type_, statuses):
         """Format statuses dictionary object."""
+        if type_ == "quota-usage":
+            return _format_quota_statuses(type_, statuses)
         formatted_statuses = type_.upper() + "\n"
         for stat_name, stat_value in statuses.items():
             formatted_statuses += f"{stat_name}: {stat_value}\n"

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -69,6 +69,13 @@ def get_user_from_token(access_token):
     return user
 
 
+def get_usage_percentage(usage, limit):
+    """Usage percentage."""
+    if limit == 0:
+        return ""
+    return "{:.1%}".format(usage / limit)
+
+
 def _get_users(_id, email, user_access_token, admin_access_token):
     """Return all users matching search criteria."""
     admin = Session.query(User).filter_by(id_=ADMIN_USER_ID).one_or_none()


### PR DESCRIPTION
- Formatted quota usage status report data into readable ASCII tables.
- Fulfilled [these](https://github.com/reanahub/reana-server/issues/330#issuecomment-736308849) requirements

Steps to test:

- Update `helm/reana/values.yaml` in `reanahub/reana` in order to send notification emails:
```python
notifications:
  enabled: true
  email_config: {}
  system_status: "*/3 * * * *"
  email_config:
    receiver: admins@reana.cern.ch
    sender: notifications@reana.cern.ch
```
- Redeploy the cluster
- Populate some test data
  - Open `invenio-shell`: ```kubectl exec -i -t deployment/reana-server -c rest-api -- invenio shell```
  - Copy the following:
```python
from reana_db.models import User, UserResource, Resource, ResourceType
from reana_db.database import Session
s = Session()

cpu_id = Resource.query.filter_by(type_=ResourceType.cpu).one().id_
disk_id = Resource.query.filter_by(type_=ResourceType.disk).one().id_

user1 = User(email="test1@example.org")
user2 = User(email="test2@example.org")
user3 = User(email="test3@example.org")
user4 = User(email="test4@example.org")
user5 = User(email="test5@example.org")

s.add(user1)
s.add(user2)
s.add(user3)
s.add(user4)
s.add(user5)
s.commit()

# -- user 1
user1_cpu = UserResource.query.filter_by(user_id=user1.id_, resource_id=cpu_id).first()
user1_cpu.quota_used = 25 * 1000 # 25s
user1_cpu.quota_limit = 50 * 1000 # 50s

user1_disk = UserResource.query.filter_by(user_id=user1.id_, resource_id=disk_id).first()
user1_disk.quota_used = 42 * 1024 * 1024 # 42 MiB
user1_disk.quota_limit = 50 * 1024 * 1024 # 50 MiB

s.add(user1_cpu)
s.add(user1_disk)
s.commit()

# -- user 2
user2_cpu = UserResource.query.filter_by(user_id=user2.id_, resource_id=cpu_id).first()
user2_cpu.quota_used = 90 * 1000 # 90s
user2_cpu.quota_limit = 900 * 1000 # 900s

user2_disk = UserResource.query.filter_by(user_id=user2.id_, resource_id=disk_id).first()
user2_disk.quota_used = 20 * 1024 * 1024 # 20 MiB
user2_disk.quota_limit = 100 * 1024 * 1024 # 100 MiB

s.add(user2_cpu)
s.add(user2_disk)
s.commit()

# -- user 3
user3_cpu = UserResource.query.filter_by(user_id=user3.id_, resource_id=cpu_id).first()
user3_cpu.quota_used = 20 * 1000 # 20s
user3_cpu.quota_limit = 5 * 1000 * 60 * 60 # 5h

user3_disk = UserResource.query.filter_by(user_id=user3.id_, resource_id=disk_id).first()
user3_disk.quota_used = 199 * 1024* 1024 # 199 MiB
user3_disk.quota_limit = 200 * 1024 * 1024 # 200 MiB

s.add(user3_cpu)
s.add(user3_disk)
s.commit()

# -- user 4
user4_cpu = UserResource.query.filter_by(user_id=user4.id_, resource_id=cpu_id).first()
user4_cpu.quota_used = 95 * 1000 # 95s
user4_cpu.quota_limit = 100 * 1000 # 100s

user4_disk = UserResource.query.filter_by(user_id=user4.id_, resource_id=disk_id).first()
user4_disk.quota_used = 90 * 1024 # 90 KiB
user4_disk.quota_limit = 100 * 1024 # 100 MiB

s.add(user4_cpu)
s.add(user4_disk)
s.commit()
```
- Check [MailDev](http://localhost:32580) for status reports. It should be delivered every 3 minutes
- (Optional) To manually trigger the status report email:
```
kubectl exec -it reana-server-5bf45c4477-5dm55  /bin/bash
export REANA_ADMIN_ACCESS_TOKEN=token
flask reana-admin status-report
```

- Quota usage output after the changes:
```
QUOTA-USAGE
top_five_disk:
  EMAIL                      | USED    | LIMIT   
  test3@example.org          | 199 MiB | 200 MiB 
  test1@example.org          | 42 MiB  | 50 MiB  
  test2@example.org          | 20 MiB  | 100 MiB 
  test4@example.org          | 90 KiB  | 100 KiB 
  audrius.mecionis@gmail.com | 0 Bytes | 0 Bytes 

top_five_cpu:
  EMAIL                      | USED   | LIMIT  
  test4@example.org          | 1m 35s | 1m 40s 
  test2@example.org          | 1m 30s | 15m    
  test1@example.org          | 25s    | 50s    
  test3@example.org          | 20s    | 5h     
  audrius.mecionis@gmail.com | 0s     | 0s     

top_five_limited_disk:
  EMAIL             | USED    | LIMIT   | PERCENTAGE (%)
  test3@example.org | 199 MiB | 200 MiB | 99.5
  test4@example.org | 90 KiB  | 100 KiB | 90.0
  test1@example.org | 42 MiB  | 50 MiB  | 84.0
  test2@example.org | 20 MiB  | 100 MiB | 20.0

top_five_limited_cpu:
  EMAIL             | USED   | LIMIT  | PERCENTAGE (%)
  test4@example.org | 1m 35s | 1m 40s | 95.0
  test1@example.org | 25s    | 50s    | 50.0
  test2@example.org | 1m 30s | 15m    | 10.0
  test3@example.org | 20s    | 5h     | 0.1
``` 
closes #330