### PR TITLE
rest: improve start workflow endpoint to work with unspecified operational_options parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Version 0.7.4 (UNRELEASED)
+--------------------------
+
+- Fixes start workflow endpoint to work with unspecified ``operational_options`` parameter
 
 Version 0.7.3 (2021-02-03)
 --------------------------

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -872,7 +872,7 @@ def start_workflow(workflow_id_or_name):  # noqa
         parameters = request.json
         workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, str(user.id_))
         parameters["operational_options"] = validate_operational_options(
-            workflow.type_, parameters["operational_options"]
+            workflow.type_, parameters.get("operational_options", {})
         )
         restart_type = None
         if "restart" in parameters:


### PR DESCRIPTION
addresses https://github.com/reanahub/docs.reana.io/issues/23

While testing [script](https://forum.reana.io/t/python-api-to-run-workflows-on-reana/19/2) to run workflows from `reana-client` Python API, I noticed that it crashed since `operational_options` was not specified. This is a quick fix to address this problem