### PR TITLE
scheduler: read running workflows count from DB

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.7.4 (UNRELEASED)
 --------------------------
 
 - Fixes start workflow endpoint to work with unspecified ``operational_options`` parameter
+- Fixes workflow scheduling bug in which failed worfklows would count as running, reaching ``REANA_MAX_CONCURRENT_BATCH_WORKFLOWS`` and therefore, blocking the ``job-submission`` queue.
 
 Version 0.7.3 (2021-02-03)
 --------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.7.4 (UNRELEASED)
 --------------------------
 
+- Adds configuration to set a timeout between ``reana_ready`` checks. (``REANA_SCHEDULER_SECONDS_TO_WAIT_FOR_REANA_READY``)
 - Fixes start workflow endpoint to work with unspecified ``operational_options`` parameter
 - Fixes workflow scheduling bug in which failed worfklows would count as running, reaching ``REANA_MAX_CONCURRENT_BATCH_WORKFLOWS`` and therefore, blocking the ``job-submission`` queue.
 

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -168,3 +168,9 @@ REANA_GITLAB_URL = "https://{}".format(os.getenv("REANA_GITLAB_HOST", "CHANGE_ME
 # Email configuration
 # ===================
 ADMIN_EMAIL = os.getenv("REANA_EMAIL_SENDER", "CHANGE_ME")
+
+
+# Workflow scheduler
+# ==================
+REANA_SCHEDULER_SECONDS_TO_WAIT_FOR_REANA_READY = 1
+"""How many seconds to wait between retries in case of REANA not ready to run more workflows."""

--- a/reana_server/scheduler.py
+++ b/reana_server/scheduler.py
@@ -12,15 +12,68 @@ import json
 import logging
 
 from bravado.exception import HTTPBadGateway, HTTPNotFound
+from kubernetes.client.rest import ApiException
+from sqlalchemy.exc import SQLAlchemyError
+
+from reana_commons.config import REANA_MAX_CONCURRENT_BATCH_WORKFLOWS
 from reana_commons.consumer import BaseConsumer
-from reana_commons.tasks import reana_ready
-from reana_db.database import Session
-from reana_db.models import Workflow
+from reana_commons.k8s.api_client import current_k8s_corev1_api_client
+from reana_db.models import Workflow, WorkflowStatus
 
 from reana_server.api_client import (
     current_rwc_api_client,
     current_workflow_submission_publisher,
 )
+
+
+def check_predefined_conditions():
+    """Check Kubernetes predefined conditions for the nodes."""
+    try:
+        node_info = json.loads(
+            current_k8s_corev1_api_client.list_node(
+                _preload_content=False
+            ).data.decode()
+        )
+        for node in node_info["items"]:
+            # check based on the predefined conditions about the
+            # node status: MemoryPressure, OutOfDisk, KubeletReady
+            #              DiskPressure, PIDPressure,
+            for condition in node.get("status", {}).get("conditions", {}):
+                if not condition.get("status"):
+                    return False
+    except ApiException as e:
+        logging.error("Something went wrong while getting node information.")
+        logging.error(e)
+        return False
+    return True
+
+
+def check_running_reana_workflows_count():
+    """Check upper limit on running REANA batch workflows."""
+    try:
+        running_workflows = Workflow.query.filter_by(
+            status=WorkflowStatus.running
+        ).count()
+        if running_workflows >= REANA_MAX_CONCURRENT_BATCH_WORKFLOWS:
+            return False
+    except SQLAlchemyError as e:
+        logging.error(
+            "Something went wrong while querying for number of running workflows."
+        )
+        logging.error(e)
+        return False
+    return True
+
+
+def reana_ready():
+    """Check if REANA can start new workflows."""
+    for check_condition in [
+        check_predefined_conditions,
+        check_running_reana_workflows_count,
+    ]:
+        if not check_condition():
+            return False
+    return True
 
 
 class WorkflowExecutionScheduler(BaseConsumer):


### PR DESCRIPTION
* Stops relaying on Kubernetes API calls to determine number of
  running workflows. This tecnique is not reliable anymore when
  ``REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES`` is
  set since jobs will be kept for debugging, therefore
  counting as "running" since they didn't complete their execution.

  Since querying for jobs is not possible another path was explored
  which was, listing the pods with label `reana_workflow_mode=batch`.
  However, this is not reliable either due to race condition:
    - Querying jobs worked because we were creating a job
      (atomic operation in etcd/DB) and then consulting the API
      (reading from etcd/DB).
    - Querying pods doesn't work because their creation is not
      happening at job creation time. The time between creating
      a job and pods to be spawned produces a race contition in
      which `WorkflowExecutionScheduler` will submit more workflows
      than allowed by `REANA_MAX_CONCURRENT_BATCH_WORKFLOWS`.

  Closes reanahub/reana-commons#250.

* Moves the `reana_ready` implentation logic from REANA-Commons to
  REANA-Server to be able to access REANA-DB. Also `reana_ready` is
  not used anywhere else, nor there are plans to do so soon.

* Avoids overloading Kubernetes API and REANA-DB when REANA is not
  ready to run workflows.

## To test

- Follow the example in https://github.com/reanahub/reana-commons/issues/250. In step `5.` you should see that `workflow.3` starts.