### PR TITLE
system-status: enrich with node, pod & job info

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -525,6 +525,130 @@
         "summary": "Add user secrets to REANA."
       }
     },
+    "/api/status": {
+      "get": {
+        "description": "Retrieve cluster health status.",
+        "operationId": "status",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Cluster health status information.",
+            "examples": {
+              "application/json": {
+                "job": {
+                  "health": "healthy",
+                  "pending": 2,
+                  "percentage": 20,
+                  "running": 8,
+                  "sort": 1
+                },
+                "node": {
+                  "health": "healthy",
+                  "percentage": 33,
+                  "sort": 0,
+                  "total": 4,
+                  "unschedulable": 2
+                },
+                "session": {
+                  "active": 3,
+                  "sort": 3
+                },
+                "workflow": {
+                  "health": "warning",
+                  "pending": 2,
+                  "percentage": 50,
+                  "queued": 2,
+                  "running": 4,
+                  "sort": 2
+                }
+              }
+            },
+            "schema": {
+              "properties": {
+                "job": {
+                  "properties": {
+                    "health": {
+                      "type": "string"
+                    },
+                    "pending": {
+                      "type": "number"
+                    },
+                    "percentage": {
+                      "type": "number"
+                    },
+                    "running": {
+                      "type": "number"
+                    },
+                    "sort": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "node": {
+                  "properties": {
+                    "available": {
+                      "type": "number"
+                    },
+                    "health": {
+                      "type": "string"
+                    },
+                    "percentage": {
+                      "type": "number"
+                    },
+                    "sort": {
+                      "type": "number"
+                    },
+                    "unschedulable": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "session": {
+                  "properties": {
+                    "active": {
+                      "type": "number"
+                    },
+                    "sort": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "workflow": {
+                  "properties": {
+                    "health": {
+                      "type": "string"
+                    },
+                    "pending": {
+                      "type": "number"
+                    },
+                    "percentage": {
+                      "type": "number"
+                    },
+                    "queued": {
+                      "type": "number"
+                    },
+                    "running": {
+                      "type": "number"
+                    },
+                    "sort": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Retrieve cluster health status"
+      }
+    },
     "/api/token": {
       "put": {
         "description": "This resource allows the user to create an empty REANA access token and mark it as requested.",

--- a/reana_server/factory.py
+++ b/reana_server/factory.py
@@ -48,7 +48,7 @@ def create_app(config_mapping=None):
     app.register_blueprint(blueprint_settings)
 
     # Register API routes
-    from .rest import config, gitlab, ping, secrets, users, workflows  # noqa
+    from .rest import config, gitlab, ping, secrets, status, users, workflows  # noqa
 
     app.register_blueprint(ping.blueprint, url_prefix="/api")
     app.register_blueprint(workflows.blueprint, url_prefix="/api")
@@ -56,6 +56,7 @@ def create_app(config_mapping=None):
     app.register_blueprint(secrets.blueprint, url_prefix="/api")
     app.register_blueprint(gitlab.blueprint, url_prefix="/api")
     app.register_blueprint(config.blueprint, url_prefix="/api")
+    app.register_blueprint(status.blueprint, url_prefix="/api")
 
     @app.teardown_appcontext
     def shutdown_session(response_or_exc):

--- a/reana_server/reana_admin.py
+++ b/reana_server/reana_admin.py
@@ -382,19 +382,21 @@ def status_report(types, email, admin_access_token):
     try:
         types = STATUS_OBJECT_TYPES.keys() if "all" in types else types
         status_report_output = ""
+        hostname = REANA_HOSTNAME or "REANA service"
         for type_ in types:
             statuses_obj = STATUS_OBJECT_TYPES[type_]()
             statuses = statuses_obj.get_status()
             status_report_output += _format_statuses(type_, statuses) + "\n"
 
-        if email:
-            status_report_body = (
-                f'Status report for {REANA_HOSTNAME or "REANA service"}\n'
-                "---\n" + status_report_output
-            )
+        status_report_body = (
+            f"Status report for {hostname}\n---\n{status_report_output}"
+        )
 
-            send_email(email, "REANA system status report", status_report_body)
+        if email:
+            send_email(email, f"{hostname} system status report", status_report_body)
             click.echo(f"Status report successfully sent by email to {email}.")
+        else:
+            click.echo(status_report_body)
     except REANAEmailNotificationError as e:
         click.secho(
             "Something went wrong while sending email:\n{}".format(e),

--- a/reana_server/rest/status.py
+++ b/reana_server/rest/status.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2021 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA-Server status functionality Flask-Blueprint."""
+
+import logging
+import traceback
+
+from flask import Blueprint, jsonify
+
+from reana_server.decorators import signin_required
+from reana_server.status import ClusterHealth, ClusterHealthSchema
+
+blueprint = Blueprint("status", __name__)
+
+
+@blueprint.route("/status")
+@signin_required()
+def status(**kwargs):  # noqa
+    r"""Endpoint to retrieve Cluster health status.
+    ---
+    get:
+      summary: Retrieve cluster health status
+      operationId: status
+      description: >-
+        Retrieve cluster health status.
+      produces:
+       - application/json
+      responses:
+        200:
+          description: >-
+            Cluster health status information.
+          schema:
+            type: object
+            properties:
+              node:
+                type: object
+                properties:
+                  available:
+                    type: number
+                  unschedulable:
+                    type: number
+                  percentage:
+                    type: number
+                  health:
+                    type: string
+                  sort:
+                    type: number
+              job:
+                type: object
+                properties:
+                  running:
+                    type: number
+                  pending:
+                    type: number
+                  percentage:
+                    type: number
+                  health:
+                    type: string
+                  sort:
+                    type: number
+              workflow:
+                type: object
+                properties:
+                  running:
+                    type: number
+                  queued:
+                    type: number
+                  pending:
+                    type: number
+                  percentage:
+                    type: number
+                  health:
+                    type: string
+                  sort:
+                    type: number
+              session:
+                type: object
+                properties:
+                  active:
+                    type: number
+                  sort:
+                    type: number
+          examples:
+            application/json:
+              {
+                "job": {
+                    "pending": 2,
+                    "running": 8,
+                    "percentage": 20,
+                    "health": "healthy",
+                    "sort": 1
+                },
+                "node": {
+                    "total": 4,
+                    "unschedulable": 2,
+                    "percentage": 33,
+                    "health": "healthy",
+                    "sort": 0
+                },
+                "session": {
+                    "active": 3,
+                    "sort": 3
+                },
+                "workflow": {
+                    "queued": 2,
+                    "running": 4,
+                    "pending": 2,
+                    "percentage": 50,
+                    "health": "warning",
+                    "sort": 2
+                }
+              }
+    """
+    try:
+        cluster_health = ClusterHealth()
+        return ClusterHealthSchema().dump(cluster_health)
+    except Exception as e:
+        logging.error(traceback.format_exc())
+        return jsonify({"message": str(e)}), 500

--- a/requirements.txt
+++ b/requirements.txt
@@ -106,7 +106,7 @@ python-dateutil==2.8.1    # via alembic, bravado, bravado-core, kubernetes
 python-editor==1.0.4      # via alembic
 pytz==2021.1              # via babel, bravado-core, celery, fs
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.8.0a12  # via reana-db, reana-server (setup.py)
+reana-commons[kubernetes]==0.8.0a13	# via reana-db, reana-server (setup.py)
 reana-db==0.8.0a15        # via reana-server (setup.py)
 redis==3.5.3              # via invenio-accounts, invenio-celery
 requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient, kubernetes

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ setup(
             "reana_server_secrets = reana_server.rest.secrets:blueprint",
             "reana_server_gitlab = reana_server.rest.gitlab:blueprint",
             "reana_server_config = reana_server.rest.config:blueprint",
+            "reana_server_status = reana_server.rest.status:blueprint",
         ],
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup_requires = [
 install_requires = [
     "marshmallow>2.13.0,<=2.20.1",
     "pyOpenSSL==17.5.0",
-    "reana-commons[kubernetes]>=0.8.0a12,<0.9.0",
+    "reana-commons[kubernetes]>=0.8.0a13,<0.9.0",
     "reana-db>=0.8.0a15,<0.9.0",
     "requests==2.20.0",
     "rfc3987==1.3.7",


### PR DESCRIPTION
closes reanahub/reana#501
closes reanahub/reana-ui#183

#### Install `metrics-server`
If `kubectl top nodes` doesn't work for you, it's because you need  `metrics-server` installed.

```console
$ kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
$ kubectl edit -n kube-system deployment/metrics-server
# Add `--kubelet-insecure-tls` to `spec.template.spec.containers[0].args` and save.
```

⚠️ Tests not passing due to missing [`reana-commons` release](https://github.com/reanahub/reana-commons/pull/262).

#### To test:

```console
kubectl exec -ti deployment/reana-server -- flask reana-admin status-report --admin-access-token $REANA_ACCESS_TOKEN 
```