### PR TITLE
scheduler: prioritize workflows in the queue by complexity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Version 0.8.0 (UNRELEASED)
 
 - Adds users quota accounting.
 - Adds ``include_progress`` and ``include_workspace_size`` query args to workflow list endpoint.
+- Adds workflow prioritization in the queue by complexity
+- Adds ``priority`` and ``min_job_memory`` params to workflow submission publisher.
+- Adds Yadage workflow specification loading to ``start_workflow`` endpoint.
+- Adds a check in scheduler if at least one workflow job could be started in Kubernetes.
+- Changes workflow execution consumer to receive only one message at a time.
 
 Version 0.7.5 (2021-04-28)
 --------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN if [ "${DEBUG}" -gt 0 ]; then pip install -e ".[debug]"; else pip install .;
 
 # Are we building with locally-checked-out shared modules?
 # hadolint ignore=SC2102
-RUN if test -e modules/reana-commons; then pip install -e modules/reana-commons[kubernetes] --upgrade; fi
+RUN if test -e modules/reana-commons; then pip install -e modules/reana-commons[kubernetes,yadage] --upgrade; fi
 RUN if test -e modules/reana-db; then pip install -e modules/reana-db --upgrade; fi
 
 # Check if there are broken requirements

--- a/reana_server/complexity.py
+++ b/reana_server/complexity.py
@@ -1,0 +1,343 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2021 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA workflow complexity estimation."""
+
+import os
+from functools import reduce
+
+from reana_db.models import WorkflowComplexity
+from reana_commons.job_utils import kubernetes_memory_to_bytes
+
+
+def estimate_complexity(workflow_type, reana_yaml):
+    """Estimate complexity in REANA workflow.
+
+    :param workflow_type: A supported workflow specification type.
+    :param reana_yaml: REANA YAML specification.
+    """
+
+    def build_estimator(workflow_type, reana_yaml):
+        if workflow_type == "serial":
+            return SerialComplexityEstimator(reana_yaml)
+        elif workflow_type == "yadage":
+            return YadageComplexityEstimator(reana_yaml)
+        elif workflow_type == "cwl":
+            return CWLComplexityEstimator(reana_yaml)
+        else:
+            raise Exception(
+                "Workflow type '{0}' is not supported".format(workflow_type)
+            )
+
+    estimator = build_estimator(workflow_type, reana_yaml)
+    try:
+        complexity = estimator.estimate_complexity()
+    except Exception:
+        return None
+
+    # Summing up parrarel jobs times memory to determine the workflow complexity
+    memory = reduce(lambda sum, item: sum + item[0] * item[1], complexity, 0)
+
+    # FIXME: Values should be configuranble
+    if memory <= kubernetes_memory_to_bytes("8Gi"):
+        return WorkflowComplexity.espresso
+    if memory <= kubernetes_memory_to_bytes("40Gi"):
+        return WorkflowComplexity.medium
+    return WorkflowComplexity.hard
+
+
+class ComplexityEstimatorBase:
+    """REANA workflow complexity estimator base class."""
+
+    def __init__(self, reana_yaml):
+        """Estimate complexity in REANA workflow.
+
+        :param reana_yaml: REANA YAML specification.
+        :param initial_step: initial workflow execution step.
+        """
+        self.reana_yaml = reana_yaml
+        self.specification = reana_yaml.get("workflow", {}).get("specification", {})
+        self.input_params = reana_yaml.get("inputs", {}).get("parameters", {})
+
+    def parse_specification(self, initial_step):
+        """Parse REANA workflow specification tree."""
+        raise NotImplementedError
+
+    def estimate_complexity(self, initial_step="init"):
+        """Estimate complexity in parsed REANA workflow tree."""
+        steps = self.parse_specification(initial_step)
+        return self._calculate_complexity(steps)
+
+    def _calculate_complexity(self, steps):
+        """Calculate complexity in parsed REANA workflow tree."""
+        complexity = []
+        for step in steps.values():
+            complexity += step["complexity"]
+        return complexity
+
+    def _get_number_of_jobs(self, step):
+        """Get number of jobs based on compute backend."""
+        backend = step.get("compute_backend")
+        if backend and backend != "kubernetes":
+            return 0
+        return 1
+
+    def _get_memory_limit(self, step):
+        """Get memory limit value."""
+        default_memory_limit = os.getenv("REANA_KUBERNETES_JOBS_MEMORY_LIMIT", "8Gi")
+        memory_limit = step.get("kubernetes_memory_limit", default_memory_limit)
+        return kubernetes_memory_to_bytes(memory_limit)
+
+
+class SerialComplexityEstimator(ComplexityEstimatorBase):
+    """REANA serial workflow complexity estimation."""
+
+    def _parse_steps(self, steps):
+        """Parse serial workflow specification tree."""
+        tree = []
+        for idx, step in enumerate(steps):
+            name = step.get("name", str(idx))
+            jobs = self._get_number_of_jobs(step)
+            memory_limit = self._get_memory_limit(step)
+            complexity = [(jobs, memory_limit)]
+            tree.append({name: {"complexity": complexity}})
+        return tree
+
+    def parse_specification(self, initial_step):
+        """Parse and filter out serial workflow specification tree."""
+        spec_steps = self.specification.get("steps", [])
+        steps = self._parse_steps(spec_steps)
+        if initial_step == "init":
+            return steps[0] if steps else {}
+        return next(filter(lambda step: initial_step in step.keys(), steps), {})
+
+
+class YadageComplexityEstimator(ComplexityEstimatorBase):
+    """REANA Yadage workflow complexity estimation."""
+
+    def _parse_steps(self, stages, initial_step):
+        """Parse and filter out Yadage workflow tree."""
+
+        def _is_initial_stage(stage):
+            dependencies = stage.get("dependencies", {}).get("expressions", [])
+
+            if dependencies == [initial_step]:
+                return True
+
+            if initial_step == "init":
+                # Not defined dependencies should be treated as `init`
+                return not dependencies
+            return False
+
+        def _get_stage_complexity(stage):
+            resources = (
+                stage.get("scheduler", {})
+                .get("step", {})
+                .get("environment", {})
+                .get("resources", [])
+            )
+            compute_backend = next(
+                filter(lambda r: "compute_backend" in r.keys(), resources), {},
+            )
+            k8s_memory_limit = next(
+                filter(lambda r: "kubernetes_memory_limit" in r.keys(), resources), {},
+            )
+            jobs = self._get_number_of_jobs(compute_backend)
+            memory_limit = self._get_memory_limit(k8s_memory_limit)
+            return [(jobs, memory_limit)]
+
+        def _parse_stages(stages):
+            tree = {}
+            for stage in stages:
+                if not _is_initial_stage(stage):
+                    continue
+                name = stage["name"]
+                scheduler = stage.get("scheduler", {})
+                parameters = scheduler.get("parameters", [])
+                tree[name] = {"params": parameters, "stages": {}, "scatter_params": []}
+
+                # Parse stage complexity
+                tree[name]["complexity"] = _get_stage_complexity(stage)
+
+                # Parse nested stages
+                if "workflow" in scheduler:
+                    nested_stages = scheduler["workflow"].get("stages", [])
+                    parsed_stages = _parse_stages(nested_stages)
+                    tree[name]["stages"].update(parsed_stages)
+
+                # Parse scatter parameters
+                if "scatter" in scheduler and scheduler["scatter"]["method"] == "zip":
+                    tree[name]["scatter_params"] = scheduler["scatter"]["parameters"]
+
+            return tree
+
+        return _parse_stages(stages)
+
+    def _populate_parameters(self, stages, parent_params):
+        """Populate parsed Yadage workflow tree with parameter values."""
+
+        def _parse_params(stage, parent_params):
+            parent_params = parent_params.copy()
+            for param in stage["params"]:
+                if isinstance(param["value"], list):
+                    parent_params[param["key"]] = param["value"]
+                elif isinstance(param["value"], dict):
+                    # Example: input_file: {step: init, output: files}
+                    # In this case `files` values should be taken from
+                    # `parent_params` and saved as `input_file`
+                    output = param["value"].get("output", "")
+                    parent_value = parent_params.get(output, "")
+                    parent_params[param["key"]] = parent_value
+                else:
+                    parent_params[param["key"]] = [param["value"]]
+            return parent_params
+
+        def _parse_stages(stages, parent_params):
+            stages = stages.copy()
+            for stage in stages.keys():
+                stage_value = stages[stage]
+                # Handle params
+                params = _parse_params(stage_value, parent_params)
+                stage_value["params"] = params
+                # Handle nested stages
+                stage_value["stages"] = _parse_stages(stage_value["stages"], params)
+            return stages
+
+        return _parse_stages(stages, parent_params)
+
+    def _populate_complexity(self, stages):
+        """Calculate number of jobs and memory needed for the parsed Yadage workflow tree."""
+
+        def _parse_stages(stages):
+            stages = stages.copy()
+            for stage in stages.keys():
+                stage_value = stages[stage]
+                complexity = stage_value["complexity"]
+
+                # Handle nested stages
+                parsed_stages = _parse_stages(stage_value["stages"])
+                stage_value["stages"] = parsed_stages
+                if parsed_stages:
+                    complexity = self._calculate_complexity(parsed_stages)
+
+                # Handle scatter parameters
+                if stage_value["scatter_params"]:
+                    first_param = stage_value["scatter_params"][0]
+                    param_len = len(stage_value["params"].get(first_param, []))
+                    complexity = [(item[0] * param_len, item[1]) for item in complexity]
+
+                stage_value["complexity"] = complexity
+            return stages
+
+        return _parse_stages(stages)
+
+    def parse_specification(self, initial_step):
+        """Parse Yadage workflow specification tree."""
+        steps = self._parse_steps(self.specification["stages"], initial_step)
+        steps = self._populate_parameters(steps, self.input_params)
+        steps = self._populate_complexity(steps)
+        return steps
+
+
+class CWLComplexityEstimator(ComplexityEstimatorBase):
+    """REANA CWL workflow complexity estimation."""
+
+    def _parse_steps(self, workflow):
+        """Parse CWL workflow specification tree."""
+        tree = {}
+        steps = workflow.get("steps", [])
+        for step in steps:
+            name = step.get("id")
+            hints = step.get("hints", [{}]).pop()
+            # Parse scatter params
+            scatter = step.get("scatter")
+            scatter_params = None
+            if scatter:
+                scatter_params = next(
+                    filter(lambda p: p["id"] == scatter, step.get("in", [])), {},
+                ).get("source")
+            # Parse nested workflows
+            workflow_file = step.get("run")
+            nested_workflow = workflow_file if isinstance(workflow_file, str) else None
+            # Parse initial complexity
+            jobs = self._get_number_of_jobs(hints)
+            memory_limit = self._get_memory_limit(hints)
+            complexity = [(jobs, memory_limit)]
+            # Parse params and dependencies
+            params = list(map(lambda i: i.get("source", ""), step.get("in", [])))
+            dependencies = set()
+            for param in params:
+                # Extract dependencies from param (e.g '#main/gendata/data')
+                if param:
+                    dependencies.update(param.split("/")[1:-1])
+
+            tree[name] = {
+                "complexity": complexity,
+                "params": params,
+                "dependencies": list(dependencies),
+                "scatter_params": scatter_params,
+                "workflow": nested_workflow,
+            }
+        return tree
+
+    def _parse_workflow(self, workflow):
+        """Parse CWL workflow specification tree."""
+        tree = {}
+        if isinstance(workflow, dict):
+            return self._parse_steps(workflow)
+        elif isinstance(workflow, list):
+            for wf in workflow:
+                tree.update(self._parse_steps(wf))
+        return tree
+
+    def _populate_dependencies(self, steps):
+        """Populate dependencies to parsed CWL workflow tree steps."""
+        for step, value in steps.items():
+            nested_workflow = value.get("workflow")
+            if nested_workflow:
+                for nested_step, nested_value in steps.items():
+                    if nested_workflow in nested_step:
+                        nested_value["dependencies"] += value["dependencies"]
+        return steps
+
+    def _populate_complexity(self, steps):
+        """Populate complexity to parsed CWL workflow tree steps."""
+        for step, value in steps.items():
+            scatter_params = value.get("scatter_params")
+            if scatter_params:
+                param_len = len(self.input_params.get(scatter_params, []))
+                if not param_len:
+                    continue
+                complexity = value.get("complexity")
+                value["complexity"] = [
+                    (item[0] * param_len, item[1]) for item in complexity
+                ]
+        return steps
+
+    def _filter_initial_steps(self, steps, initial_step):
+        """Filter out initial CWL workflow tree steps."""
+        tree = {}
+        for step, value in steps.items():
+            dependencies = value.get("dependencies", [])
+
+            if dependencies == [initial_step]:
+                tree[step] = value
+
+            if initial_step == "init" and not dependencies:
+                tree[step] = value
+
+        return tree
+
+    def parse_specification(self, initial_step):
+        """Parse and filter out CWL workflow specification tree."""
+        workflow = self.specification.get("$graph", self.specification)
+        steps = self._parse_workflow(workflow)
+        steps = self._populate_dependencies(steps)
+        steps = self._populate_complexity(steps)
+        steps = self._filter_initial_steps(steps, initial_step)
+        return steps

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -38,6 +38,14 @@ REANA_SSO_CERN_CONSUMER_KEY = os.getenv("CERN_CONSUMER_KEY", "CHANGE_ME")
 
 REANA_SSO_CERN_CONSUMER_SECRET = os.getenv("CERN_CONSUMER_SECRET", "CHANGE_ME")
 
+REANA_KUBERNETES_DEFAULT_JOBS_MEMORY_LIMIT = "4Gi"
+"""Default memory limit for user job containers."""
+
+REANA_COMPLEXITY_JOBS_MEMORY_LIMIT = os.getenv(
+    "REANA_KUBERNETES_JOBS_MEMORY_LIMIT", REANA_KUBERNETES_DEFAULT_JOBS_MEMORY_LIMIT
+)
+"""Maximum default memory limit for user job containers for workflow complexity estimation."""
+
 
 # Invenio configuration
 # =====================

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -414,6 +414,7 @@ def create_workflow(user):  # noqa
                 user_id=str(user.id_),
                 workflow_id_or_name=response["workflow_id"],
                 parameters=request.json,
+                # TODO: send complexity
             )
         return jsonify(response), http_response.status_code
     except HTTPError as e:
@@ -924,6 +925,7 @@ def start_workflow(workflow_id_or_name, user):  # noqa
             user_id=str(user.id_),
             workflow_id_or_name=workflow.get_full_workflow_name(),
             parameters=parameters,
+            priority=workflow.complexity.value,
         )
         response = {
             "message": "Workflow submitted.",

--- a/requirements.txt
+++ b/requirements.txt
@@ -106,8 +106,8 @@ python-dateutil==2.8.1    # via alembic, bravado, bravado-core, kubernetes
 python-editor==1.0.4      # via alembic
 pytz==2021.1              # via babel, bravado-core, celery, fs
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.8.0a13	# via reana-db, reana-server (setup.py)
-reana-db==0.8.0a15        # via reana-server (setup.py)
+reana-commons[kubernetes]==0.8.0a15	# via reana-db, reana-server (setup.py)
+reana-db==0.8.0a17	# via reana-server (setup.py)
 redis==3.5.3              # via invenio-accounts, invenio-celery
 requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient, kubernetes
 requests==2.20.0          # via bravado, kubernetes, reana-server (setup.py), requests-oauthlib

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ setup_requires = [
 install_requires = [
     "marshmallow>2.13.0,<=2.20.1",
     "pyOpenSSL==17.5.0",
-    "reana-commons[kubernetes,yadage]>=0.8.0a13,<0.9.0",
-    "reana-db>=0.8.0a15,<0.9.0",
+    "reana-commons[kubernetes,yadage]>=0.8.0a15,<0.9.0",
+    "reana-db>=0.8.0a17,<0.9.0",
     "requests==2.20.0",
     "rfc3987==1.3.7",
     "strict-rfc3339==0.7",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup_requires = [
 install_requires = [
     "marshmallow>2.13.0,<=2.20.1",
     "pyOpenSSL==17.5.0",
-    "reana-commons[kubernetes]>=0.8.0a13,<0.9.0",
+    "reana-commons[kubernetes,yadage]>=0.8.0a13,<0.9.0",
     "reana-db>=0.8.0a15,<0.9.0",
     "requests==2.20.0",
     "rfc3987==1.3.7",

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2021 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test workflow complexity estimation."""
+
+import pytest
+from mock import patch
+
+from reana_server.complexity import (
+    get_workflow_min_job_memory,
+    calculate_workflow_priority,
+    estimate_complexity,
+)
+
+
+@pytest.mark.parametrize(
+    "complexity,min_job_memory",
+    [
+        ([(8, 5), (5, 10)], 5),
+        ([(1, 8589934592.0), (2, 4294967296.0)], 4294967296.0),
+        ([(2, 10)], 10),
+        ([], 0),
+    ],
+)
+def test_get_workflow_min_job_memory(complexity, min_job_memory):
+    """Test get_workflow_min_job_memory."""
+    assert get_workflow_min_job_memory(complexity) == min_job_memory
+
+
+@pytest.mark.parametrize(
+    "complexity,priority,cluster_memory",
+    [
+        ([(1, 8589934592.0), (2, 4294967296.0), (5, 4294967296.0)], 55, 85899345920.0),
+        ([(2, 8)], 96, 400),
+        ([(1, 6), (1, 6)], 97, 400),
+        ([(5, 2), (5, 2)], 95, 400),
+        ([(1, 396)], 1, 400),
+        ([(1, 401)], 0, 400),
+        ([], 0, 100),
+        ([(3, 5), (1, 5)], 80, 100),
+        ([(3, 20), (2, 10)], 20, 100),
+        ([(2, 20), (5, 1)], 55, 100),
+        ([(1, 1), (1, 1)], 98, 100),
+        ([(1, 10), (1, 20), (1, 5), (1, 5), (1, 10), (1, 10)], 40, 100),
+    ],
+)
+def test_calculate_workflow_priority(complexity, priority, cluster_memory):
+    """Test calculate_workflow_priority."""
+    with patch(
+        "reana_server.status.NodesStatus.get_total_memory", return_value=cluster_memory,
+    ):
+        assert calculate_workflow_priority(complexity) == priority
+
+
+def test_estimate_complexity(yadage_workflow_spec_loaded):
+    """Test estimate_complexity."""
+    assert estimate_complexity("yadage", yadage_workflow_spec_loaded) == [
+        (1, 4294967296.0)
+    ]


### PR DESCRIPTION
closes https://github.com/reanahub/reana-server/issues/358

This PR tweaks start_workflow() endpoint to estimate and store workflow complexity in the database. The reason behind storing this value in the database is to make scheduling process a bit lighter. If the logic would be there, it would mean additional calls to db (to fetch workflow spec, etc.) and complexity calculation each time the workflow reaches consumer (it can be rescheduled multiple times).

Complexity estimation code is taken from this [PR](https://github.com/reanahub/reana-client/pull/516) with the only changes being made [here](https://github.com/reanahub/reana-server/pull/366/files#diff-dd451815d7362d3092b6e4d2bc6880a2fe0698d82d2415e90b8adc23181eb3faR20-R35) to simply calculate memory needed for all initial jobs and to determine the workflow complexity by it (needs to be discussed and improved).

In addition it also loads Yadage specification and stores it in the database in the `start_workflow()` endpoint

### A bit of context about the PR set in general

By default `RabbitMQ just dispatches a message when the message enters the queue.`, but there is an option to tell RabbitMQ not to give more than one message to a consumer at a time. This option can be set by defining `prefetch_count=1` in the `kombu Consumer`. You can read more about it in the official docs - [Fair dispatch section](https://www.rabbitmq.com/tutorials/tutorial-two-python.html). 

With this option on all the unconsumed messages in the RabbitMQ queue are still in the `Ready` state (which means they are still in the queue ready to be consumed) instead of `Unacked` (which means they already reached the consumer, but was not yet processed.)

#### Before testing it

Make sure you redeploy the cluster after checking out the code or after making any changes to the queues. RabbitMQ does not allow to modify the queues while it is still running.

#### How to test it

- First of all here is the procedure to launch RabbitMQ management UI:
  ```
  kubectl exec reana-message-broker-5874b75cdd-xzm5c rabbitmq-plugins enable rabbitmq_management
  kubectl port-forward reana-message-broker-5874b75cdd-xzm5c 15672:15672
  ```
  Open `http://localhost:15672` in the browser

- Add `import wdb; wdb.set_trace()` breakpoint [here](https://github.com/reanahub/reana-server/blob/master/reana_server/scheduler.py#L139) before `message.ack()`.
- Restart `reana-server` pod. Note that live reloading does not work in this pod, so after any changes the pod needs to be killed.
- Start a new workflow from any demo example we have
- Open up Wdb web interface: http://localhost:31984/
- Inspect `workflow_submission`, it should also have `priority` inside
- Check RabbitMQ management console, `workflow-submission` should now have 1 `Unacked` message, it means it was received by the consumer
- Start `bsm-search` workflow
- Start `helloworld` workflow
- RabbitMQ management console should now show 3 messages in total, 2 should be in ready state
- Force close (stop tracing) the Wdb debugger session
- Inspect `workflow_submission` argument of the next debugger session, it should be the `helloworld` workflow with priority 3. Even though we submitted `bsm-search` workflow first, the next processed workflow was `helloworld`!
- Force close the debugger session, the next processed workflow should be `bsm-search`

#### TODO
- [ ] Count how many times workflow was requeued to avoid loops, e.g. if cluster has only 1 GiB free, the consumer action could loop forever (separate issue?)
- [ ] Decide on default memory limit for job while estimating the complexity since `REANA_KUBERNETES_JOBS_MEMORY_LIMIT` could be not set through helm
- [ ] Modify `create_workflow()` endpoint to call `start_endpoint()` for gitlab workflows, since we calculate the complexity and set priority only there

#### Depends on:
- https://github.com/reanahub/pytest-reana/pull/83
- https://github.com/reanahub/reana-commons/pull/264