### PR TITLE
config: remove default k8s memory limit

### DIFF
--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -178,5 +178,5 @@ ADMIN_EMAIL = os.getenv("REANA_EMAIL_SENDER", "CHANGE_ME")
 REANA_SCHEDULER_SECONDS_TO_WAIT_FOR_REANA_READY = 60
 """How many seconds to wait between retries in case of REANA not ready to run more workflows."""
 
-REANA_SCHEDULER_RETRY_DELAY = 60000
-"""How many milliseconds for a workflow to be delayed once rescheduled."""
+REANA_SCHEDULER_RETRY_DELAY = 60
+"""How many seconds for a workflow to be delayed once rescheduled."""

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -175,8 +175,10 @@ ADMIN_EMAIL = os.getenv("REANA_EMAIL_SENDER", "CHANGE_ME")
 
 # Workflow scheduler
 # ==================
-REANA_SCHEDULER_SECONDS_TO_WAIT_FOR_REANA_READY = 60
+REANA_SCHEDULER_SECONDS_TO_WAIT_FOR_REANA_READY = os.getenv(
+    "REANA_SCHEDULER_SECONDS_TO_WAIT_FOR_REANA_READY"
+)
 """How many seconds to wait between retries in case of REANA not ready to run more workflows."""
 
-REANA_SCHEDULER_RETRY_DELAY = 60
+REANA_SCHEDULER_SECONDS_RETRY_DELAY = os.getenv("REANA_SCHEDULER_SECONDS_RETRY_DELAY")
 """How many seconds for a workflow to be delayed once rescheduled."""

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -38,13 +38,8 @@ REANA_SSO_CERN_CONSUMER_KEY = os.getenv("CERN_CONSUMER_KEY", "CHANGE_ME")
 
 REANA_SSO_CERN_CONSUMER_SECRET = os.getenv("CERN_CONSUMER_SECRET", "CHANGE_ME")
 
-REANA_KUBERNETES_DEFAULT_JOBS_MEMORY_LIMIT = "4Gi"
-"""Default memory limit for user job containers."""
-
-REANA_COMPLEXITY_JOBS_MEMORY_LIMIT = os.getenv(
-    "REANA_KUBERNETES_JOBS_MEMORY_LIMIT", REANA_KUBERNETES_DEFAULT_JOBS_MEMORY_LIMIT
-)
-"""Maximum default memory limit for user job containers for workflow complexity estimation."""
+REANA_COMPLEXITY_JOBS_MEMORY_LIMIT = os.getenv("REANA_KUBERNETES_JOBS_MEMORY_LIMIT")
+"""Maximum memory limit for user job containers for workflow complexity estimation."""
 
 
 # Invenio configuration

--- a/reana_server/scheduler.py
+++ b/reana_server/scheduler.py
@@ -145,7 +145,7 @@ class WorkflowExecutionScheduler(BaseConsumer):
                 priority=kwargs.get("priority", 0),
                 min_job_memory=kwargs.get("min_job_memory", 0),
                 retry_count=kwargs.get("retry_count", 0) + 1,
-                delay=REANA_SCHEDULER_RETRY_DELAY,
+                delay=REANA_SCHEDULER_RETRY_DELAY * 1000,
             )
             logging.info(f"Requeueing workflow " f'{kwargs["workflow_id_or_name"]} ...')
         except KeyError:

--- a/reana_server/scheduler.py
+++ b/reana_server/scheduler.py
@@ -30,7 +30,7 @@ from reana_server.api_client import (
 )
 from reana_server.config import (
     REANA_SCHEDULER_SECONDS_TO_WAIT_FOR_REANA_READY,
-    REANA_SCHEDULER_RETRY_DELAY,
+    REANA_SCHEDULER_SECONDS_RETRY_DELAY,
 )
 from reana_server.status import NodesStatus
 
@@ -145,7 +145,7 @@ class WorkflowExecutionScheduler(BaseConsumer):
                 priority=kwargs.get("priority", 0),
                 min_job_memory=kwargs.get("min_job_memory", 0),
                 retry_count=kwargs.get("retry_count", 0) + 1,
-                delay=REANA_SCHEDULER_RETRY_DELAY * 1000,
+                delay=REANA_SCHEDULER_SECONDS_RETRY_DELAY * 1000,
             )
             logging.info(f"Requeueing workflow " f'{kwargs["workflow_id_or_name"]} ...')
         except KeyError:

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -33,6 +33,7 @@ def test_get_workflow_min_job_memory(complexity, min_job_memory):
 
 def test_estimate_complexity(yadage_workflow_spec_loaded):
     """Test estimate_complexity."""
-    assert estimate_complexity("yadage", yadage_workflow_spec_loaded) == [
-        (1, 4294967296.0)
-    ]
+    with patch("reana_server.complexity.REANA_COMPLEXITY_JOBS_MEMORY_LIMIT", "4Gi"):
+        assert estimate_complexity("yadage", yadage_workflow_spec_loaded) == [
+            (1, 4294967296.0)
+        ]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -39,6 +39,8 @@ def test_scheduler_starts_workflows(
         reana_ready=Mock(return_value=True),
         current_rwc_api_client=mock_rwc_api_client,
         current_workflow_submission_publisher=in_memory_workflow_submission_publisher,
+        REANA_SCHEDULER_SECONDS_TO_WAIT_FOR_REANA_READY=0,
+        REANA_SCHEDULER_SECONDS_RETRY_DELAY=0,
     ):
         consume_queue(scheduler, limit=1)
     assert in_memory_queue_connection.channel().queues["workflow-submission"].empty()
@@ -60,6 +62,8 @@ def test_scheduler_requeues_workflows(
         "reana_server.scheduler",
         reana_ready=Mock(return_value=False),
         current_workflow_submission_publisher=in_memory_workflow_submission_publisher,
+        REANA_SCHEDULER_SECONDS_TO_WAIT_FOR_REANA_READY=0,
+        REANA_SCHEDULER_SECONDS_RETRY_DELAY=0,
     ):
         consume_queue(scheduler, limit=1)
         assert (
@@ -94,6 +98,8 @@ def test_scheduler_requeues_on_rwc_failure(
         reana_ready=Mock(return_value=True),
         current_rwc_api_client=mock_rwc_api_client,
         current_workflow_submission_publisher=in_memory_workflow_submission_publisher,
+        REANA_SCHEDULER_SECONDS_TO_WAIT_FOR_REANA_READY=0,
+        REANA_SCHEDULER_SECONDS_RETRY_DELAY=0,
     ):
         consume_queue(scheduler, limit=1)
         assert (


### PR DESCRIPTION
Rely on the default Helm k8s memory limit instead.

closes reanahub/reana#509