### PR TITLE
docker: add --no-cache-dir to pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 
 # Install dependencies
 COPY requirements.txt /code/
-RUN pip install -r /code/requirements.txt
+RUN pip install --no-cache-dir -r /code/requirements.txt
 
 # Copy cluster component source code
 WORKDIR /code


### PR DESCRIPTION
This PR disables the pip cache when installing requirements. This is a common practice when installing packages on Docker images, as it helps reduce images size. In the case of `reana-server`, the resulting image shrink from `791` MBs to `700` MBs, ~90MBs in total.

The same optimization can be applied to:
- [reana-env-jupyter](https://github.com/reanahub/reana-env-jupyter/blob/master/Dockerfile#L16-L26).
- [reana-job-controller](https://github.com/reanahub/reana-job-controller/blob/master/Dockerfile#L68).
- [reana-workflow-controller](https://github.com/reanahub/reana-workflow-controller/blob/master/Dockerfile#L21).
- [reana-workflow-engine-cwl](https://github.com/reanahub/reana-workflow-engine-cwl/blob/master/Dockerfile#L21).
- [reana-workflow-engine-serial](https://github.com/reanahub/reana-workflow-engine-serial/blob/master/Dockerfile#L18).
- [reana-workflow-engine-snakemake](https://github.com/reanahub/reana-workflow-engine-snakemake/blob/master/Dockerfile#L18).
- [reana-workflow-engine-yadage](https://github.com/reanahub/reana-workflow-engine-yadage/blob/master/Dockerfile#L31).


