### PR TITLE
snakemake: add complexity estimator class

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -113,7 +113,7 @@ python-dateutil==2.8.1    # via alembic, bravado, bravado-core, kubernetes
 python-editor==1.0.4      # via alembic
 pytz==2021.1              # via babel, bravado-core, celery, fs
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, packtivity, reana-commons, swagger-spec-validator, yadage, yadage-schemas
-reana-commons[kubernetes,yadage]==0.8.0a25	# via reana-db, reana-server (setup.py)
+reana-commons[kubernetes,yadage]==0.8.0a29	# via reana-db, reana-server (setup.py)
 reana-db==0.8.0a20	# via reana-server (setup.py)
 redis==3.5.3              # via invenio-accounts, invenio-celery
 requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient, kubernetes

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.8.0a6,<0.9.0",
+    "pytest-reana>=0.8.0a7,<0.9.0",
 ]
 
 extras_require = {
@@ -48,7 +48,7 @@ setup_requires = [
 install_requires = [
     "marshmallow>2.13.0,<=2.20.1",
     "pyOpenSSL==17.5.0",
-    "reana-commons[kubernetes,yadage]>=0.8.0a25,<0.9.0",
+    "reana-commons[kubernetes,yadage]>=0.8.0a29,<0.9.0",
     "reana-db>=0.8.0a20,<0.9.0",
     "requests==2.20.0",
     "rfc3987==1.3.7",


### PR DESCRIPTION
The logic of this estimator class is a bit different than the other workflow engines
as it relies on the `dependencies` between jobs that the Snakemake DAG class calculates
(logic implemented in `reana-commons`). From that information, we extract the maximum
number of jobs that can run in parallel and their assigned kubernetes memory limit to
estimate the complexity tuple with the maximum amount of memory to allocate.

closes #392

Depends on https://github.com/reanahub/pytest-reana/pull/89 release
~~Depends on https://github.com/reanahub/reana-commons/pull/300 release~~

**To test:**

1. Change [REANA scheduling policy](https://github.com/reanahub/reana/blob/5c240525313bfef4a49c6db11c12433fbeb51029/helm/reana/values.yaml#L69) to balance and redeploy your cluster:
```diff
diff --git a/helm/reana/values.yaml b/helm/reana/values.yaml
index 03d6fc6..cc84dcc 100644
--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -66,7 +66,7 @@ components:
       REANA_MAX_CONCURRENT_BATCH_WORKFLOWS: 30
       REANA_SCHEDULER_REQUEUE_SLEEP: 15
       REANA_USER_EMAIL_CONFIRMATION: true
-      REANA_WORKFLOW_SCHEDULING_POLICY: "fifo"
+      REANA_WORKFLOW_SCHEDULING_POLICY: "balanced"
     uwsgi:
       processes: 6
       threads: 4
```
2. Run an example with job parallelization such as `reana-demo-cms-h4l` or create a dummy one:
```yaml
# reana-dummy-parallel.yaml

version: 0.8.0
inputs:
  directories:
    - workflow/snakemake
workflow:
  type: snakemake
  file: workflow/snakemake/Snakefile-dummy-parallel
```

```make
# Snakefile-dummy-parallel

rule all:
    input:
        "results/all.txt"

rule scatterA:
    output:
       "results/A.prev.txt"
    container:
        "docker://python:2.7-slim"
    shell:
        "sleep 15 && "
        "mkdir -p results && touch {output}"

rule scatterB:
    output:
        "results/B.prev.txt"
    container:
        "docker://python:2.7-slim"
    resources:
        kubernetes_memory_limit="200Mi"
    shell:
        "sleep 30 && "
        "mkdir -p results && touch {output}"

rule gather:
    input:
       "results/A.prev.txt",
       "results/B.prev.txt"
    output:
        "results/all.txt"
    container:
        "docker://python:2.7-slim"
    shell:
        "sleep 5 && "
        "touch {output}"

```

3. Set a breakpoint where the workflow complexity gets calculated.
https://github.com/reanahub/reana-server/blob/c7393d862626df651e19be66c745fa5f68eaa7db/reana_server/utils.py#L112

4. Verify that the estimated complexity is equal to the job (or parallel jobs) that will allocate the maximum of memory. On the previous dummy example should be `[(2 parallel scatter jobs, (4Gi + 200Mi)/2))]`, i.e. `[(2, 2252341248.0)]`. 