### PR TITLE
scheduler: catch rabbitmq message conflict exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ install_requires = [
     "uwsgitop>=0.10",
     "webcolors==1.7",
     "click<8.0.0",
+    "wtforms<3.0.0",
     # Invenio dependencies
     "invenio-app>=1.2.6,<1.3.0",
     "invenio-base>=1.2.3,<1.3.0",


### PR DESCRIPTION
closes https://github.com/reanahub/reana-message-broker/issues/41

While testing https://github.com/reanahub/reana/pull/558 I've noticed that in some cases after killing `reana-message-broker` the queue gets stuck with the following error in the `scheduler`:
```
2021-10-27 12:08:05,443 | root | MainThread | ERROR | Something went wrong while calling RWC :
409 CONFLICT
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/reana_server/scheduler.py", line 143, in on_message
    ) = current_rwc_api_client.api.set_workflow_status(
  File "/usr/local/lib/python3.8/site-packages/bravado/http_future.py", line 271, in result
    swagger_result = self._get_swagger_result(incoming_response)
  File "/usr/local/lib/python3.8/site-packages/bravado/http_future.py", line 124, in wrapper
    return func(self, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/bravado/http_future.py", line 299, in _get_swagger_result
    unmarshal_response(
  File "/usr/local/lib/python3.8/site-packages/bravado/http_future.py", line 352, in unmarshal_response
    raise_on_expected(incoming_response)
  File "/usr/local/lib/python3.8/site-packages/bravado/http_future.py", line 416, in raise_on_expected
    raise make_http_exception(
bravado.exception.HTTPConflict: 409 CONFLICT
```
It happens because `reana-message-broker` is being killed while still processing the message which is not yet acknowledged. After this happens new `reana-message-broker` pod starts to send the same message to the consumer which triggers this error. This PR catches these cases and drops the message.

To test:
- Should be tested with https://github.com/reanahub/reana/pull/558
- Similar approach as https://github.com/reanahub/reana/pull/558 (NFS and  sleep time (e.g. sleep 60) to the helloworld serial demo)
- Modify helm values (similar to -dev environment):
  - `REANA_SCHEDULER_REQUEUE_SLEEP: 15`
  - `REANA_MAX_CONCURRENT_BATCH_WORKFLOWS: 5`
 - Launch 10 helloworld demos and kill `reana-message-broker-0` after some have started
 - Check that all workflows finish as expected
 - Check `scheduler` logs for `bravado.exception.HTTPConflict: 409 CONFLICT` error