### PR TITLE
scheduler: set correct logging level

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
-    "version": "0.8.0a5"
+    "version": "0.8.0a6"
   },
   "parameters": {},
   "paths": {

--- a/reana_server/cli.py
+++ b/reana_server/cli.py
@@ -19,7 +19,7 @@ from reana_server.scheduler import WorkflowExecutionScheduler
 @click.command("start-scheduler")
 def start_scheduler():
     """Start a workflow execution scheduler process."""
-    logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT)
+    logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT, force=True)
     scheduler = WorkflowExecutionScheduler()
     logging.info("Starting scheduler...")
     scheduler.run()

--- a/reana_server/factory.py
+++ b/reana_server/factory.py
@@ -26,7 +26,7 @@ from reana_db.database import Session
 
 def create_app(config_mapping=None):
     """REANA Server application factory."""
-    logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT)
+    logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT, force=True)
     app = Flask(__name__)
     app.config.from_object("reana_server.config")
     if config_mapping:

--- a/reana_server/version.py
+++ b/reana_server/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a5"
+__version__ = "0.8.0a6"


### PR DESCRIPTION
closes reanahub#415

This issue appeared because we were `logging` inside [configs](https://github.com/reanahub/reana-server/blob/master/reana_server/config.py#L151) before setting the log level. This resulted in `WARNING` level set to default which was not overridden by `logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT)` later on.
This PR sets a logging level with force to override it.
