### PR TITLE
reana-admin: use resource type while setting quota limit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 0.8.1 (2021-11-29)
+--------------------------
+
+- Changes ``quota-set`` command used by the REANA administrators to use the resource type along with a resource name for specifying the resource.
+- Changes email validation used in ``create-admin-user`` command by the REANA administrators to be more permissive.
+
 Version 0.8.0 (2021-11-22)
 ---------------------------
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
-    "version": "0.8.0"
+    "version": "0.8.1"
   },
   "parameters": {},
   "paths": {
@@ -2599,7 +2599,7 @@
                     }
                   }
                 },
-                "reana_server_version": "0.8.0",
+                "reana_server_version": "0.8.1",
                 "reana_token": {
                   "requested_at": "Mon, 25 May 2020 10:39:57 GMT",
                   "status": "active",

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -145,25 +145,8 @@ def _is_valid_rate_limit(rate_limit: str) -> bool:
 
 
 def _get_rate_limit(env_variable: str, default: str) -> str:
-    env_value = os.getenv(env_variable)
-
-    if not env_value:
-        logging.warning(
-            f"API rate limit config {env_variable} environment variable is not present. "
-            f"Using default value: {default}"
-        )
-        # assuming default has correct format
-        return default
-
-    if _is_valid_rate_limit(env_value):
-        return env_value
-    else:
-        logging.warning(
-            f"API rate limit config {env_variable} environment variable has incorrect format. "
-            f"Incorrect value: {env_value}. Using default value: {default}"
-        )
-        # assuming default has correct format
-        return default
+    env_value = os.getenv(env_variable, "")
+    return env_value if _is_valid_rate_limit(env_value) else default
 
 
 # Note: users that are connecting via reana-client will be treated as guests by the Invenio framework

--- a/reana_server/rest/users.py
+++ b/reana_server/rest/users.py
@@ -112,7 +112,7 @@ def get_you(user):
             application/json:
               {
                 "email": "user@reana.info",
-                "reana_server_version": "0.8.0",
+                "reana_server_version": "0.8.1",
                 "reana_token": {
                     "value": "Drmhze6EPcv0fN_81Bj-nA",
                     "status": "active",

--- a/reana_server/version.py
+++ b/reana_server/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"


### PR DESCRIPTION
`quota-set` command in `reana_admin` was using resource _name_ for specifying the resource. Currently we have "processing time" as a `cpu` name and "shared storage" as a `disk` name. So one had to do something like this in order to set some quota limits for a specific user:
```
kubectl exec -i -t deployment/reana-server -- flask reana-admin quota-set -r "shared storage" -e audrius.mecionis@gmail.com -l 200 --admin-access-token $REANA_ACCESS_TOKEN 
```
This PR fixes `quota-set`, `quota-resources`, `quota-set-default-limits` commands to use resource types (e.g. disk, cpu) instead of a resource names ("shared storage", "processing time"). In case of same-type-multi-resource setup scenario it will ask for `--resource-name` to specify the exact resource.

To test:
```
$ kubectl exec -i -t deployment/reana-server -- flask reana-admin quota-resources --admin-access-token $REANA_ACCESS_TOKEN
$ kubectl exec -i -t deployment/reana-server -- flask reana-admin quota-set-default-limits --admin-access-token $REANA_ACCESS_TOKEN 
$ kubectl exec -i -t deployment/reana-server -- flask reana-admin quota-set -r cpu -e audrius.mecionis@gmail.com -l 200 --admin-access-token $REANA_ACCESS_TOKEN
$ kubectl exec -i -t deployment/reana-server -- flask reana-admin quota-set -r disk -e audrius.mecionis@gmail.com -l 200 --admin-access-token $REANA_ACCESS_TOKEN
```

Snippet to add another `cpu` resource:
```
$ kubectl exec -i -t deployment/reana-server -c rest-api -- invenio shell

from reana_db.models import Resource, ResourceType, ResourceUnit
from reana_db.database import Session
r = Resource(name="test", type_=ResourceType.cpu, unit=ResourceUnit.milliseconds, title="test cpu")
Session.add(r)
Session.commit()
```
Then one has to do:
`$ kubectl exec -i -t deployment/reana-server -- flask reana-admin quota-set -r cpu --resource-name "test" ...`