### PR TITLE
utils: email validation, handle additional cases

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+# This file is part of REANA.
+# Copyright (C) 2021 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA-Server tests for utils module."""
+
+import pytest
+from reana_server.utils import is_valid_email
+
+
+@pytest.mark.parametrize(
+    "email,is_valid",
+    [
+        ("john@example.org", True),
+        ("john.doe@example.org", True),
+        ("john-doe@example.org", True),
+        ("john.doe@edu.uni.org", True),
+        ("jean-yves.le.meur@cern.ch", True),
+        ("john.doe@exampleorg", False),
+        ("john.doeexample.org", False),
+        ("john@example.org.", False),
+        ("john@example..org", False),
+        ("john@@example.org", False),
+    ],
+)
+def test_is_email_valid(email: str, is_valid: bool):
+    assert is_valid_email(email) == is_valid


### PR DESCRIPTION
I went with a minimal implementation just to cover the issue, but there are more cases that we do not support and we might consider it in this PR or open an issue for later. What do you think?

## Another option

I found a [website](http://emailregex.com) with a less strict email regex. In python:

```python
email_regex = r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
```

This regex covers cases like `john.doe@edu.uni.ch` or `john.doe.boe@example.org` (double dots) that are not covered currently. But it allows for emails like `john..doe@example.org` which are incorrect, etc.

*question(non-blocking):* @mvidalgarcia do you remember what was the goal for email validation? Like being more strict or catching common input mistakes.

closes #422