### PR TITLE
ext: enable logging in REANA Invenio app

### DIFF
--- a/reana_server/app.py
+++ b/reana_server/app.py
@@ -6,7 +6,7 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-"""Main entrypoint for Reana-Server."""
+"""Main entrypoint for REANA-Server."""
 
 from reana_server.factory import create_app
 

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -9,7 +9,6 @@
 """Flask application configuration."""
 
 import copy
-import logging
 import os
 import re
 

--- a/reana_server/ext.py
+++ b/reana_server/ext.py
@@ -8,7 +8,10 @@
 
 """Flask extension REANA-Server."""
 
+import logging
+
 from flask_menu import Menu
+from reana_commons.config import REANA_LOG_FORMAT, REANA_LOG_LEVEL
 
 from reana_server import config
 
@@ -18,6 +21,9 @@ class REANA(object):
 
     def __init__(self, app=None):
         """Extension initialization."""
+        logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT, force=True)
+        werkzeug_logger = logging.getLogger("werkzeug")
+        werkzeug_logger.propagate = False
         if app:
             self.app = app
             self.init_app(app)

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -14,20 +14,17 @@ import traceback
 import requests
 from bravado.exception import HTTPError
 from flask import Blueprint, Response
-from flask import current_app as app
 from flask import jsonify, request, stream_with_context
 from reana_commons.config import REANA_WORKFLOW_ENGINES
 from reana_commons.errors import REANAQuotaExceededError, REANAValidationError
 from reana_commons.operational_options import validate_operational_options
 from reana_commons.workspaces import validate_workspace
-from reana_db.database import Session
 from reana_db.models import (
     InteractiveSessionType,
     ResourceType,
     ResourceUnit,
     RunStatus,
     UserResource,
-    Workflow,
 )
 from reana_db.utils import _get_workflow_with_uuid_or_name, get_default_quota_resource
 from webargs import fields, validate


### PR DESCRIPTION
closes #417
closes #298

#### To test:

Two scenarios:
1. Debug mode (`invenio run`)
2. Production mode (`uwsgi`)

To switch between scenarios check https://github.com/reanahub/reana/pull/603

In **both** scenarios, perform these steps:
1. Leave reana-server pod logs open in a terminal
```console
$ kubectl logs deployment/reana-server rest-api -f
```
2. Navigate to the different endpoints via UI and CLI, e.g. UI: sign in, go to the status page, etc.; CLI: `reana-client ping/info/run..`
3. Verify that the logs correspond to the network calls
4. Go to a certain endpoint (e.g. [`/api/config`](https://github.com/reanahub/reana-server/blob/0b4229726fb0a354378970350cda7049f05c2b94/reana_server/rest/config.py#L22)) and add some log messages at the beginning of the function
```diff
diff --git a/reana_server/rest/config.py b/reana_server/rest/config.py
index 9353aad..014a916 100644
--- a/reana_server/rest/config.py
+++ b/reana_server/rest/config.py
@@ -65,6 +65,11 @@ def get_config():
                 "message": "Internal server error."
               }
     """
+    logging.debug("debug foo")
+    logging.error("error foo")
+    logging.info("info foo")
+    logging.critical("critical foo")
+    print("this is a print")
     try:
         return (
             jsonify(REANAConfig.load("ui")),

```
5. Call this endpoint and check logs.
6. Do the same but instead of printing a message, raise an Exception to verify that is caught properly and the traceback is printed.
```python
raise Exception("foo")
```