### PR TITLE
rest: validate Kubernetes job memory limits before publishing workflow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.8.3 (UNRELEASED)
+--------------------------
+
+- Adds Kubernetes job memory limits validation before publishing workflow submission.
+
 Version 0.8.2 (2022-02-07)
 --------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-Version 0.8.3 (UNRELEASED)
+Version 0.8.3 (2022-02-10)
 --------------------------
 
 - Adds Kubernetes job memory limits validation before publishing workflow submission.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
-    "version": "0.8.2"
+    "version": "0.8.3"
   },
   "parameters": {},
   "paths": {

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -45,6 +45,18 @@ REANA_KUBERNETES_JOBS_MEMORY_LIMIT_IN_BYTES = (
 )
 """Maximum memory limit for user job containers in bytes."""
 
+REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT = os.getenv(
+    "REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT"
+)
+"""Maximum memory limit that users can assign to their job containers."""
+
+REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT_IN_BYTES = (
+    kubernetes_memory_to_bytes(REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT)
+    if REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT
+    else 0
+)
+"""Maximum memory limit that users can assign to their job containers in bytes."""
+
 REANA_WORKFLOW_SCHEDULING_POLICY = os.getenv("REANA_WORKFLOW_SCHEDULING_POLICY", "fifo")
 
 REANA_WORKFLOW_SCHEDULING_POLICIES = ["fifo", "balanced"]

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -40,7 +40,11 @@ from sqlalchemy.exc import (
 )
 
 from reana_server.api_client import current_workflow_submission_publisher
-from reana_server.complexity import get_workflow_min_job_memory, estimate_complexity
+from reana_server.complexity import (
+    get_workflow_min_job_memory,
+    estimate_complexity,
+    validate_job_memory_limits,
+)
 from reana_server.config import (
     ADMIN_EMAIL,
     ADMIN_USER_ID,
@@ -112,6 +116,7 @@ def publish_workflow_submission(workflow, user_id, parameters):
         complexity = _calculate_complexity(workflow)
         workflow_priority = workflow.get_priority(total_cluster_memory)
         workflow_min_job_memory = get_workflow_min_job_memory(complexity)
+        validate_job_memory_limits(complexity)
     current_workflow_submission_publisher.publish_workflow_submission(
         user_id=str(user_id),
         workflow_id_or_name=workflow.get_full_workflow_name(),

--- a/reana_server/version.py
+++ b/reana_server/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -127,8 +127,8 @@ pyrsistent==0.18.1        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core, kubernetes
 pytz==2021.3              # via babel, bravado-core, celery, fs
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, packtivity, reana-commons, swagger-spec-validator, yadage, yadage-schemas
-reana-commons[kubernetes,yadage]==0.8.3  # via reana-db, reana-server (setup.py)
-reana-db==0.8.1           # via reana-server (setup.py)
+reana-commons[kubernetes,yadage]==0.8.4	# via reana-db, reana-server (setup.py)
+reana-db==0.8.1	# via reana-server (setup.py)
 redis==4.1.2              # via invenio-accounts, invenio-celery
 requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient, kubernetes
 requests[security]==2.25.0  # via bravado, kubernetes, packtivity, reana-server (setup.py), requests-oauthlib, yadage, yadage-schemas

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup_requires = [
 install_requires = [
     "marshmallow>2.13.0,<=2.20.1",
     "pyOpenSSL==17.5.0",
-    "reana-commons[kubernetes,yadage]>=0.8.3,<0.9.0",
+    "reana-commons[kubernetes,yadage]>=0.8.4,<0.9.0",
     "reana-db>=0.8.1,<0.9.0",
     "requests==2.25.0",
     "rfc3987==1.3.7",


### PR DESCRIPTION
closes https://github.com/reanahub/reana-server/issues/437

About the issue:
It only appears in the `balanced` scheduling mode and with working Kubernetes metrics-server, probably that's why it slipped through our testing. The root cause of the issue happens [here](https://github.com/reanahub/reana-server/blob/master/reana_server/scheduler.py#L38). In `balanced` mode we also measure if at least one workflow job could be started:
- We take `min_job_memory` [here](https://github.com/reanahub/reana-server/blob/master/reana_server/utils.py#L114) and send it as a param in message header to the scheduler.
- The scheduler [verifies if there are enough memory to execute the job](https://github.com/reanahub/reana-server/blob/master/reana_server/scheduler.py#L32). If not - it reschedules it for later. 
- And here is the problem - if `workflow_min_job_memory` exceeds `max_node_available_memory` it can never be started and is stuck if never ending requeuing loop.

This fix is to validate the maximal value of initial job memory against `REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT` to fail early. Note that it only checks the initial jobs which are returned from `estimate_complexity()`. All the rest workflow jobs are validated with [this check](https://github.com/reanahub/reana-job-controller/blob/master/reana_job_controller/kubernetes_job_manager.py#L484).

To test:
- In order to reproduce the issue follow steps described in https://github.com/reanahub/reana-server/issues/437
- In addition change `REANA_WORKFLOW_SCHEDULING_POLICY: "balanced"` in Helm values
- Make sure you have working Kubernetes metrics-server. Instructions to install can be found [here](https://github.com/reanahub/reana/wiki/Tips-for-Kind#install-metrics-server-locally)
- Checkout https://github.com/reanahub/reana/pull/615