### PR TITLE
scheduler: add retry mechanism

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.8.4 (UNRELEASED)
+--------------------------
+
+- Changes workflow scheduler to count number of workflow retries.
+
 Version 0.8.3 (2022-02-10)
 --------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-Version 0.8.4 (UNRELEASED)
+Version 0.8.4 (2022-02-23)
 --------------------------
 
 - Changes workflow scheduler to count number of workflow retries.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
-    "version": "0.8.3"
+    "version": "0.8.4"
   },
   "parameters": {},
   "paths": {

--- a/reana_server/api_client.py
+++ b/reana_server/api_client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +10,6 @@
 from functools import partial
 
 from reana_commons.api_client import get_current_api_client
-from reana_commons.config import MQ_DEFAULT_QUEUES
 from reana_commons.publisher import WorkflowSubmissionPublisher
 from werkzeug.local import LocalProxy
 

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -220,3 +220,6 @@ ADMIN_EMAIL = os.getenv("REANA_EMAIL_SENDER", "CHANGE_ME")
 # ==================
 REANA_SCHEDULER_REQUEUE_SLEEP = float(os.getenv("REANA_SCHEDULER_REQUEUE_SLEEP", "15"))
 """How many seconds to wait between consuming workflows."""
+
+REANA_SCHEDULER_REQUEUE_COUNT = int(os.getenv("REANA_SCHEDULER_REQUEUE_COUNT", "200"))
+"""How many times to requeue workflow, in case of error or busy cluster, before failing it."""

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -12,7 +12,6 @@ import csv
 import io
 import json
 import logging
-import re
 import secrets
 import sys
 import os
@@ -119,7 +118,7 @@ def publish_workflow_submission(workflow, user_id, parameters):
         validate_job_memory_limits(complexity)
     current_workflow_submission_publisher.publish_workflow_submission(
         user_id=str(user_id),
-        workflow_id_or_name=workflow.get_full_workflow_name(),
+        workflow_id_or_name=str(workflow.id_),
         parameters=parameters,
         priority=workflow_priority,
         min_job_memory=workflow_min_job_memory,

--- a/reana_server/version.py
+++ b/reana_server/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.3"
+__version__ = "0.8.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -127,8 +127,8 @@ pyrsistent==0.18.1        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core, kubernetes
 pytz==2021.3              # via babel, bravado-core, celery, fs
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, packtivity, reana-commons, swagger-spec-validator, yadage, yadage-schemas
-reana-commons[kubernetes,yadage]==0.8.4	# via reana-db, reana-server (setup.py)
-reana-db==0.8.1	# via reana-server (setup.py)
+reana-commons[kubernetes,yadage]==0.8.5	# via reana-db, reana-server (setup.py)
+reana-db==0.8.2	# via reana-server (setup.py)
 redis==4.1.2              # via invenio-accounts, invenio-celery
 requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient, kubernetes
 requests[security]==2.25.0  # via bravado, kubernetes, packtivity, reana-server (setup.py), requests-oauthlib, yadage, yadage-schemas

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ setup_requires = [
 install_requires = [
     "marshmallow>2.13.0,<=2.20.1",
     "pyOpenSSL==17.5.0",
-    "reana-commons[kubernetes,yadage]>=0.8.4,<0.9.0",
-    "reana-db>=0.8.1,<0.9.0",
+    "reana-commons[kubernetes,yadage]>=0.8.5,<0.9.0",
+    "reana-db>=0.8.2,<0.9.0",
     "requests==2.25.0",
     "rfc3987==1.3.7",
     "strict-rfc3339==0.7",

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,18 +1,20 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA-Server Workflow Execution Scheduler."""
+import base64
+import json
 
-
-from bravado.exception import HTTPError
+import pytest
+from bravado.exception import HTTPBadGateway, HTTPNotFound, HTTPConflict
 from mock import DEFAULT, Mock, patch
-from reana_commons.publisher import WorkflowSubmissionPublisher
 
+from reana_server.api_client import WorkflowSubmissionPublisher
 from reana_server.scheduler import WorkflowExecutionScheduler
 
 
@@ -41,7 +43,7 @@ def test_scheduler_starts_workflows(
     assert in_memory_queue_connection.channel().queues["workflow-submission"].empty()
 
 
-def test_scheduler_requeues_workflows(
+def test_scheduler_requeues_when_not_ready(
     in_memory_queue_connection, default_in_memory_producer, consume_queue,
 ):
     """Test that the scheduler requeues workflows if conditions not met."""
@@ -52,6 +54,7 @@ def test_scheduler_requeues_workflows(
     with patch.multiple(
         "reana_server.scheduler",
         reana_ready=Mock(return_value=False),
+        current_workflow_submission_publisher=in_memory_wsp,
         REANA_SCHEDULER_REQUEUE_SLEEP=0,
     ):
         consume_queue(scheduler, limit=1)
@@ -60,10 +63,29 @@ def test_scheduler_requeues_workflows(
             .queues["workflow-submission"]
             .empty()
         )
+        message = (
+            in_memory_queue_connection.channel().queues["workflow-submission"].get()
+        )
+        message_body = base64.b64decode(message["body"]).decode("ascii")
+        message_body = json.loads(json.loads(message_body))
+        assert message_body["retry_count"] == 1
 
 
+@pytest.mark.parametrize(
+    "error,should_retry",
+    [
+        (HTTPBadGateway(Mock()), True),
+        (Exception(Mock()), True),
+        (HTTPNotFound(Mock()), False),
+        (HTTPConflict(Mock()), False),
+    ],
+)
 def test_scheduler_requeues_on_rwc_failure(
-    in_memory_queue_connection, default_in_memory_producer, consume_queue,
+    in_memory_queue_connection,
+    default_in_memory_producer,
+    consume_queue,
+    error,
+    should_retry,
 ):
     """Test scheduler requeues requests if RWC fails to start workflows."""
     scheduler = WorkflowExecutionScheduler(connection=in_memory_queue_connection)
@@ -72,17 +94,51 @@ def test_scheduler_requeues_on_rwc_failure(
     in_memory_wsp.publish_workflow_submission("1", "workflow.1", {})
     mock_rwc_api_client = Mock()
     mock_result_obj = Mock()
-    mock_response = Mock()
-    mock_response.status_code = 502
-    mock_result_obj.result = Mock(
-        side_effect=HTTPError(mock_response, message="DB connection timed out.")
-    )
+    mock_result_obj.result = Mock(side_effect=error)
     mock_rwc_api_client.api.set_workflow_status.return_value = mock_result_obj
     with patch.multiple(
         "reana_server.scheduler",
         reana_ready=Mock(return_value=True),
         current_rwc_api_client=mock_rwc_api_client,
+        current_workflow_submission_publisher=in_memory_wsp,
         REANA_SCHEDULER_REQUEUE_SLEEP=0,
+    ):
+        consume_queue(scheduler, limit=1)
+
+        if should_retry:
+            assert (
+                not in_memory_queue_connection.channel()
+                .queues["workflow-submission"]
+                .empty()
+            )
+            message = (
+                in_memory_queue_connection.channel().queues["workflow-submission"].get()
+            )
+            message_body = base64.b64decode(message["body"]).decode("ascii")
+            message_body = json.loads(json.loads(message_body))
+            assert message_body["retry_count"] == 1
+        else:
+            assert (
+                in_memory_queue_connection.channel()
+                .queues["workflow-submission"]
+                .empty()
+            )
+
+
+def test_scheduler_fail_after_too_many_retries(
+    in_memory_queue_connection, default_in_memory_producer, consume_queue,
+):
+    """Test scheduler requeues requests if RWC fails to start workflows."""
+    scheduler = WorkflowExecutionScheduler(connection=in_memory_queue_connection)
+    in_memory_wsp = WorkflowSubmissionPublisher(connection=in_memory_queue_connection)
+
+    in_memory_wsp.publish_workflow_submission("1", "workflow.1", {})
+    with patch.multiple(
+        "reana_server.scheduler",
+        reana_ready=Mock(return_value=False),
+        current_workflow_submission_publisher=in_memory_wsp,
+        REANA_SCHEDULER_REQUEUE_SLEEP=0,
+        REANA_SCHEDULER_REQUEUE_COUNT=1,
     ):
         consume_queue(scheduler, limit=1)
         assert (
@@ -90,3 +146,8 @@ def test_scheduler_requeues_on_rwc_failure(
             .queues["workflow-submission"]
             .empty()
         )
+        consume_queue(scheduler, limit=1)
+        assert (
+            in_memory_queue_connection.channel().queues["workflow-submission"].empty()
+        )
+        assert not in_memory_queue_connection.channel().queues["jobs-status"].empty()


### PR DESCRIPTION
closes #436

**Important:** there are two commits in a not-ready state because I moved some scheduler code to a separate folder. if reviewers will not object to the change, I will squash commits before merging. 

How to test:

1. Checkout all related PRs from the issue description

2. Edit `values-dev.yaml`:

```yaml
components:
    reana_server:
      image: reanahub/reana-server
      environment:
        REANA_SCHEDULER_REQUEUE_SLEEP: 5
        REANA_SCHEDULER_REQUEUE_COUNT: 10
        REANA_WORKFLOW_SCHEDULING_POLICY: "balanced"
...
kubernetes_jobs_memory_limit: 2Gi
kubernetes_jobs_max_user_memory_limit: 24Gi  # this value should be bigger then your available memory
```

3. Re-deploy REANA

4. Set a memory limit for a job in a workflow that still fits within the specified limit but exceeds your machine capacity. For example, `20Gi`.

5. Start a workflow, observe logs from `scheduler`.

6. Workflow should fail after a couple of retries, check `reana-client logs`.
