### PR TITLE
fetcher: add workflow specification fetcher

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.9.0 (UNRELEASED)
 --------------------------
 
 - Adds new ``/api/launch`` endpoint that allows running workflows from remote sources.
+- Adds the possibility to fetch the workflow specification from a remote URL.
 
 Version 0.8.4 (2022-02-23)
 --------------------------

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -223,3 +223,11 @@ REANA_SCHEDULER_REQUEUE_SLEEP = float(os.getenv("REANA_SCHEDULER_REQUEUE_SLEEP",
 
 REANA_SCHEDULER_REQUEUE_COUNT = int(os.getenv("REANA_SCHEDULER_REQUEUE_COUNT", "200"))
 """How many times to requeue workflow, in case of error or busy cluster, before failing it."""
+
+# Workflow fetcher
+# ================
+WORKFLOW_SPEC_FILENAMES = ["reana.yaml", "reana.yml"]
+"""Filenames to use when discovering workflow specifications."""
+
+WORKFLOW_SPEC_EXTENSIONS = [".yaml", ".yml"]
+"""Valid file extensions of workflow specifications."""

--- a/reana_server/fetcher.py
+++ b/reana_server/fetcher.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA Server workflow fetcher."""
+
+from abc import ABC, abstractmethod
+import os
+import shutil
+from typing import List, Optional
+from urllib.parse import urlparse
+from urllib.request import urlretrieve
+import zipfile
+
+from git import Repo
+
+from reana_server.config import WORKFLOW_SPEC_EXTENSIONS, WORKFLOW_SPEC_FILENAMES
+
+
+class WorkflowFetcherBase(ABC):
+    """Fetch the specification of a workflow."""
+
+    def __init__(self, url: str, output_dir: str, spec: Optional[str] = None):
+        """Initialize the workflow specification fetcher.
+
+        :param url: URL of the workflow specification to fetch.
+        :param output_dir: Directory where all the data will be saved to.
+        :param spec: Optional path to the workflow specification.
+        """
+        self._url = url
+        self._output_dir = os.path.abspath(output_dir)
+        self._spec = spec
+
+    @abstractmethod
+    def fetch(self) -> None:
+        """Fetch the workflow specification."""
+        pass
+
+    def _discover_workflow_specs(self, dir: Optional[str] = None) -> List[str]:
+        """Discover if there is a workflow specification in the given directory.
+
+        :param dir: Directory used for the search.
+            If None, the output directory will be used.
+        :returns: List of paths of possible specification files.
+        """
+        if dir is None:
+            dir = self._output_dir
+
+        specs = []
+        for filename in WORKFLOW_SPEC_FILENAMES:
+            path = os.path.join(dir, filename)
+            if os.path.isfile(path):
+                specs.append(path)
+        return specs
+
+    def _is_path_inside_output_dir(self, path: str) -> bool:
+        """Check if a file is inside the output directory.
+
+        :param path: Absolute path to the file.
+        :returns: ``True`` if the file is inside the output directory, ``False`` otherwise.
+        """
+        real_output_dir = os.path.realpath(self._output_dir)
+        real_file_path = os.path.realpath(path)
+        return os.path.commonpath([real_output_dir, real_file_path]) == real_output_dir
+
+    def workflow_spec_path(self) -> str:
+        """Get the path of the workflow specification file.
+
+        If the path to the specification file was provided, only that will be used to
+        find the workflow specification. Otherwise, the file will be searched in the
+        output directory. This method should be called after ``fetch``.
+
+        :returns: Path of the workflow specification file.
+        """
+        if self._spec:
+            spec_path = os.path.abspath(os.path.join(self._output_dir, self._spec))
+            if not self._is_path_inside_output_dir(spec_path):
+                raise Exception("Invalid path to the workflow specification")
+            if not os.path.isfile(spec_path):
+                raise Exception("Cannot find provided workflow specification")
+            return spec_path
+
+        specs = [os.path.abspath(path) for path in self._discover_workflow_specs()]
+        unique_specs = list(set(specs))
+        if not unique_specs:
+            raise Exception("Workflow specification was not found")
+        if len(unique_specs) > 1:
+            raise Exception("Multiple workflow specifications found")
+        return unique_specs[0]
+
+
+class WorkflowFetcherGit(WorkflowFetcherBase):
+    """Fetch the specification of a workflow from a Git repository."""
+
+    def __init__(
+        self,
+        url: str,
+        output_dir: str,
+        git_ref: Optional[str] = None,
+        spec: Optional[str] = None,
+    ):
+        """Initialize the workflow specification fetcher.
+
+        :param url: URL of the git repository containing the workflow specification.
+        :param output_dir: Directory where all the data will be saved to.
+        :param git_ref: Optional reference to a specific git branch/commit.
+        :param spec: Optional path to the workflow specification.
+        """
+        super().__init__(url, output_dir, spec)
+        self._git_ref = git_ref
+
+    def fetch(self) -> None:
+        """Fetch workflow specification from a Git repository."""
+        repository = Repo.clone_from(self._url, self._output_dir, depth=1)
+        if self._git_ref:
+            repository.remote().fetch(self._git_ref, depth=1)
+            repository.git.checkout(self._git_ref)
+
+
+class WorkflowFetcherYaml(WorkflowFetcherBase):
+    """Fetch the specification of a workflow from a given URL pointing to a YAML file."""
+
+    def __init__(self, url: str, output_dir: str, spec_name: str):
+        """Initialize the workflow specification fetcher.
+
+        :param url: URL of the workflow specification to fetch.
+        :param output_dir: Directory where all the data will be saved to.
+        :param spec_name: Filename of the workflow specification file to be fetched.
+        """
+        super().__init__(url, output_dir, spec_name)
+
+    def fetch(self) -> None:
+        """Fetch workflow specification from a given URL."""
+        workflow_spec_path = os.path.join(self._output_dir, self._spec)
+        urlretrieve(self._url, workflow_spec_path)
+
+
+class WorkflowFetcherZip(WorkflowFetcherBase):
+    """Fetch the specification of a workflow from a zip archive."""
+
+    def __init__(self, url: str, output_dir: str, archive_name: str):
+        """Initialize the workflow specification fetcher.
+
+        :param url: URL of the workflow specification to fetch.
+        :param output_dir: Directory where all the data will be saved to.
+        :param archive_name: Filename of the zip archive to be fetched.
+        """
+        super().__init__(url, output_dir)
+        self._archive_name = archive_name
+
+    def fetch(self) -> None:
+        """Fetch workflow specification from a zip archive."""
+        archive_path = os.path.join(self._output_dir, self._archive_name)
+        urlretrieve(self._url, archive_path)
+        with zipfile.ZipFile(archive_path, "r") as zip_file:
+            zip_file.extractall(path=self._output_dir)
+        os.remove(archive_path)
+
+        if not self._discover_workflow_specs():
+            top_level_entries = [
+                os.path.join(self._output_dir, entry)
+                for entry in os.listdir(self._output_dir)
+            ]
+            # Some zip archives contain a single directory with all the files.
+            if len(top_level_entries) == 1 and os.path.isdir(top_level_entries[0]):
+                top_level_dir = top_level_entries[0]
+                # Move all entries inside the top level directory
+                # to the output directory.
+                for entry in os.listdir(top_level_dir):
+                    shutil.move(os.path.join(top_level_dir, entry), self._output_dir)
+                os.rmdir(top_level_dir)
+
+
+def _get_github_fetcher(url: str, output_dir: str) -> WorkflowFetcherGit:
+    """Parse a GitHub URL and return the correct fetcher.
+
+    :param url: URL to a GitHub repository.
+    :param output_dir: Directory where all the data fetched will be saved.
+    :returns: Workflow fetcher.
+    """
+    # There are four different GitHub URLs:
+    # 1. URL to a repository: /<user>/<repo>
+    # 2. URL to a branch/commit: /<user>/<repo>/tree/<git_ref>
+    # 3. URL to a specific folder: /<user>/<repo>/tree/<git_ref>/<path_to_dir>
+    # 4. URL to a specific file: /<user>/<repo>/blob/<git_ref>/<path_to_file>
+
+    # We are interested in five components: username, repository, tree/blob, git_ref, path
+    url_path_components = ["username", "repository", "tree_or_blob", "git_ref", "path"]
+    parsed_url = urlparse(url)
+    split_url_path = parsed_url.path.strip("/").split(
+        "/", maxsplit=len(url_path_components) - 1
+    )
+    components = {k: v for k, v in zip(url_path_components, split_url_path)}
+
+    username = components.get("username")
+    repository = components.get("repository")
+    tree_or_blob = components.get("tree_or_blob")
+    git_ref = components.get("git_ref")
+    path = components.get("path")
+
+    if not username:
+        raise ValueError("Username not provided in GitHub URL")
+    if not repository:
+        raise ValueError("Repository not provided in GitHub URL")
+    if tree_or_blob and tree_or_blob not in ["tree", "blob"]:
+        raise ValueError("Malformed GitHub URL")
+    if tree_or_blob and not git_ref:
+        raise ValueError("Branch or commit ID not provided in GitHub URL")
+    if tree_or_blob == "blob" and not path:
+        raise ValueError("Specification file not provided in GitHub URL")
+    if tree_or_blob == "blob":
+        _, extension = os.path.splitext(path)
+        if extension not in WORKFLOW_SPEC_EXTENSIONS:
+            raise ValueError("GitHub URL points to an invalid specification file")
+    if tree_or_blob == "tree" and path:
+        raise ValueError("GitHub URL points to a directory")
+
+    repository_url = f"https://github.com/{username}/{repository}.git"
+    return WorkflowFetcherGit(repository_url, output_dir, git_ref, spec=path)
+
+
+def get_fetcher(url: str, output_dir: str) -> WorkflowFetcherBase:
+    """Select the correct workflow fetcher based on the given URL.
+
+    :param url: URL of the workflow specification.
+    :param output_dir: Directory where all the data fetched will be saved.
+    :returns: Workflow fetcher.
+    """
+    parsed_url = urlparse(url)
+    _, extension = os.path.splitext(parsed_url.path)
+    basename = os.path.basename(parsed_url.path)
+
+    if extension == ".git":
+        return WorkflowFetcherGit(url, output_dir)
+    elif parsed_url.netloc == "github.com":
+        return _get_github_fetcher(url, output_dir)
+    elif extension in WORKFLOW_SPEC_EXTENSIONS:
+        return WorkflowFetcherYaml(url, output_dir, spec_name=basename)
+    elif extension == ".zip":
+        return WorkflowFetcherZip(url, output_dir, archive_name=basename)
+    else:
+        raise ValueError("Cannot handle given url")

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,8 @@ flask-wtf==1.0.0          # via flask-security, invenio-accounts, invenio-oauth2
 flask==2.0.2              # via flask-alembic, flask-babelex, flask-breadcrumbs, flask-caching, flask-celeryext, flask-cors, flask-kvsession-invenio, flask-limiter, flask-login, flask-mail, flask-menu, flask-oauthlib, flask-principal, flask-security, flask-shell-ipython, flask-sqlalchemy, flask-wtf, invenio-base, invenio-cache, invenio-config, invenio-logging, invenio-mail, invenio-oauthclient, invenio-userprofiles
 fs==2.4.14                # via reana-commons
 future==0.18.2            # via invenio-accounts, invenio-oauth2server
+gitdb==4.0.9              # via gitpython
+gitpython==3.1.27         # via reana-server (setup.py)
 glob2==0.7                # via packtivity, yadage
 google-auth==2.6.0        # via kubernetes
 idna==2.10                # via email-validator, jsonschema, requests
@@ -136,6 +138,7 @@ rsa==4.8                  # via google-auth
 simplejson==3.17.6        # via bravado, bravado-core
 simplekv==0.14.1          # via flask-kvsession-invenio, invenio-accounts
 six==1.16.0               # via bravado, bravado-core, click-repl, flask-breadcrumbs, flask-cors, flask-kvsession-invenio, flask-limiter, flask-menu, flask-talisman, fs, google-auth, invenio-app, invenio-base, invenio-logging, invenio-oauthclient, jsonpath-rw, jsonschema, kubernetes, mock, pyopenssl, python-dateutil, reana-server (setup.py), sqlalchemy-utils, swagger-spec-validator, validators, wtforms-components, yadage-schemas
+smmap==5.0.0              # via gitdb
 speaklater==1.3           # via flask-babelex
 sqlalchemy-utils[encrypted]==0.35.0  # via invenio-db, invenio-oauth2server, invenio-oauthclient, reana-db, reana-server (setup.py), wtforms-alchemy
 sqlalchemy==1.3.24        # via alembic, flask-alembic, flask-sqlalchemy, invenio-db, reana-db, sqlalchemy-utils, wtforms-alchemy

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup_requires = [
 ]
 
 install_requires = [
+    "gitpython>=3.1",
     "marshmallow>2.13.0,<=2.20.1",
     "pyOpenSSL==17.5.0",
     "reana-commons[kubernetes,yadage]>=0.9.0a2,<0.10.0",

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""REANA-Server workflow fetcher tests."""
+
+import os
+import pytest
+from unittest.mock import Mock, patch
+import zipfile
+
+from git import Repo
+
+from reana_server.fetcher import (
+    _get_github_fetcher,
+    get_fetcher,
+    WorkflowFetcherGit,
+    WorkflowFetcherYaml,
+    WorkflowFetcherZip,
+)
+
+GIT_URL = "https://github.com/reanahub/reana-demo-root6-roofit.git"
+GITHUB_REPO_URL = "https://github.com/reanahub/reana-demo-root6-roofit"
+ZENODO_URL = "https://zenodo.org/record/5752285/files/circular-health-data-processing-master.zip?download=1"
+YAML_URL = "https://raw.githubusercontent.com/reanahub/reana-demo-root6-roofit/master/reana.yaml"
+
+
+@pytest.mark.parametrize(
+    "url, expected_fetcher_class",
+    [
+        (GIT_URL, WorkflowFetcherGit),
+        (GITHUB_REPO_URL, WorkflowFetcherGit),
+        (ZENODO_URL, WorkflowFetcherZip),
+        (YAML_URL, WorkflowFetcherYaml),
+        pytest.param(
+            "https://reana.io",
+            None,
+            marks=pytest.mark.xfail(raises=ValueError, strict=True),
+        ),
+    ],
+)
+def test_fetcher_selection(url, expected_fetcher_class, tmp_path):
+    """Test selection of the fetcher based on the provided URL."""
+    assert isinstance(get_fetcher(url, tmp_path), expected_fetcher_class)
+
+
+@pytest.mark.parametrize("with_git_ref", [True, False])
+def test_fetcher_git(with_git_ref, tmp_path):
+    """Test fetching the workflow specification from a git repository."""
+
+    def create_git_repository(repo_path, files):
+        """Create a git repository with one commit for each file."""
+        repository = Repo.init(repo_path)
+
+        commits = []
+        for file, content in files:
+            file_path = os.path.join(repo_path, file)
+            with open(file_path, "w") as f:
+                f.write(content)
+            repository.index.add(file_path)
+            commit = repository.index.commit(f"Add {file}")
+            commits.append(commit.hexsha)
+
+        return commits
+
+    repo_dir = os.path.join(tmp_path, "repo")
+    output_dir = os.path.join(tmp_path, "output")
+
+    files = [
+        ("reana.yaml", "Content of reana.yaml"),
+        ("README.md", "# Test Git Repository"),
+    ]
+    commits = create_git_repository(repo_dir, files)
+
+    git_ref = commits[0] if with_git_ref else None
+    fetcher = WorkflowFetcherGit(repo_dir, output_dir, git_ref)
+    fetcher.fetch()
+    expected_path = os.path.join(output_dir, "reana.yaml")
+    assert expected_path == fetcher.workflow_spec_path()
+    assert os.path.isfile(expected_path)
+
+
+@pytest.mark.parametrize(
+    "spec_name", ["reana.yaml", "reana.yml", "reana-snakemake.yaml"]
+)
+def test_fetcher_yaml(spec_name, tmp_path):
+    """Test fetching the workflow specification file from a URL."""
+
+    input_dir = os.path.join(tmp_path, "input")
+    os.makedirs(input_dir)
+    output_dir = os.path.join(tmp_path, "output")
+    os.makedirs(output_dir)
+
+    spec_path = os.path.join(input_dir, spec_name)
+    with open(spec_path, "w") as f:
+        f.write("Content of reana.yaml")
+
+    fetcher = get_fetcher(f"file://{spec_path}", output_dir)
+    assert isinstance(fetcher, WorkflowFetcherYaml)
+    fetcher.fetch()
+    expected_path = os.path.join(output_dir, spec_name)
+    assert expected_path == fetcher.workflow_spec_path()
+    assert os.path.isfile(expected_path)
+
+
+@pytest.mark.parametrize("with_top_level_dir", [True, False])
+def test_fetcher_zip(with_top_level_dir, tmp_path):
+    """Test fetching the workflow specification from a zip archive."""
+
+    def create_zip_file(archive_path, files):
+        """Create a zip archive with the given files."""
+        with zipfile.ZipFile(archive_path, "w") as zip_file:
+            for file, content in files:
+                zip_file.writestr(file, content)
+
+    input_dir = os.path.join(tmp_path, "input")
+    os.makedirs(input_dir)
+    output_dir = os.path.join(tmp_path, "output")
+    os.makedirs(output_dir)
+
+    archive_path = os.path.join(input_dir, "archive.zip")
+    if with_top_level_dir:
+        files = [("dir/reana.yaml", "Content of reana.yaml")]
+    else:
+        files = [("reana.yaml", "Content of reana.yaml")]
+    create_zip_file(archive_path, files)
+
+    fetcher = get_fetcher(f"file://{archive_path}", output_dir)
+    assert isinstance(fetcher, WorkflowFetcherZip)
+    fetcher.fetch()
+    expected_path = os.path.join(output_dir, "reana.yaml")
+    assert expected_path == fetcher.workflow_spec_path()
+    assert os.path.isfile(expected_path)
+
+
+@pytest.mark.parametrize(
+    "url, username, repository, git_ref, spec",
+    [
+        ("https://github.com/user/repo", "user", "repo", None, None),
+        ("https://github.com/user/repo/tree/branch", "user", "repo", "branch", None),
+        (
+            "https://github.com/user/repo/blob/branch/path/to/reana.yaml",
+            "user",
+            "repo",
+            "branch",
+            "path/to/reana.yaml",
+        ),
+        (
+            "https://github.com/user/repo/blob/branch/path/to/reana.yml",
+            "user",
+            "repo",
+            "branch",
+            "path/to/reana.yml",
+        ),
+    ],
+)
+def test_github_fetcher(url, username, repository, git_ref, spec, tmp_path):
+    """Test creating a valid fetcher for GitHub URLs."""
+    mock_git_fetcher = Mock()
+    with patch("reana_server.fetcher.WorkflowFetcherGit", mock_git_fetcher):
+        _get_github_fetcher(url, tmp_path)
+        mock_git_fetcher.assert_called_once_with(
+            f"https://github.com/{username}/{repository}.git",
+            tmp_path,
+            git_ref,
+            spec=spec,
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/user/repo/invalid",
+        "https://github.com/user/repo/tree/branch/path/to/dir",
+        "https://github.com/user/repo/blob/branch/path/to/file.txt",
+        "https://github.com/user",
+        "https://github.com/",
+    ],
+)
+@pytest.mark.xfail(raises=ValueError, strict=True)
+def test_invalid_github_fetcher(url, tmp_path):
+    """Test handling of invalid GitHub URLs."""
+    _get_github_fetcher(url, tmp_path)


### PR DESCRIPTION
Closes #441

How to test:
1. Save the following python snippet to a file in the repository's root directory (e.g. `pr445.py`)
```python
import os
import random
import string

from reana_server.fetcher import get_fetcher
from tests.test_fetcher import GIT_URL, GITHUB_REPO_URL, YAML_URL, ZENODO_URL


def random_string():
    return "".join(random.choices(string.ascii_lowercase, k=5))


def fetch(url, tmp_dir=None):
    if not tmp_dir:
        tmp_dir = os.path.join("/tmp", "test-fetcher-{}".format(random_string()))
        os.makedirs(tmp_dir)
    print(f"Fetching to directory: {tmp_dir}")
    fetcher = get_fetcher(url, tmp_dir)
    fetcher.fetch()
    spec = fetcher.workflow_spec_path()
    print(f"REANA workflow specification file: {spec}")

```
2. Execute the saved file in interactive mode: `python -i pr445.py`
3. Call the `fetch` function passing an URL and an output directory. If the output directory is not provided, a random one in `/tmp` will be used

Expected results: The workflow specification is fetched correctly. When fetching from a Git repository or a zip archive, also the other files will be present in the output directory.
```pycon
>>> fetch(GIT_URL)
Fetching to directory: /tmp/test-fetcher-fyjka
REANA workflow specification file: /tmp/test-fetcher-fyjka/reana.yaml
>>> fetch(GITHUB_REPO_URL)
Fetching to directory: /tmp/test-fetcher-ohhav
REANA workflow specification file: /tmp/test-fetcher-ohhav/reana.yaml
>>> fetch(YAML_URL)
Fetching to directory: /tmp/test-fetcher-satvh
REANA workflow specification file: /tmp/test-fetcher-satvh/reana.yaml
>>> fetch(ZENODO_URL)
Fetching to directory: /tmp/test-fetcher-lsxdp
REANA workflow specification file: /tmp/test-fetcher-lsxdp/reana.yaml
```