### PR TITLE
validation: refactor validation imports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 0.9.0 (UNRELEASED)
 
 - Adds new ``/api/launch`` endpoint that allows running workflows from remote sources.
 - Adds the possibility to fetch the workflow specification from a remote URL.
+- Adds REANA specification validation utilities.
 
 Version 0.8.4 (2022-02-23)
 --------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,6 +10,7 @@ FROM python:3.8-slim
 RUN apt-get update && \
     apt-get install -y \
       gcc \
+      git \
       vim-tiny \
       libffi-dev \
       procps
@@ -28,7 +29,7 @@ RUN if [ "${DEBUG}" -gt 0 ]; then pip install -e ".[debug]"; else pip install .;
 
 # Are we building with locally-checked-out shared modules?
 # hadolint ignore=SC2102
-RUN if test -e modules/reana-commons; then pip install -e modules/reana-commons[kubernetes,yadage] --upgrade; fi
+RUN if test -e modules/reana-commons; then pip install -e modules/reana-commons[kubernetes,yadage,snakemake,cwl] --upgrade; fi
 RUN if test -e modules/reana-db; then pip install -e modules/reana-db --upgrade; fi
 
 # Check if there are broken requirements

--- a/reana_server/rest/info.py
+++ b/reana_server/rest/info.py
@@ -10,13 +10,11 @@
 
 import logging
 import traceback
-from flask import Blueprint, jsonify
 
+from flask import Blueprint, jsonify
 from marshmallow import Schema, fields
-from reana_commons.config import (
-    WORKSPACE_PATHS,
-    DEFAULT_WORKSPACE_PATH,
-)
+
+from reana_commons.config import DEFAULT_WORKSPACE_PATH, WORKSPACE_PATHS
 
 from reana_server.config import SUPPORTED_COMPUTE_BACKENDS
 from reana_server.decorators import signin_required

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -17,8 +17,8 @@ from flask import Blueprint, Response
 from flask import jsonify, request, stream_with_context
 from reana_commons.config import REANA_WORKFLOW_ENGINES
 from reana_commons.errors import REANAQuotaExceededError, REANAValidationError
-from reana_commons.operational_options import validate_operational_options
-from reana_commons.validation import validate_workspace, validate_workflow_name
+from reana_commons.validation.operational_options import validate_operational_options
+from reana_commons.validation.utils import validate_workflow_name
 from reana_db.models import (
     InteractiveSessionType,
     ResourceType,
@@ -33,6 +33,7 @@ from werkzeug.datastructures import Headers
 
 from reana_server.api_client import current_rwc_api_client
 from reana_server.decorators import check_quota, signin_required
+from reana_server.validation import validate_workspace_path
 from reana_server.utils import (
     RequestStreamWithLen,
     _load_yadage_spec,
@@ -406,9 +407,8 @@ def create_workflow(user):  # noqa
         workflow_dict["operational_options"] = validate_operational_options(
             workflow_engine, reana_spec_file.get("inputs", {}).get("options", {})
         )
-        workspace_root_path = validate_workspace(
-            reana_spec_file.get("workspace", {}).get("root_path")
-        )
+        workspace_root_path = reana_spec_file.get("workspace", {}).get("root_path")
+        validate_workspace_path(reana_spec_file)
         if git_data:
             workflow_dict["git_data"] = git_data
         response, http_response = current_rwc_api_client.api.create_workflow(

--- a/reana_server/validation.py
+++ b/reana_server/validation.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA Server validation utilities."""
+
+from typing import Dict
+
+from reana_commons.validation.parameters import build_parameters_validator
+from reana_commons.validation.compute_backends import build_compute_backends_validator
+from reana_commons.validation.utils import validate_workspace
+from reana_commons.config import WORKSPACE_PATHS
+
+from reana_server.config import SUPPORTED_COMPUTE_BACKENDS
+
+
+def validate_parameters(reana_yaml: Dict) -> None:
+    """Validate the presence of input parameters in workflow step commands and viceversa.
+
+    :param reana_yaml: REANA YAML specification.
+
+    :raises REANAValidationError: Given there are parameter validation errors in REANA spec file.
+    """
+    validator = build_parameters_validator(reana_yaml)
+    validator.validate_parameters()
+
+
+def validate_workspace_path(reana_yaml: Dict) -> None:
+    """Validate workspace in REANA specification file.
+
+    :param reana_yaml: REANA YAML specification.
+
+    :raises REANAValidationError: Given workspace in REANA spec file does not validate against
+        allowed workspaces.
+    """
+    root_path = reana_yaml.get("workspace", {}).get("root_path")
+    if root_path:
+        available_paths = list(WORKSPACE_PATHS.values())
+        validate_workspace(root_path, available_paths)
+
+
+def validate_compute_backends(reana_yaml: Dict) -> None:
+    """Validate compute backends in REANA specification file according to workflow type.
+
+    :param reana_yaml: dictionary which represents REANA specification file.
+
+    :raises REANAValidationError: Given compute backend specified in REANA spec file does not validate against
+        supported compute backends.
+    """
+    validator = build_compute_backends_validator(reana_yaml, SUPPORTED_COMPUTE_BACKENDS)
+    validator.validate()

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ install_requires = [
     "gitpython>=3.1",
     "marshmallow>2.13.0,<=2.20.1",
     "pyOpenSSL==17.5.0",
-    "reana-commons[kubernetes,yadage]>=0.9.0a2,<0.10.0",
+    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.9.0a3,<0.10.0",
     "reana-db>=0.9.0a2,<0.10.0",
     "requests==2.25.0",
     "rfc3987==1.3.7",


### PR DESCRIPTION
closes https://github.com/reanahub/reana-server/issues/442

To test:
- Install `ipython`, local `reana-commons` and `reana-server` into a new virtualenv
- Navigate to `reana-demo-root6-roofit` and launch `ipython`:
```python
import logging

from reana_commons.specification import load_reana_spec
from reana_commons.validation.utils import validate_reana_yaml
from reana_commons.errors import REANAValidationError
from reana_server.validation import (
    validate_parameters,
    validate_compute_backends,
    validate_workspace_path,
)

reana_yaml = load_reana_spec("./reana.yaml")

try:
    validate_reana_yaml(reana_yaml)
    validate_parameters(reana_yaml)
    validate_compute_backends(reana_yaml)
    validate_workspace_path(reana_yaml)
except REANAValidationError as e:
    logging.error(e)

```

TODO:
- [x] some small PR needs to be done to `reana` repo to fix benchmark script dependencies
- [ ] PR to `reana-workflow-engine-cwl` needs to be created to install `cwltool` from `reana-commons` once it's released