### PR TITLE
fetcher: add limitations to the download of files

### DIFF
--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -238,3 +238,12 @@ WORKFLOW_SPEC_EXTENSIONS = [".yaml", ".yml"]
 
 REGEX_CHARS_TO_REPLACE = re.compile("[^a-zA-Z0-9_]+")
 """Regex matching groups of characters that need to be replaced in workflow names."""
+
+FETCHER_MAXIMUM_FILE_SIZE = 1024 ** 3  # 1 GB
+"""Maximum file size allowed when fetching workflow specifications."""
+
+FETCHER_ALLOWED_SCHEMES = ["https", "http"]
+"""Schemes allowed when fetching workflow specifications."""
+
+FETCHER_REQUEST_TIMEOUT = 60
+"""Timeout used when fetching workflow specifications."""


### PR DESCRIPTION
This PR adds some limitations and checks to the download of files:
- Connection and read timeout
- Limit to the size of the file to be downloaded
- Allow only `http` and `https`

How to test:
Launch this workflow: `https://zenodo.org/record/5752285/files/circular-health-data-processing-master.zip`

In each of these cases, the workflow is not launched and an error is reported:
- Set `FETCHER_MAXIMUM_FILE_SIZE` to a small value (e.g. 1024)
- Remove `https` from `FETCHER_ALLOWED_SCHEMES`
- Set `FETCHER_REQUEST_TIMEOUT` to a small value (e.g. 0.1)