### PR TITLE
rest: add `spec` parameter to launch endpoint

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -324,6 +324,10 @@
                   "description": "Workflow parameters.",
                   "type": "string"
                 },
+                "spec": {
+                  "description": "Path to the workflow specification file to be used.",
+                  "type": "string"
+                },
                 "url": {
                   "description": "Remote origin URL where the REANA specification file is hosted.",
                   "type": "string"

--- a/reana_server/rest/launch.py
+++ b/reana_server/rest/launch.py
@@ -67,10 +67,11 @@ def handle_validation_error(error: werkzeug.exceptions.UnprocessableEntity):
         "url": fields.Url(schemes=FETCHER_ALLOWED_SCHEMES, required=True),
         "name": fields.Str(),
         "parameters": fields.Str(),
+        "spec": fields.Str(),
     }
 )
 @signin_required()
-def launch(user, url, name="", parameters="{}"):
+def launch(user, url, name="", parameters="{}", spec=None):
     r"""Endpoint to launch a REANA workflow from URL.
 
     ---
@@ -101,6 +102,9 @@ def launch(user, url, name="", parameters="{}"):
                 type: string
               parameters:
                 description: Workflow parameters.
+                type: string
+              spec:
+                description: Path to the workflow specification file to be used.
                 type: string
       responses:
         200:
@@ -144,7 +148,7 @@ def launch(user, url, name="", parameters="{}"):
         tmpdir = get_fetched_workflows_dir(user_id)
 
         # Fetch and load workflow spec
-        fetcher = get_fetcher(url, tmpdir)
+        fetcher = get_fetcher(url, tmpdir, spec)
         fetcher.fetch()
         spec_path = fetcher.workflow_spec_path()
         reana_yaml = load_reana_spec(spec_path)


### PR DESCRIPTION
Closes #452

How to test:
Launch some of the example workflows, choosing different workflow specifications, for example:
```
/launch?url=https://zenodo.org/record/5752285/files/circular-health-data-processing-master.zip
/launch?spec=reana.yaml&url=https://zenodo.org/record/5752285/files/circular-health-data-processing-master.zip
/launch?url=https://github.com/reanahub/reana-demo-root6-roofit
/launch?spec=reana.yaml&url=https://github.com/reanahub/reana-demo-root6-roofit
/launch?spec=reana-cwl.yaml&url=https://github.com/reanahub/reana-demo-root6-roofit
```
Note that the last example will fail due to #456 
