### PR TITLE
rest: improve error messages in `/launch` endpoint

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,6 +12,7 @@ The list of contributors in alphabetical order:
 - `Harri Hirvonsalo <https://orcid.org/0000-0002-5503-510X>`_
 - `Jan Okraska <https://orcid.org/0000-0002-1416-3244>`_
 - `Leticia Wanderley <https://orcid.org/0000-0003-4649-6630>`_
+- `Marco Donadoni <https://orcid.org/0000-0003-2922-5505>`_
 - `Marco Vidal <https://orcid.org/0000-0002-9363-4971>`_
 - `Rokas Maciulaitis <https://orcid.org/0000-0003-1064-6967>`_
 - `Sinclert Perez <https://www.linkedin.com/in/sinclert>`_

--- a/reana_server/rest/launch.py
+++ b/reana_server/rest/launch.py
@@ -191,9 +191,12 @@ def launch(user, url, name="", parameters="{}", specification=None):
     except (REANAFetcherError, REANAValidationError, ValueError, ValidationError) as e:
         logging.error(traceback.format_exc())
         return jsonify({"message": str(e)}), 400
-    except Exception as e:
+    except Exception:
         logging.error(traceback.format_exc())
-        return jsonify({"message": str(e)}), 500
+        return (
+            jsonify({"message": "Something went wrong while fetching the workflow."}),
+            500,
+        )
     finally:
         remove_fetched_workflows_dir(tmpdir)
 


### PR DESCRIPTION
Closes #472

How to test:
Launch the following workflows
```
https://github.com/reanahub/reana-demo-root6-roofit/tree/invalid
https://github.com/reanahub/invalid
```
Expected result:
The workflows are not launched and the error messages shown to the user are short and user-friendly