### PR TITLE
auth: migrate to the new SSO

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Version 0.9.0 (UNRELEASED)
 - Changes API rate limiter error messages to be more verbose.
 - Changes workflow scheduler to allow defining the checks needed to assess whether the cluster can start new workflows.
 - Changes the Invenio dependencies to the latest versions.
+- Changes OAuth configuration to enable the new CERN SSO.
 
 Version 0.8.4 (2022-02-23)
 --------------------------

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
-    "version": "0.9.0a3"
+    "version": "0.9.0a4"
   },
   "parameters": {},
   "paths": {

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -16,7 +16,7 @@ import re
 from distutils.util import strtobool
 from limits.util import parse
 from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
-from invenio_oauthclient.contrib import cern
+from invenio_oauthclient.contrib import cern_openid
 from reana_commons.config import REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES
 from reana_commons.job_utils import kubernetes_memory_to_bytes
 
@@ -211,20 +211,30 @@ RATELIMIT_PER_ENDPOINT = {
 # =========================================
 BREADCRUMBS_ROOT = "breadcrumbs"
 
-CERN_REMOTE_APP = copy.deepcopy(cern.REMOTE_APP)
+# OAuth configuration
+# ===================
+OAUTH_REDIRECT_URL = "/signin_callback"
 
-OAUTHCLIENT_REMOTE_APPS = dict(
-    cern=CERN_REMOTE_APP,
+OAUTH_REMOTE_REST_APP = copy.deepcopy(cern_openid.REMOTE_REST_APP)
+
+OAUTH_REMOTE_REST_APP.update(
+    {
+        "authorized_redirect_url": OAUTH_REDIRECT_URL,
+        "error_redirect_url": OAUTH_REDIRECT_URL,
+    }
 )
 
-REANA_CERN_ALLOW_SOCIAL_LOGIN = os.getenv("REANA_CERN_ALLOW_SOCIAL_LOGIN", False)
+OAUTHCLIENT_REST_DEFAULT_ERROR_REDIRECT_URL = OAUTH_REDIRECT_URL
 
-if REANA_CERN_ALLOW_SOCIAL_LOGIN:
-    OAUTHCLIENT_CERN_ALLOWED_IDENTITY_CLASSES = (
-        cern.OAUTHCLIENT_CERN_ALLOWED_IDENTITY_CLASSES + ["Unverified External"]
-    )
+OAUTHCLIENT_REMOTE_APPS = dict(
+    cern_openid=OAUTH_REMOTE_REST_APP,
+)
 
-CERN_APP_CREDENTIALS = dict(
+OAUTHCLIENT_REST_REMOTE_APPS = dict(
+    cern_openid=OAUTH_REMOTE_REST_APP,
+)
+
+CERN_APP_OPENID_CREDENTIALS = dict(
     consumer_key=REANA_SSO_CERN_CONSUMER_KEY,
     consumer_secret=REANA_SSO_CERN_CONSUMER_SECRET,
 )

--- a/reana_server/version.py
+++ b/reana_server/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.0a3"
+__version__ = "0.9.0a4"


### PR DESCRIPTION
Changes Invenio `oauthclient contrib` to `cern_openid` which enables the new SSO usage.

In order to test:
- Some instructions can be found in [DR docs](https://digital-repositories.web.cern.ch/digital-repositories/common-recipes/cern-oauth/)
- Test application was created in QA environment: https://application-portal-qa.web.cern.ch/manage/08da188d-ef3c-4d9f-8b9d-38ed6f954d58 . Please copy the secrets from there to use it below
- In order to point to QA server please update `OAUTH_REMOTE_REST_APP["params"]` to: 
```
{
    "base_url": "https://keycloak-qa.cern.ch/auth/realms/cern",
    "access_token_url": "https://keycloak-qa.cern.ch/auth/realms/cern/protocol/openid-connect/token",
    "authorize_url": "https://keycloak-qa.cern.ch/auth/realms/cern/protocol/openid-connect/auth",
}
```
- Update `values.yaml` file accordingly:

```diff
secrets:
  cern:
-  sso: {}
+  sso:
      CERN_CONSUMER_KEY: reana-test
      CERN_CONSUMER_SECRET: copy_the_key_here 
```
```diff
reana_ui:
+  cern_sso: true
```
```diff
- REANA_USER_EMAIL_CONFIRMATION: true
+ REANA_USER_EMAIL_CONFIRMATION: false
```

closes https://github.com/reanahub/reana-server/issues/480