### PR TITLE
fetcher: add support for GitLab URLs

### DIFF
--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -274,3 +274,6 @@ FETCHER_ALLOWED_SCHEMES = ["https", "http"]
 
 FETCHER_REQUEST_TIMEOUT = 60
 """Timeout used when fetching workflow specifications."""
+
+FETCHER_ALLOWED_GITLAB_HOSTNAMES = ["gitlab.com", "gitlab.cern.ch"]
+"""GitLab instances allowed when fetching workflow specifications."""


### PR DESCRIPTION
Closes #483

How to test:
- Create a new public repository and push a REANA demo to [gitlab.cern.ch](https://gitlab.cern.ch)
- Launch some workflows using the following URLs:
  - URL to the repository
  - URL to a specific tag/branch/commit
  - URL to the repository's zip archive

Expected result: The workflows are launched and executed correctly