### PR TITLE
admin: add command to delete messages from queue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.0 (UNRELEASED)
 --------------------------
 
+- Adds ``queue-consume`` command that can be used by REANA administrators to remove specific messages from the queue.
 - Adds configuration environment variable to set an API rate limit for slow endpoints (``REANA_RATELIMIT_SLOW``).
 - Adds new ``/api/launch`` endpoint that allows running workflows from remote sources.
 - Adds the possibility to fetch the workflow specification from a remote URL.

--- a/reana_server/reana_admin/__init__.py
+++ b/reana_server/reana_admin/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA-Server admin tools."""
+
+from .cli import reana_admin

--- a/reana_server/reana_admin/consumer.py
+++ b/reana_server/reana_admin/consumer.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA Admin MessageConsumer."""
+
+import json
+from enum import Enum, auto
+from typing import List, Optional
+
+import click
+
+from reana_commons.consumer import BaseConsumer
+
+
+class UserDecision(Enum):
+    """Possible user decisions in interactive consumer mode."""
+
+    DELETE_MESSAGE = auto()
+    KEEP_MESSAGE = auto()
+    STOP_CONSUMER = auto()
+
+
+class MessageConsumer(BaseConsumer):
+    """Consumer responsible for cleaning queues."""
+
+    def __init__(
+        self,
+        queue_name: str,
+        key: Optional[str],
+        values_to_delete: List[str],
+        is_interactive: bool = False,
+        **kwargs,
+    ):
+        """Initialise the class."""
+        super(MessageConsumer, self).__init__(queue=queue_name, **kwargs)
+        self.key = key
+        self.values_to_delete = values_to_delete
+        self.is_interactive = is_interactive
+
+        click.secho(
+            "MessageConsumer initialized with the following settings: \n"
+            f"  - queue_name: {queue_name}\n"
+            f"  - message_key: {self.key}\n"
+            f"  - values_to_delete: {self.values_to_delete}\n"
+            f"  - interactive: {self.is_interactive}"
+        )
+
+    def get_consumers(self, Consumer, channel):
+        """Implement providing kombu.Consumers with queues/callbacks."""
+        return [
+            Consumer(
+                queues=self.queue,
+                callbacks=[self.on_message],
+                accept=[self.message_default_format],
+                prefetch_count=1,
+            )
+        ]
+
+    def on_consume_ready(self, connection, channel, consumers, **kwargs):  # noqa: D102
+        click.secho(f"Starting consuming the {self.queue.name} queue", fg="green")
+        click.secho("If you want to stop the consumer, use Ctrl+C.\n", fg="yellow")
+
+    def on_consume_end(self, connection, channel):  # noqa: D102
+        click.secho(f"Finished consuming the {self.queue.name} queue", fg="green")
+
+    @staticmethod
+    def ask_user() -> UserDecision:
+        """Prompt user to decide what to do next."""
+        while True:
+            answer = input(
+                "Delete the above message? (Y - Yes, N - No, S - Stop consuming): "
+            )
+            if answer.lower() in ["yes", "y"]:
+                return UserDecision.DELETE_MESSAGE
+            elif answer.lower() in ["no", "n"]:
+                return UserDecision.KEEP_MESSAGE
+            elif answer.lower() in ["stop", "s"]:
+                return UserDecision.STOP_CONSUMER
+            else:
+                click.secho("Please, provide correct input.", fg="red")
+
+    def on_message(self, body, message):
+        """Remove selected messages."""
+        msg_body = json.loads(body)
+        click.secho(
+            f"New message received: \n{json.dumps(msg_body, sort_keys=True, indent=4)}"
+        )
+
+        decision = UserDecision.KEEP_MESSAGE
+        should_filter = self.key is not None
+
+        if should_filter:
+            value = msg_body.get(self.key, "")
+            if value in self.values_to_delete:
+                click.secho(
+                    f"Message with searched value {value} for {self.key} key is found."
+                )
+                decision = UserDecision.DELETE_MESSAGE
+                if self.is_interactive:
+                    decision = self.ask_user()
+        elif self.is_interactive:
+            decision = self.ask_user()
+
+        if decision == UserDecision.DELETE_MESSAGE:
+            message.ack()
+            click.secho("Message is ACK and removed from the queue.")
+        elif decision == UserDecision.KEEP_MESSAGE:
+            message.reject(requeue=True)
+            click.secho("Message is ignored and re-queued.")
+        elif decision == UserDecision.STOP_CONSUMER:
+            self.should_stop = True


### PR DESCRIPTION
closes reanahub/reana-message-broker#45

How to test?

0. Unit tests should cover the situation when you specify some `values-to-delete` (using the -v option). So, you should test the interactive way.

1. Bash into r-server `kubectl exec -it deployment/reana-server -- bash`. Run `flask reana-admin consume-queue -q workflow-submission -i`. This command will start listening to messages from the `workflow-submission` queue.

2. Submit some workflows. You will see our consumer picks up some messages (because the scheduler is working at the same time). Use