### PR TITLE
admin: add command to detect out-of-sync workflows

### DIFF
--- a/reana_server/reana_admin/check_workflows.py
+++ b/reana_server/reana_admin/check_workflows.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA Server administrative tool - check workflows command."""
+
+
+import datetime
+import logging
+import sys
+from typing import Optional, List, Dict, Tuple
+from functools import partial
+
+import click
+from reana_commons.k8s.api_client import current_k8s_corev1_api_client
+from reana_commons.config import REANA_RUNTIME_KUBERNETES_NAMESPACE
+from reana_db.database import Session
+from reana_db.models import (
+    Workflow,
+    RunStatus,
+)
+from kubernetes.client import V1Pod
+from kubernetes.client.rest import ApiException
+from sqlalchemy.orm import Query
+
+from reana_server.reana_admin.consumer import CollectingConsumer
+
+
+class WorkflowCheckFailed(Exception):
+    """Error when workflow doesn't pass some check."""
+
+
+WorkflowCheckResult = Tuple[Workflow, List[WorkflowCheckFailed]]
+
+
+def _display(validation_results: List[WorkflowCheckResult]):
+    for workflow_result in validation_results:
+        workflow = workflow_result[0]
+        click.secho(
+            f"- id: {str(workflow.id_)}, name: {workflow.name}, user: {workflow.owner.email}, status: {workflow.status}"
+        )
+
+        failed_checks = workflow_result[1]
+        for check_error in failed_checks:
+            click.secho(f"   - ERROR: {check_error}\n", fg="red")
+
+
+def _get_all_pods() -> List[V1Pod]:
+    try:
+        response = current_k8s_corev1_api_client.list_namespaced_pod(
+            namespace=REANA_RUNTIME_KUBERNETES_NAMESPACE
+        )
+        return response.items
+    except ApiException as error:
+        click.secho(
+            "Couldn't fetch list of pods due to an error.",
+            fg="red",
+        )
+        logging.exception(error)
+        return []
+
+
+def _collect_messages_from_scheduler_queue(filtered_workflows: Query) -> Dict:
+    scheduler_messages_collector = CollectingConsumer(
+        queue_name="workflow-submission",
+        key="workflow_id_or_name",
+        values_to_collect=[str(workflow.id_) for workflow in filtered_workflows],
+    )
+    scheduler_messages_collector.run()
+    return scheduler_messages_collector.messages
+
+
+def _message_is_in_scheduler_queue(workflow, pods, scheduler_messages):
+    if workflow.id_ not in scheduler_messages:
+        raise WorkflowCheckFailed("Message is not found in workflow-submission queue.")
+
+
+def _pods_dont_exist(workflow, pods, scheduler_messages):
+    if len(pods) > 0:
+        raise WorkflowCheckFailed("Some pods still exist for the workflow.")
+
+
+def _pods_exist(workflow, pods, scheduler_messages):
+    if len(pods) == 0:
+        raise WorkflowCheckFailed("No pods found for the workflow.")
+
+
+def _all_batch_pods_have_phase(workflow, pods, scheduler_messages, phase):
+    if any(
+        [pod.status.phase != phase for pod in pods if "batch-pod" in pod.metadata.name]
+    ):
+        raise WorkflowCheckFailed(f"Some pods are not in {phase}.")
+
+
+def _no_batch_pods_are_in_notready_state(workflow, pods, scheduler_messages):
+    for pod in pods:
+        if "batch-pod" in pod.metadata.name:
+            for container in pod.status.container_statuses:
+                if container.state.terminated:
+                    raise WorkflowCheckFailed(
+                        f"{pod.metadata.name} pod is in NotReady state."
+                    )
+
+
+validation_map = {
+    RunStatus.queued: [
+        _message_is_in_scheduler_queue,
+    ],
+    RunStatus.pending: [
+        _pods_exist,
+        partial(_all_batch_pods_have_phase, phase="Pending"),
+    ],
+    RunStatus.running: [
+        _pods_exist,
+        partial(_all_batch_pods_have_phase, phase="Running"),
+        _no_batch_pods_are_in_notready_state,
+    ],
+    RunStatus.finished: [
+        _pods_dont_exist,
+    ],
+    RunStatus.failed: [
+        _pods_dont_exist,
+    ],
+}
+
+
+def check_workflows(
+    date_start: datetime.datetime, date_end: Optional[datetime.datetime]
+) -> None:
+    """Check if selected workflows are in sync with database according to predefined rules."""
+    # filter workflows that need to be checked
+    statuses_to_check = validation_map.keys()
+    query_filter = [
+        Workflow.status.in_(statuses_to_check),
+        Workflow.created >= date_start,
+    ]
+
+    if date_end:
+        query_filter.append(Workflow.created < date_end)
+
+    filtered_workflows = Session.query(Workflow).filter(*query_filter)
+
+    time_range_message = f"{date_start} - {date_end if date_end else 'now'}"
+
+    if filtered_workflows.count() == 0:
+        click.secho(
+            f"No workflows found matching time range {time_range_message}.\nPlease, adjust your filter conditions.",
+            fg="red",
+        )
+        sys.exit(1)
+    click.secho(
+        f"Found {filtered_workflows.count()} workflow(s) matching time range {time_range_message}.\n",
+    )
+
+    try:
+        click.secho("Collecting MQ messages...")
+        scheduler_messages = _collect_messages_from_scheduler_queue(filtered_workflows)
+    except Exception as error:
+        click.secho(
+            "Error is raised when collecting scheduler messages.",
+            fg="red",
+        )
+        logging.exception(error)
+        sys.exit(1)
+
+    click.secho("Collecting information about Pods...")
+    pods = _get_all_pods()
+    if not pods:
+        click.secho(
+            "List of active pods is empty. It is required to validate workflows. Exiting..",
+            fg="red",
+        )
+        sys.exit(1)
+
+    in_sync_workflows: List[WorkflowCheckResult] = []
+    out_of_sync_workflows: List[WorkflowCheckResult] = []
+    for workflow in filtered_workflows:
+        filtered_pods = [pod for pod in pods if str(workflow.id_) in pod.metadata.name]
+
+        checks = validation_map[workflow.status]
+        failed_checks: List[WorkflowCheckFailed] = []
+
+        workflow_is_in_sync = True
+        for check in checks:
+            try:
+                check(workflow, filtered_pods, scheduler_messages)
+            except WorkflowCheckFailed as error:
+                failed_checks.append(error)
+                workflow_is_in_sync = False
+
+        if workflow_is_in_sync:
+            in_sync_workflows.append((workflow, failed_checks))
+        else:
+            out_of_sync_workflows.append((workflow, failed_checks))
+
+    if in_sync_workflows:
+        click.secho(
+            f"\nIn-sync workflows ({len(in_sync_workflows)} out of {filtered_workflows.count()})\n",
+            fg="green",
+        )
+        _display(in_sync_workflows)
+
+    if out_of_sync_workflows:
+        click.secho(
+            f"\nOut-of-sync workflows ({len(out_of_sync_workflows)} out of {filtered_workflows.count()})\n",
+            fg="red",
+        )
+        _display(out_of_sync_workflows)
+
+    if out_of_sync_workflows:
+        click.secho("\nFAILED")
+        sys.exit(1)
+    else:
+        click.secho("\nOK")

--- a/reana_server/reana_admin/cli.py
+++ b/reana_server/reana_admin/cli.py
@@ -716,3 +716,25 @@ def queue_consume(
         logging.exception(error)
     else:
         consumer.run()
+
+
+@reana_admin.command("check-workflows")
+@click.option(
+    "--date-start",
+    type=click.DateTime(formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S"]),
+    default=datetime.datetime.now() - datetime.timedelta(hours=24),
+    help="Default value is 24 hours ago.",
+)
+@click.option(
+    "--date-end",
+    type=click.DateTime(formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S"]),
+    default=None,
+    help="Default value is now.",
+)
+def check_workflows(
+    date_start: Optional[datetime.datetime], date_end: Optional[datetime.datetime]
+) -> None:
+    """Check consistency of selected workflow run statuses between database, message queue and Kubernetes."""
+    from .check_workflows import check_workflows
+
+    check_workflows(date_start, date_end)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require = {
         "Flask-DebugToolbar",
     ],
     "docs": [
-        "Sphinx>=1.5.1",
+        "Sphinx>=1.5.1,<5.0.0",
         "sphinx-rtd-theme>=0.1.9",
         "sphinxcontrib-httpdomain>=1.5.0",
         "sphinxcontrib-openapi>=0.3.0,<0.4.0",


### PR DESCRIPTION
closes #491

## How to test

You will need to reproduce a few scenarios where workflows end up in sync situations. There are multiple ways to do it and probably some ways we didn't discover yet. Below you can find *one* way to do it for each state.

### 1. Queued

The message is not published to the `workflow-submission` queue. To do this go to `values-dev.yaml`. Enable "balanced" strategy, and set `kubernetes_jobs_max_user_memory_limit`:

```yaml
components:
    reana_server:
      image: reanahub/reana-server
      environment:
        ...
        REANA_WORKFLOW_SCHEDULING_POLICY: "balanced"
...
kubernetes_jobs_max_user_memory_limit: "4Gi"
```

Go to `helloworld` workflow, set `kubernetes_memory_limit`higher than allowed - `8Gi`. Run the workflow using `reana-client run`. Submission will fail right away but the workflow will end up in the queued state. **Revert your change in `reana.yaml`**

This is an actual bug that needs a separate issue :)

### 2. Pending

This is harder to reproduce without breaking code explicitly. Go to `r-w-controller/rest/utils.py` to `start_workflow` function. Replace:

```python
  try:
      kwrm.start_batch_workflow_run(
          overwrite_input_params=parameters.get("input_parameters"),
          overwrite_operational_options=parameters.get("operational_options"),
      )
      _start_workflow_db(workflow, parameters)
  except SQLAlchemyError as e:
  ...
```

with:

```python
 try:
      _start_workflow_db(workflow, parameters)
      raise ApiException("hello")
      kwrm.start_batch_workflow_run(
          overwrite_input_params=parameters.get("input_parameters"),
          overwrite_operational_options=parameters.get("operational_options"),
      )
  except SQLAlchemyError as e:
  ...
```

Run `helloworld`. It will stay pending forever.
**Revert code changes you made.**

### 3. Running

Go to `r-w-controller/consumer.py` and add this line:

```python
def _update_workflow_status(workflow, status, logs):
    """Update workflow status in DB."""
    if workflow.status != status:
        if status == RunStatus.finished:
            raise Exception("Something abd with db")
        ...
```

Rebuild image, load to kind, delete current pod and start a workflow. It will be stuck in running state.

### 4. Finished/Failed

You can make any workflow fail or finish while having `REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES: failed` set up in `values-dev.yaml`. Similar to finished.

### 5. Run one workflow correctly

Run a plain `helloworld` demo with no memory requirements. Let it finish.

### 6. Run `reana-admin check-workflows` command.

- ssh into scheduler container using `kubectl exec -it deployment/reana-server -c scheduler -- bash`

- run `flask reana-admin check-workflows` command. You will get a report. The first 4 workflows should be out of sync, the last one should be fine.