### PR TITLE
rest: more informative output when users exceed quotas

### DIFF
--- a/reana_server/status.py
+++ b/reana_server/status.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021 CERN.
+# Copyright (C) 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -29,6 +29,7 @@ from reana_commons.k8s.api_client import (
     current_k8s_corev1_api_client,
     current_k8s_custom_objects_api_client,
 )
+from reana_commons.utils import get_usage_percentage
 from reana_db.database import Session
 from reana_db.models import (
     InteractiveSession,
@@ -44,7 +45,6 @@ from reana_db.models import (
 from sqlalchemy import desc
 
 from reana_server.config import REANA_KUBERNETES_JOBS_MEMORY_LIMIT_IN_BYTES
-from reana_server.utils import get_usage_percentage
 
 
 class REANAStatus:

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -214,13 +214,6 @@ def get_user_from_token(access_token):
     return user
 
 
-def get_usage_percentage(usage, limit):
-    """Usage percentage."""
-    if limit == 0:
-        return ""
-    return "{:.1%}".format(usage / limit)
-
-
 def publish_workflow_submission(workflow, user_id, parameters):
     """Publish workflow submission."""
     from reana_server.status import NodesStatus

--- a/requirements.txt
+++ b/requirements.txt
@@ -157,7 +157,7 @@ pywebpack==1.2.0          # via flask-webpackext
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas
 ratelimiter==1.2.0.post0  # via snakemake
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons[cwl,kubernetes,snakemake,yadage]==0.9.0a8	# via reana-db, reana-server (setup.py)
+reana-commons[cwl,kubernetes,snakemake,yadage]==0.9.0a9	# via reana-db, reana-server (setup.py)
 reana-db==0.9.0a6	# via reana-server (setup.py)
 redis==4.2.2              # via invenio-accounts, invenio-celery
 requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient, kubernetes

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_requires = [
     "gitpython>=3.1",
     "marshmallow>2.13.0,<=2.20.1",
     "pyOpenSSL==17.5.0",
-    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.9.0a8,<0.10.0",
+    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.9.0a9,<0.10.0",
     "reana-db>=0.9.0a6,<0.10.0",
     "requests==2.25.0",
     "rfc3987==1.3.7",


### PR DESCRIPTION
closes https://github.com/reanahub/reana-client/issues/607

To test:
- Change [this line](https://github.com/reanahub/reana/blob/master/helm/reana/values.yaml#L145) to `termination_update_policy: "disk,cpu"`
- Redeploy the cluster
- Run some workflows
- Add some quota limits for your user:
  - `kubectl exec -i -t deployment/reana-server -- flask reana-admin quota-set -r cpu -e your.email@cern.ch -l 100000`
  - `kubectl exec -i -t deployment/reana-server -- flask reana-admin quota-set -r disk -e your.email@cern.ch -l 100000`
- Verify quota limits:
  - `kubectl exec -i -t deployment/reana-server -- flask reana-admin quota-usage --admin-access-token $REANA_ACCESS_TOKEN`
- Check if `quota-show` still works as expected: 
  - `reana-client quota-show --resource disk -h`
- Try to create a new workflow:
  - `reana-client create -w myanalysis --skip-validation`
  - Output now should display something like this:
    ```
    reana-client create -w myanalysis --skip-validation
    ==> ERROR: Cannot create workflow myanalysis:
    User quota exceeded.
    Resource: cpu, usage: 2m 31s out of 1m 40s used (151%)
    Resource: disk, usage: 380 KiB out of 97.66 KiB used (389%)
    ```
- Try other ways to start the workflow: e.g. launcher