### PR TITLE
config: fix REANA_SCHEDULER_REQUEUE_SLEEP for large numbers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Version 0.9.0 (UNRELEASED)
 - Changes workflow scheduler to allow defining the checks needed to assess whether the cluster can start new workflows.
 - Changes the Invenio dependencies to the latest versions.
 - Changes OAuth configuration to enable the new CERN SSO.
+- Fixes issue when irregular number formats are passed to ``REANA_SCHEDULER_REQUEUE_COUNT``.
 - Fixes GitLab integration error reporting in case user exceeds CPU or Disk quota usage limits.
 
 Version 0.8.4 (2022-02-23)

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -264,7 +264,7 @@ ADMIN_EMAIL = os.getenv("REANA_EMAIL_SENDER", "CHANGE_ME")
 REANA_SCHEDULER_REQUEUE_SLEEP = float(os.getenv("REANA_SCHEDULER_REQUEUE_SLEEP", "15"))
 """How many seconds to wait between consuming workflows."""
 
-REANA_SCHEDULER_REQUEUE_COUNT = int(os.getenv("REANA_SCHEDULER_REQUEUE_COUNT", "200"))
+REANA_SCHEDULER_REQUEUE_COUNT = float(os.getenv("REANA_SCHEDULER_REQUEUE_COUNT", "200"))
 """How many times to requeue workflow, in case of error or busy cluster, before failing it."""
 
 # Workflow fetcher


### PR DESCRIPTION
- replace int() with float() to allow "1e+06" liek numbers and "infinity"

closes #502