### PR TITLE
rest: update openapi specification of `download_file`

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2627,7 +2627,11 @@
           }
         ],
         "produces": [
-          "multipart/form-data"
+          "application/octet-stream",
+          "application/json",
+          "application/zip",
+          "image/*",
+          "text/html"
         ],
         "responses": {
           "200": {

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -1267,7 +1267,11 @@ def download_file(workflow_id_or_name, file_name, user):  # noqa
         inside the workspace to return its content.
       operationId: download_file
       produces:
-        - multipart/form-data
+        - application/octet-stream
+        - application/json
+        - application/zip
+        - image/*
+        - text/html
       parameters:
         - name: workflow_id_or_name
           in: path


### PR DESCRIPTION
Update the list of possible response MIME types of the `download_file` endpoint.

Closes #418