### PR TITLE
openapi: updated api schema

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -169,18 +169,26 @@
         "operationId": "delete_gitlab_webhook",
         "parameters": [
           {
-            "description": "The GitLab project id.",
-            "in": "path",
-            "name": "project_id",
-            "required": true,
-            "type": "integer"
-          },
-          {
-            "description": "The GitLab webhook id of the project.",
-            "in": "path",
-            "name": "hook_id",
-            "required": true,
-            "type": "integer"
+            "description": "Data required to delete an existing webhook from GitLab.",
+            "in": "body",
+            "name": "data",
+            "schema": {
+              "properties": {
+                "hook_id": {
+                  "description": "The GitLab webhook id of the project.",
+                  "type": "integer"
+                },
+                "project_id": {
+                  "description": "The GitLab project id.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "project_id",
+                "hook_id"
+              ],
+              "type": "object"
+            }
           }
         ],
         "produces": [
@@ -212,11 +220,21 @@
         "operationId": "create_gitlab_webhook",
         "parameters": [
           {
-            "description": "The GitLab project id.",
-            "in": "path",
-            "name": "project_id",
-            "required": true,
-            "type": "integer"
+            "description": "Data required to set a new webhook from GitLab.",
+            "in": "body",
+            "name": "data",
+            "schema": {
+              "properties": {
+                "project_id": {
+                  "description": "The GitLab project id.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "project_id"
+              ],
+              "type": "object"
+            }
           }
         ],
         "produces": [
@@ -286,10 +304,43 @@
             },
             "schema": {
               "properties": {
+                "compute_backends": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
                 "default_workspace": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
                   "type": "object"
                 },
                 "workspaces_available": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
                   "type": "object"
                 }
               },
@@ -1047,10 +1098,88 @@
                       "id": {
                         "type": "string"
                       },
+                      "launcher_url": {
+                        "type": "string",
+                        "x-nullable": true
+                      },
                       "name": {
                         "type": "string"
                       },
                       "progress": {
+                        "properties": {
+                          "current_command": {
+                            "type": "string",
+                            "x-nullable": true
+                          },
+                          "current_step_name": {
+                            "type": "string",
+                            "x-nullable": true
+                          },
+                          "failed": {
+                            "properties": {
+                              "job_ids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "total": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "finished": {
+                            "properties": {
+                              "job_ids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "total": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "run_finished_at": {
+                            "type": "string",
+                            "x-nullable": true
+                          },
+                          "run_started_at": {
+                            "type": "string",
+                            "x-nullable": true
+                          },
+                          "running": {
+                            "properties": {
+                              "job_ids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "total": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "total": {
+                            "properties": {
+                              "job_ids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "total": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
                         "type": "object"
                       },
                       "size": {

--- a/reana_server/rest/gitlab.py
+++ b/reana_server/rest/gitlab.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -248,11 +248,17 @@ def gitlab_webhook(user):  # noqa
       produces:
        - application/json
       parameters:
-      - name: project_id
-        in: path
-        description: The GitLab project id.
-        required: true
-        type: integer
+        - name: data
+          in: body
+          description: Data required to set a new webhook from GitLab.
+          schema:
+            required:
+              - project_id
+            type: object
+            properties:
+              project_id:
+                description: The GitLab project id.
+                type: string
       responses:
         201:
           description: >-
@@ -276,16 +282,21 @@ def gitlab_webhook(user):  # noqa
       produces:
       - application/json
       parameters:
-      - name: project_id
-        in: path
-        description: The GitLab project id.
-        required: true
-        type: integer
-      - name: hook_id
-        in: path
-        description: The GitLab webhook id of the project.
-        required: true
-        type: integer
+        - name: data
+          in: body
+          description: Data required to delete an existing webhook from GitLab.
+          schema:
+            type: object
+            required:
+              - project_id
+              - hook_id
+            properties:
+              project_id:
+                description: The GitLab project id.
+                type: string
+              hook_id:
+                description: The GitLab webhook id of the project.
+                type: integer
       responses:
         204:
           description: >-

--- a/reana_server/rest/info.py
+++ b/reana_server/rest/info.py
@@ -50,8 +50,29 @@ def info(user, **kwargs):  # noqa
             properties:
               workspaces_available:
                 type: object
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: array
+                    items:
+                      type: string
               default_workspace:
                 type: object
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+              compute_backends:
+                type: object
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: array
+                    items:
+                      type: string
           examples:
             application/json:
               {

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -158,10 +158,62 @@ def get_workflows(user, **kwargs):  # noqa
                           type: string
                     user:
                       type: string
+                    launcher_url:
+                      type: string
+                      x-nullable: true
                     created:
                       type: string
                     progress:
                       type: object
+                      properties:
+                        current_command:
+                          type: string
+                          x-nullable: true
+                        current_step_name:
+                          type: string
+                          x-nullable: true
+                        failed:
+                          properties:
+                            job_ids:
+                              items:
+                                type: string
+                              type: array
+                            total:
+                              type: number
+                          type: object
+                        finished:
+                          properties:
+                            job_ids:
+                              items:
+                                type: string
+                              type: array
+                            total:
+                              type: number
+                          type: object
+                        run_finished_at:
+                          type: string
+                          x-nullable: true
+                        run_started_at:
+                          type: string
+                          x-nullable: true
+                        running:
+                          properties:
+                            job_ids:
+                              items:
+                                type: string
+                              type: array
+                            total:
+                              type: number
+                          type: object
+                        total:
+                          properties:
+                            job_ids:
+                              items:
+                                type: string
+                              type: array
+                            total:
+                              type: number
+                          type: object
           examples:
             application/json:
               [


### PR DESCRIPTION
Updated api schema for:
- `info` endpoint:
  - added `compute_backends` and specified properties for other fields
- `workflows` endpoint:
  - enriched `progress` schema, added missing `launcher_url` field
- gitlab `webhook` endpoint:
  - changed parameters to from `query` to `path`. `go-swagger` validator gave an error for the specification because of this:
  ```
      the swagger spec at "/home/amecioni/Documents/projects/reana-client-go/reana_server.json" is invalid against swagger specification 2.0. see errors :
    - path param "project_id" is not present in path "/api/gitlab/webhook"
    - path param "hook_id" is not present in path "/api/gitlab/webhook"
  ```