### PR TITLE
reana-admin: add `retention-rules-apply` command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Version 0.9.0 (UNRELEASED)
 - Adds new ``/api/launch`` endpoint that allows running workflows from remote sources.
 - Adds the possibility to fetch the workflow specification from a remote URL.
 - Adds REANA specification validation utilities.
+- Adds `retention-rules-apply` command that can be used to apply pending retention rules.
 - Changes workflow create endpoint to populate workspace retention rules for the workflow.
 - Changes workflow list endpoint to return workspace retention rules for the workflow.
 - Changes API rate limiter error messages to be more verbose.

--- a/reana_server/reana_admin/retention_rule_deleter.py
+++ b/reana_server/reana_admin/retention_rule_deleter.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""REANA utilities to apply retention rules."""
+
+
+from pathlib import Path
+from typing import Dict, Union
+
+import click
+from reana_db.models import WorkspaceRetentionRule
+
+from reana_server.utils import is_relative_to
+
+
+class RetentionRuleDeleter:
+    """Delete files and directories matching the given retention rule."""
+
+    def __init__(self, rule: WorkspaceRetentionRule):
+        """Initialize the RetentionRuleDeleter.
+
+        :param rule: Retention rule to be applied.
+        """
+        self.rule_id = rule.id_
+        self.specification = rule.workflow.reana_specification
+        self.workflow_id = rule.workflow.id_
+        self.workspace = Path(rule.workflow.workspace_path)
+        self.workspace_files = rule.workspace_files
+
+    def is_input_output(self, file_or_dir: Path) -> bool:
+        """Check whether the file/directory is an input/output or not.
+
+        :param file_or_dir: Path to the file/directory.
+        """
+        for key in ("inputs", "outputs"):
+            files = self.specification.get(key, {}).get("files", [])
+            directories = self.specification.get(key, {}).get("directories", [])
+            for file in files:
+                if file_or_dir == self.workspace / file:
+                    return True
+            for directory in directories:
+                if is_relative_to(file_or_dir, self.workspace / directory):
+                    return True
+        return False
+
+    def is_inside_workspace(self, file_or_dir: Path) -> bool:
+        """Check if given file/directory is inside the workspace.
+
+        :param file_or_dir: Path to the file/directory.
+        """
+        return is_relative_to(file_or_dir.resolve(), self.workspace.resolve())
+
+    def delete_keeping_inputs_outputs(self, file_or_dir: Path):
+        """Delete the given file/directory, keeping the inputs/outputs.
+
+        :param file_or_dir: Path to the file/directory.
+        """
+        if not self.is_inside_workspace(file_or_dir):
+            click.echo(f"Path outside workspace: {file_or_dir}")
+        elif self.is_input_output(file_or_dir):
+            click.echo(f"Preserved in/out: {file_or_dir}")
+        elif file_or_dir.is_file() or file_or_dir.is_symlink():
+            file_or_dir.unlink()
+            click.echo(f"Deleted file: {file_or_dir}")
+        else:
+            for child in file_or_dir.iterdir():
+                self.delete_keeping_inputs_outputs(child)
+            if not any(file_or_dir.iterdir()):
+                file_or_dir.rmdir()
+                click.echo(f"Deleted dir: {file_or_dir}")
+
+    def apply_rule(self):
+        """Delete the files/directories matching the given retention rule, keeping inputs/outputs."""
+        click.secho(
+            f"Applying rule {self.rule_id} to workflow {self.workflow_id}: "
+            f"'{self.workspace_files}' will be deleted from '{self.workspace}'",
+            fg="green",
+        )
+        for file_or_dir in self.workspace.glob(self.workspace_files):
+            if not file_or_dir.exists():
+                click.echo(" Already deleted: {file_or_dir}")
+                continue
+            self.delete_keeping_inputs_outputs(file_or_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,11 +10,19 @@
 
 from __future__ import absolute_import, print_function
 
+from datetime import datetime, timedelta
 import os
+
 
 import flask_login
 import pytest
 from mock import Mock, patch
+
+from reana_db.models import (
+    WorkspaceRetentionAuditLog,
+    WorkspaceRetentionRule,
+    WorkspaceRetentionRuleStatus,
+)
 
 from reana_server.factory import create_app
 
@@ -44,3 +52,57 @@ def _get_user_mock():
     mocked_get_user = Mock(return_value=mocked_user)
     with patch("flask_login.utils._get_user", mocked_get_user):
         yield flask_login.utils._get_user
+
+
+@pytest.fixture()
+def workflow_with_retention_rules(sample_serial_workflow_in_db, session):
+    workflow = sample_serial_workflow_in_db
+    workflow.reana_specification = dict(workflow.reana_specification)
+    workflow.reana_specification["inputs"] = {
+        "files": ["input.txt", "to_be_deleted/input.txt"],
+        "directories": ["inputs"],
+    }
+    workflow.reana_specification["outputs"] = {
+        "files": ["output.txt"],
+        "directories": ["outputs", "to_be_deleted/outputs"],
+    }
+    current_time = datetime.now()
+    workflow.retention_rules = [
+        WorkspaceRetentionRule(
+            workflow_id=workflow.id_,
+            workspace_files="inputs",
+            retention_days=1,
+            status=WorkspaceRetentionRuleStatus.active,
+            apply_on=current_time - timedelta(days=1),
+        ),
+        WorkspaceRetentionRule(
+            workflow_id=workflow.id_,
+            workspace_files="**/*.txt",
+            retention_days=1,
+            status=WorkspaceRetentionRuleStatus.active,
+            apply_on=current_time - timedelta(days=1),
+        ),
+        WorkspaceRetentionRule(
+            workflow_id=workflow.id_,
+            workspace_files="to_be_deleted",
+            retention_days=1,
+            status=WorkspaceRetentionRuleStatus.active,
+            apply_on=current_time - timedelta(days=1),
+        ),
+        WorkspaceRetentionRule(
+            workflow_id=workflow.id_,
+            workspace_files="**/*",
+            retention_days=3,
+            status=WorkspaceRetentionRuleStatus.active,
+            apply_on=current_time + timedelta(days=1),
+        ),
+    ]
+    session.add_all(workflow.retention_rules)
+    session.add(workflow)
+    session.commit()
+
+    yield workflow
+
+    session.query(WorkspaceRetentionAuditLog).delete()
+    session.query(WorkspaceRetentionRule).delete()
+    session.commit()


### PR DESCRIPTION
Add command to apply pending retention rules, deleting the necessary files or directories.

How to test:
1. Modify one of the demo examples, defining some retention rules
2. Fake a different current time (e.g. one day in the future)
```diff
--- a/reana_server/reana_admin/cli.py
+++ b/reana_server/reana_admin/cli.py
@@ -748,6 +748,7 @@ def check_workflows(
 def retention_rules_apply() -> None:
     """Apply pending retentions rules."""
     current_time = datetime.datetime.now()
+    current_time = current_time + datetime.timedelta(days=1)
     pending_rules = WorkspaceRetentionRule.query.filter(
         WorkspaceRetentionRule.status == WorkspaceRetentionRuleStatus.active,
         WorkspaceRetentionRule.apply_on < current_time,
```
3. Run the `retention-rules-apply` command
```
kubectl exec -it deployments/reana-server -- flask reana-admin retention-rules-apply
```

Expected result: The retention rules are applied correctly and the correct files are deleted.