### PR TITLE
admin: detect out-of-sync interactive sessions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.0 (UNRELEASED)
 --------------------------
 
+- Adds interactive sessions out-of-sync check to ``reana-admin check-workflows`` command.
 - Adds workspace retention rules validation to ``get_workspace_retention_rules`` function.
 - Adds ``queue-consume`` command that can be used by REANA administrators to remove specific messages from the queue.
 - Adds configuration environment variable to set an API rate limit for slow endpoints (``REANA_RATELIMIT_SLOW``).


### PR DESCRIPTION
- add possibility to "check-workflows" command to detect out-of-sync interactive sessions.

### Intro

Session has `created` status in DB when they are open. When it is closed, the record is deleted from the database. It differs from workflow, where deleted workflow is kept in the database.

### How to test

There are three scenarios:

1. Interactive session is in database, open, and pod exist:

- run some workflow like `helloworld`
- open a session (`reana-client open -w <workflow-name>`)
- ssh into `r-server` using `kubectl exec -i -t <r-server-pod-id> -- /bin/bash`
- run check command `flask reana-admin check-workflows`
- it should pass

2. Interactive session is in DB but pod doesn't exist:

- reuse a session from before
- run `kubectl get deployments` to locate Deployment for interactive session
- delete deployment using `kubectl delete deployment <id>`
- run check command like before, it should fail

3. Interactive session is not in DB (closed), but the pod still exists:

- open a new session
- ssh into r-server:
```bash
root@reana-server-f5976658d-hv8fw:/code# python
Python 3.8.13 (default, Jul 13 2022, 05:54:24)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from reana_db.database import Session
>>> from reana_db.models import InteractiveSession
>>> sessions = InteractiveSession.query.all()
>>> sessions
[<InteractiveSession 'reana-run-session-d579f1b3-7e88-4143-b188-2a081c8db936'>]
>>> [Session.delete(session) for session in sessions]
[None]
>>> Session.commit()
>>> sessions = InteractiveSession.query.all()
>>> exit()
root@reana-server-f5976658d-hv8fw:/code# flask reana-admin check-workflows  # should fail
```