### PR TITLE
workspace retention: allow disabling retention rules

### DIFF
--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -12,6 +12,7 @@ import copy
 import json
 import os
 import re
+from typing import Optional
 
 from distutils.util import strtobool
 from limits.util import parse
@@ -300,9 +301,14 @@ LAUNCHER_ALLOWED_SNAKEMAKE_URLS = [
 
 # Workspace retention rules
 # ==================
-
-WORKSPACE_RETENTION_PERIOD = int(os.getenv("WORKSPACE_RETENTION_PERIOD", "365"))
-"""Maximum allowed period for workspace retention rules."""
+_workspace_retention_period_env = os.getenv("WORKSPACE_RETENTION_PERIOD", "forever")
+if _workspace_retention_period_env == "forever":
+    WORKSPACE_RETENTION_PERIOD: Optional[int] = None
+else:
+    WORKSPACE_RETENTION_PERIOD: Optional[int] = int(_workspace_retention_period_env)
+"""Maximum allowed period for workspace retention rules.
+The value "forever" means "do not apply any rules to files by default", and it is represented by None.
+"""
 
 DEFAULT_WORKSPACE_RETENTION_RULE = "**/*"
 """Workspace retention rule which will be applied to all the workflows by default."""

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -572,10 +572,15 @@ def get_workspace_retention_rules(
             validate_retention_rule(rule, days)
             retention_rules.append({"workspace_files": rule, "retention_days": days})
 
-    # Insert a default rule in case it's not present
-    if not any(
+    default_retention_rules_are_not_disabled = WORKSPACE_RETENTION_PERIOD is not None
+    default_retention_rule_is_not_present = not any(
         rule["workspace_files"] == DEFAULT_WORKSPACE_RETENTION_RULE
         for rule in retention_rules
+    )
+
+    if (
+        default_retention_rule_is_not_present
+        and default_retention_rules_are_not_disabled
     ):
         retention_rules.append(
             {

--- a/reana_server/validation.py
+++ b/reana_server/validation.py
@@ -146,7 +146,8 @@ def validate_retention_rule(rule: str, days: int) -> None:
     if ".." in rule_path.parts:
         raise REANAValidationError(f"Retention rule {rule} cannot contain '..'")
 
-    if days >= WORKSPACE_RETENTION_PERIOD:
+    default_retention_rules_are_not_disabled = WORKSPACE_RETENTION_PERIOD is not None
+    if default_retention_rules_are_not_disabled and days >= WORKSPACE_RETENTION_PERIOD:
         raise REANAValidationError(
             "Maximum workflow retention period was reached. "
             f"Please use less than {WORKSPACE_RETENTION_PERIOD} days."

--- a/requirements.txt
+++ b/requirements.txt
@@ -157,7 +157,7 @@ pywebpack==1.2.0          # via flask-webpackext
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas
 ratelimiter==1.2.0.post0  # via snakemake
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons[cwl,kubernetes,snakemake,yadage]==0.9.0a10	# via reana-db, reana-server (setup.py)
+reana-commons[cwl,kubernetes,snakemake,yadage]==0.9.0a11	# via reana-db, reana-server (setup.py)
 reana-db==0.9.0a7	# via reana-server (setup.py)
 redis==4.2.2              # via invenio-accounts, invenio-celery
 requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient, kubernetes

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_requires = [
     "gitpython>=3.1",
     "marshmallow>2.13.0,<=2.20.1",
     "pyOpenSSL==17.5.0",
-    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.9.0a10,<0.10.0",
+    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.9.0a11,<0.10.0",
     "reana-db>=0.9.0a7,<0.10.0",
     "requests==2.25.0",
     "rfc3987==1.3.7",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -7,6 +7,7 @@
 """REANA-Server tests for validation module."""
 
 import pytest
+from unittest.mock import patch
 from contextlib import nullcontext as does_not_raise
 
 from reana_commons.errors import REANAValidationError
@@ -43,6 +44,7 @@ def test_validate_inputs(paths, error):
         ("../**/*", 10, pytest.raises(REANAValidationError, match="'..'")),
     ],
 )
+@patch("reana_server.validation.WORKSPACE_RETENTION_PERIOD", 365)
 def test_validate_retention_rule(rule, days, error):
     with error:
         validate_retention_rule(rule, days)


### PR DESCRIPTION
- if rules are disabled they will not be created in the database; this is easier because we do not need additional code logic to skip rules.

## How to test?

1. Add some retention rules (e.g. root6 workflow):

```diff
diff --git a/reana.yaml b/reana.yaml
index 9b13d45..59c80db 100644
--- a/reana.yaml
+++ b/reana.yaml
@@ -21,6 +21,12 @@ workflow:
         kubernetes_memory_limit: '256Mi'
         commands:
         - root -b -q 'code/fitdata.C("${data}","${plot}")'
+
+workspace:
+  retention_days:
+    results/*.root: 1
+    code/*.C: 1
+
 outputs:
   files:
     - results/plot.png
```

2. Modify values to set default retention period to always keep files:

```diff
diff --git a/helm/reana/values.yaml b/helm/reana/values.yaml
index 4d66cfa..487683b 100644
--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -13,7 +13,7 @@ eos:

 workspaces:
   retention_rules:
-    maximum_period: 365
+    maximum_period: forever
     cronjob_schedule: "0 2 * * *"  # everyday at 2am
   paths:
     - /var/reana:/var/reana
```

3. Run workflow
4. SSH into the r-server container and start python interpreter:

```python
root@reana-server-f5976658d-wbp7t:/code# python
Python 3.8.13 (default, Jul 13 2022, 05:54:24)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from reana_db.database import Session
>>> from reana_db.models import WorkspaceRetentionRule
>>> WorkspaceRetentionRule.query.all()
[<WorkspaceRetentionRule 72456171-5dd5-41a5-becc-617b5f85d6fe results/*.root 1 WorkspaceRetentionRuleStatus.active>, <WorkspaceRetentionRule 72456171-5dd5-41a5-becc-617b5f85d6fe code/*.C 1 WorkspaceRetentionRuleStatus.active>]
>>>
```

Check that the default rule (`**/*`) is not created.

closes reanahub/reana#653