### PR TITLE
rest: validate REANA specification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.0 (UNRELEASED)
 --------------------------
 
+- Adds validation of REANA specification to ``create_workflow`` and ``start_workflow`` endpoints.
 - Adds interactive sessions out-of-sync check to ``reana-admin check-workflows`` command.
 - Adds workspace retention rules validation to ``get_workspace_retention_rules`` function.
 - Adds ``queue-consume`` command that can be used by REANA administrators to remove specific messages from the queue.

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -72,7 +72,7 @@ from reana_server.config import (
     WORKSPACE_RETENTION_PERIOD,
     DEFAULT_WORKSPACE_RETENTION_RULE,
 )
-from reana_server.validation import validate_retention_rule
+from reana_server.validation import validate_retention_rule, validate_workflow
 
 
 def is_uuid_v4(uuid_or_name):
@@ -594,6 +594,8 @@ def get_workspace_retention_rules(
 def clone_workflow(workflow, reana_spec, restart_type):
     """Create a copy of workflow in DB for restarting."""
     reana_specification = reana_spec or workflow.reana_specification
+    validate_workflow(reana_specification, input_parameters={})
+
     retention_days = reana_specification.get("workspace", {}).get("retention_days")
     retention_rules = get_workspace_retention_rules(retention_days)
     try:


### PR DESCRIPTION
- before, "create_workflow" endpoint was not validating REANA specification; this commit adds validation.
- it also fixes some tests as they incorrectly put "workflow_name" in JSON body instead of query string.

closes #468