### PR TITLE
rest: remove specification validation from "create" endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 Version 0.9.0 (UNRELEASED)
 --------------------------
 
-- Adds validation of REANA specification to ``create_workflow`` and ``start_workflow`` endpoints.
+- Adds validation of REANA specification to ``start_workflow`` endpoint.
 - Adds interactive sessions out-of-sync check to ``reana-admin check-workflows`` command.
 - Adds workspace retention rules validation to ``get_workspace_retention_rules`` function.
 - Adds ``queue-consume`` command that can be used by REANA administrators to remove specific messages from the queue.


### PR DESCRIPTION
- because client doesn't include Yadage specification in "create" endpoint, validation fails;
- workflow validation is moved to "start_workflow" so in case Yadage specification has multiple files, they can be loaded and properly validated.

closes #535