### PR TITLE
openapi: update schema of `get_workflow_status`

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2947,10 +2947,12 @@
                 "progress": {
                   "properties": {
                     "current_command": {
-                      "type": "string"
+                      "type": "string",
+                      "x-nullable": true
                     },
                     "current_step_name": {
-                      "type": "string"
+                      "type": "string",
+                      "x-nullable": true
                     },
                     "failed": {
                       "properties": {
@@ -2981,10 +2983,12 @@
                       "type": "object"
                     },
                     "run_finished_at": {
-                      "type": "string"
+                      "type": "string",
+                      "x-nullable": true
                     },
                     "run_started_at": {
-                      "type": "string"
+                      "type": "string",
+                      "x-nullable": true
                     },
                     "running": {
                       "properties": {

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -917,8 +917,10 @@ def get_workflow_status(workflow_id_or_name, user):  # noqa
                 properties:
                   run_started_at:
                     type: string
+                    x-nullable: true
                   run_finished_at:
                     type: string
+                    x-nullable: true
                   total:
                     type: object
                     properties:
@@ -957,8 +959,10 @@ def get_workflow_status(workflow_id_or_name, user):  # noqa
                           type: string
                   current_command:
                     type: string
+                    x-nullable: true
                   current_step_name:
                     type: string
+                    x-nullable: true
               logs:
                 type: string
           examples:


### PR DESCRIPTION
Some fields of the response of `get_workflow_status` can be `null`.

Closes #538