### PR TITLE
openapi: add missing param schema to start_workflow

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2598,6 +2598,7 @@
                   "type": "string"
                 },
                 "parameters": {
+                  "minProperties": 0,
                   "type": "object"
                 },
                 "type": {
@@ -2810,6 +2811,20 @@
             "name": "parameters",
             "required": false,
             "schema": {
+              "properties": {
+                "input_parameters": {
+                  "type": "object"
+                },
+                "operational_options": {
+                  "type": "object"
+                },
+                "reana_specification": {
+                  "type": "object"
+                },
+                "restart": {
+                  "type": "boolean"
+                }
+              },
               "type": "object"
             }
           }

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -1094,6 +1094,15 @@ def start_workflow(workflow_id_or_name, user):  # noqa
           required: false
           schema:
             type: object
+            properties:
+              operational_options:
+                type: object
+              reana_specification:
+                type: object
+              input_parameters:
+                type: object
+              restart:
+                type: boolean
       responses:
         200:
           description: >-
@@ -2025,6 +2034,7 @@ def get_workflow_parameters(workflow_id_or_name, user):  # noqa
                 type: string
               parameters:
                 type: object
+                minProperties: 0
           examples:
             application/json:
               {


### PR DESCRIPTION
closes https://github.com/reanahub/reana-client-go/issues/95