### PR TITLE
admin: add `--dry-run` option to `retention-rules-apply`

### DIFF
--- a/reana_server/reana_admin/retention_rule_deleter.py
+++ b/reana_server/reana_admin/retention_rule_deleter.py
@@ -73,13 +73,15 @@ class RetentionRuleDeleter:
                 file_or_dir.rmdir()
                 click.echo(f"Deleted dir: {file_or_dir}")
 
-    def apply_rule(self):
+    def apply_rule(self, dry_run: bool = False):
         """Delete the files/directories matching the given retention rule, keeping inputs/outputs."""
         click.secho(
             f"Applying rule {self.rule_id} to workflow {self.workflow_id}: "
             f"'{self.workspace_files}' will be deleted from '{self.workspace}'",
             fg="green",
         )
+        if dry_run:
+            return
         for file_or_dir in self.workspace.glob(self.workspace_files):
             if not file_or_dir.exists():
                 click.echo(" Already deleted: {file_or_dir}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -382,6 +382,12 @@ def test_retention_rules_apply(workflow_with_retention_rules):
         assert f.exists()
 
     runner = CliRunner()
+
+    result = runner.invoke(reana_admin, ["retention-rules-apply", "--dry-run"])
+    assert result.exit_code == 0
+    for file in to_be_deleted:
+        assert workspace.joinpath(file).exists()
+
     result = runner.invoke(reana_admin, ["retention-rules-apply"])
     assert result.exit_code == 0
 


### PR DESCRIPTION
closes https://github.com/reanahub/reana-server/issues/555

To test:
- create some workflows with retention rules
- `kubectl exec -i -t deployment/reana-server -c rest-api -- flask reana-admin retention-rules-apply --dry-run`