### PR TITLE
admin: add retention-rules-extend command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Version 0.9.0 (UNRELEASED)
 - Adds the possibility to fetch the workflow specification from a remote URL.
 - Adds REANA specification validation utilities.
 - Adds `retention-rules-apply` command that can be used to apply pending retention rules.
+- Adds `retention-rules-extend` command that can be used to extend the duration of active retentions rules.
 - Changes workflow create endpoint to populate workspace retention rules for the workflow.
 - Changes workflow list endpoint to return workspace retention rules for the workflow.
 - Changes workflow start endpoint to disallow restarting a workflow when retention rules are pending.

--- a/reana_server/reana_admin/options.py
+++ b/reana_server/reana_admin/options.py
@@ -38,21 +38,26 @@ def add_user_options(func):
     return wrapper
 
 
-def add_workflow_option(func):
+def add_workflow_option(**attrs):
     """Add options to get a workflow by its UUID."""
 
-    @click.option("-w", "--workflow", "workflow_uuid", help="The id of the workflow.")
-    @functools.wraps(func)
-    def wrapper(*args, workflow_uuid, **kwargs):
-        workflow = None
-        if workflow_uuid is not None:
-            if not is_uuid_v4(workflow_uuid):
-                click.secho("Invalid workflow UUID.", fg="red")
-                sys.exit(1)
-            workflow = Workflow.query.filter(Workflow.id_ == workflow_uuid).first()
-            if not workflow:
-                click.secho("Workflow not found.", fg="red")
-                sys.exit(1)
-        func(*args, workflow=workflow, **kwargs)
+    def decorator(func):
+        @click.option(
+            "-w", "--workflow", "workflow_uuid", help="The id of the workflow.", **attrs
+        )
+        @functools.wraps(func)
+        def wrapper(*args, workflow_uuid, **kwargs):
+            workflow = None
+            if workflow_uuid is not None:
+                if not is_uuid_v4(workflow_uuid):
+                    click.secho("Invalid workflow UUID.", fg="red")
+                    sys.exit(1)
+                workflow = Workflow.query.filter(Workflow.id_ == workflow_uuid).first()
+                if not workflow:
+                    click.secho("Workflow not found.", fg="red")
+                    sys.exit(1)
+            func(*args, workflow=workflow, **kwargs)
 
-    return wrapper
+        return wrapper
+
+    return decorator

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -473,6 +473,28 @@ def test_retention_rules_apply_error(
         assert rule.status == WorkspaceRetentionRuleStatus.active
 
 
+def test_retention_rules_extend(workflow_with_retention_rules):
+    """Test extending of retention rules."""
+    workflow = workflow_with_retention_rules
+    runner = CliRunner()
+    extend_days = 5
+
+    result = runner.invoke(
+        reana_admin, ["retention-rules-extend", "-w non-valid-id", "-d", extend_days]
+    )
+    assert result.output == "Invalid workflow UUID.\n"
+    assert result.exit_code == 1
+
+    result = runner.invoke(
+        reana_admin, ["retention-rules-extend", "-w", workflow.id_, "-d", extend_days]
+    )
+    assert "Extending rule" in result.output
+    assert result.exit_code == 0
+
+    for rule in workflow.retention_rules:
+        assert rule.retention_days > extend_days
+
+
 def test_retention_rule_deleter_file_outside_workspace(tmp_path):
     """Test that file outside the workspace are not deleted."""
     file = tmp_path.joinpath("do_not_delete.txt")


### PR DESCRIPTION
closes https://github.com/reanahub/reana-server/issues/556

To test:
- create some workflows with retention rules
- `kubectl exec -i -t deployment/reana-server -c rest-api -- flask reana-admin retention-rules-extend -d 4 -w d171760a-a7db-4270-80fd-dddd526bc20c`

