### PR TITLE
reana-admin: add interactive-session-cleanup command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.1 (UNRELEASED)
 --------------------------
 
+- Adds ``interactive-session-cleanup`` command that can be used by REANA administrators to close interactive sessions that are inactive for more than the specified number of days.
 - Changes the system status report to simplify and clarify the disk usage summary.
 - Fixes GitLab integration to automatically redirect the user to the correct URL when the access request is accepted.
 


### PR DESCRIPTION
Add command to close interactive sessions running longer than a specified number of days.

closes https://github.com/reanahub/reana-workflow-controller/issues/498