### PR TITLE
auth: add `invenio_oauthclient.contrib.keycloak` and configuration for generic SSO login

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,7 @@ The list of contributors in alphabetical order:
 - `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_
+- `Domenic Gosein <https://orcid.org/0000-0002-1546-0435>`_
 - `Harri Hirvonsalo <https://orcid.org/0000-0002-5503-510X>`_
 - `Jan Okraska <https://orcid.org/0000-0002-1416-3244>`_
 - `Leticia Wanderley <https://orcid.org/0000-0003-4649-6630>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 0.9.1 (UNRELEASED)
 - Adds ``interactive-session-cleanup`` command that can be used by REANA administrators to close interactive sessions that are inactive for more than the specified number of days.
 - Changes the system status report to simplify and clarify the disk usage summary.
 - Fixes GitLab integration to automatically redirect the user to the correct URL when the access request is accepted.
+- Adds logic to support SSO with third-party Keycloak authentication services to ``config.py``.
 
 Version 0.9.0 (2023-01-19)
 --------------------------


### PR DESCRIPTION
This PR adds `invenio_oauthclient.contrib.keycloak` and configures a second OAuth app for generic/Keycloak SSO functionality to the server's config.

Fixes #513