### PR TITLE
rest: add max inactivity period for interactive sessions to info endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.1 (UNRELEASED)
 --------------------------
 
+- Changes OpenAPI specification with respect to return the maximum inactivity time before automatic closure of interactive sessions in ``info`` endpoint.
 - Adds the content of the ``REANA_GITLAB_HOST`` environment variable to the list of GitLab instances from which it is possible to launch a workflow.
 - Adds new ``prune_workspace`` endpoint to allow users to delete all the files of a workflow, specifying whether to also delete the inputs and/or the outputs.
 - Adds ``interactive-session-cleanup`` command that can be used by REANA administrators to close interactive sessions that are inactive for more than the specified number of days.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -455,6 +455,18 @@
                   },
                   "type": "object"
                 },
+                "maximum_interactive_session_inactivity_period": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
                 "maximum_kubernetes_jobs_timeout": {
                   "properties": {
                     "title": {

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -207,6 +207,7 @@ PROXYFIX_CONFIG = {"x_proto": 1}
 APP_DEFAULT_SECURE_HEADERS["content_security_policy"] = {}
 APP_HEALTH_BLUEPRINT_ENABLED = False
 
+
 # Rate limiting configuration using invenio-app
 # ===========================
 
@@ -328,11 +329,9 @@ REANA_GITLAB_OAUTH_APP_SECRET = os.getenv("REANA_GITLAB_OAUTH_APP_SECRET", "CHAN
 REANA_GITLAB_HOST = os.getenv("REANA_GITLAB_HOST", None)
 REANA_GITLAB_URL = "https://{}".format((REANA_GITLAB_HOST or "CHANGE ME"))
 
-
 # Email configuration
 # ===================
 ADMIN_EMAIL = os.getenv("REANA_EMAIL_SENDER", "CHANGE_ME")
-
 
 # Workflow scheduler
 # ==================
@@ -388,6 +387,19 @@ The value "forever" means "do not apply any rules to files by default", and it i
 
 DEFAULT_WORKSPACE_RETENTION_RULE = "**/*"
 """Workspace retention rule which will be applied to all the workflows by default."""
+
+# Interactive sessions configuration
+# ==================
+_reana_interactive_session_max_inactivity_period_env = os.getenv(
+    "REANA_INTERACTIVE_SESSION_MAX_INACTIVITY_PERIOD", "forever"
+)
+if _reana_interactive_session_max_inactivity_period_env == "forever":
+    REANA_INTERACTIVE_SESSION_MAX_INACTIVITY_PERIOD: Optional[str] = None
+else:
+    REANA_INTERACTIVE_SESSION_MAX_INACTIVITY_PERIOD: Optional[
+        str
+    ] = _reana_interactive_session_max_inactivity_period_env
+"""Maximum allowed period (in days) for interactive session inactivity before automatic closure."""
 
 # Kubernetes jobs timeout
 # ==================

--- a/reana_server/rest/info.py
+++ b/reana_server/rest/info.py
@@ -23,6 +23,7 @@ from reana_server.config import (
     REANA_KUBERNETES_JOBS_MEMORY_LIMIT,
     REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT,
     REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT,
+    REANA_INTERACTIVE_SESSION_MAX_INACTIVITY_PERIOD,
 )
 from reana_server.decorators import signin_required
 
@@ -140,6 +141,10 @@ def info(user, **kwargs):  # noqa
                 title="Maximum timeout for Kubernetes jobs",
                 value=REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT,
             ),
+            maximum_interactive_session_inactivity_period=dict(
+                title="Maximum inactivity period in days before automatic closure of interactive sessions",
+                value=REANA_INTERACTIVE_SESSION_MAX_INACTIVITY_PERIOD,
+            ),
         )
         return InfoSchema().dump(cluster_information)
 
@@ -180,3 +185,6 @@ class InfoSchema(Schema):
     maximum_workspace_retention_period = fields.Nested(StringNullableInfoValue)
     default_kubernetes_jobs_timeout = fields.Nested(StringInfoValue)
     maximum_kubernetes_jobs_timeout = fields.Nested(StringInfoValue)
+    maximum_interactive_session_inactivity_period = fields.Nested(
+        StringNullableInfoValue
+    )


### PR DESCRIPTION
Adds the `maximum_interactive_session_inactivity_period` value to the ones returned by `/api/info`.

Addresses reanahub/reana-client#657