### PR TITLE
global: update to apispec v3

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,11 +1,9 @@
 {
-  "definitions": {},
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
     "version": "0.9.1a3"
   },
-  "parameters": {},
   "paths": {
     "/account/settings/linkedaccounts/": {},
     "/account/settings/linkedaccounts/static/{filename}": {},
@@ -4450,6 +4448,5 @@
     "/signin": {},
     "/signup/": {}
   },
-  "swagger": "2.0",
-  "tags": []
+  "swagger": "2.0"
 }

--- a/reana_server/rest/info.py
+++ b/reana_server/rest/info.py
@@ -53,7 +53,79 @@ def info(user, **kwargs):  # noqa
         200:
           description: >-
             Request succeeded. The response contains general info about the cluster.
-          schema: InfoSchema
+          schema:
+            properties:
+              compute_backends:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              default_kubernetes_jobs_timeout:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                type: object
+              default_kubernetes_memory_limit:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                type: object
+              default_workspace:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                type: object
+              kubernetes_max_memory_limit:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                    x-nullable: true
+                type: object
+              maximum_interactive_session_inactivity_period:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                    x-nullable: true
+                type: object
+              maximum_kubernetes_jobs_timeout:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                type: object
+              maximum_workspace_retention_period:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                    x-nullable: true
+                type: object
+              workspaces_available:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
           examples:
             application/json:
               {

--- a/requirements.txt
+++ b/requirements.txt
@@ -157,7 +157,7 @@ pywebpack==1.2.0          # via flask-webpackext
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas
 ratelimiter==1.2.0.post0  # via snakemake
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons[cwl,kubernetes,snakemake,yadage]==0.9.3a3	# via reana-db, reana-server (setup.py)
+reana-commons[cwl,kubernetes,snakemake,yadage]==0.9.3a4	# via reana-db, reana-server (setup.py)
 reana-db==0.9.1	# via reana-server (setup.py)
 redis==4.5.1              # via invenio-accounts, invenio-celery
 requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient, kubernetes

--- a/scripts/generate_openapi_spec.py
+++ b/scripts/generate_openapi_spec.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020, 2021, 2022 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,6 +14,7 @@ import os
 
 import click
 from apispec import APISpec
+from apispec_webframeworks.flask import FlaskPlugin
 from flask import current_app
 from flask.cli import with_appcontext
 from reana_commons.utils import copy_openapi_specs
@@ -57,8 +58,9 @@ def build_openapi_spec(publish):
     spec = APISpec(
         title=package,
         version=ver,
+        openapi_version="2.0",
         info=dict(description=desc),
-        plugins=("apispec.ext.flask", "apispec.ext.marshmallow"),
+        plugins=(FlaskPlugin(),),
     )
 
     # Add marshmallow schemas to the specification here
@@ -67,7 +69,7 @@ def build_openapi_spec(publish):
     # Collect OpenAPI docstrings from Flask endpoints
     for key in current_app.view_functions:
         if key != "static" and key != "get_openapi_spec":
-            spec.add_path(view=current_app.view_functions[key])
+            spec.path(view=current_app.view_functions[key])
 
     spec_json = json.dumps(
         spec.to_dict(), indent=2, separators=(",", ": "), sort_keys=True

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.9.0a6,<0.10.0",
+    "pytest-reana>=0.9.1a1,<0.10.0",
 ]
 
 extras_require = {
@@ -54,7 +54,7 @@ install_requires = [
     "flask-celeryext<0.5.0",
     "gitpython>=3.1",
     "marshmallow>2.13.0,<=2.20.1",
-    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.9.3a3,<0.10.0",
+    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.9.3a4,<0.10.0",
     "reana-db>=0.9.1,<0.10.0",
     "requests==2.25.0",
     "tablib>=0.12.1",


### PR DESCRIPTION
Update to apispec v3, as the version used before is not compatible with
PyYAML v6. This commit also removes the marshmallow plugin for apispec,
as the generated OpenAPI spec is different and causes issues with
reana-client. This is due to the fact that the OpenAPI specifications of
marshmallow schemas are now put inside the global `definitions` object,
instead of being inlined in the endpoint's specification as before.

Closes reanahub/reana-commons#399
