### PR TITLE
launch: include validation warnings in returned message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.1 (UNRELEASED)
 --------------------------
 
+- Changes ``launch`` endpoint also include the warnings of the validation of the workflow specification.
 - Changes OpenAPI specification with respect to return the maximum inactivity time before automatic closure of interactive sessions in ``info`` endpoint.
 - Adds the timestamp of when the workflow was stopped (``run_stopped_at``) to the workflow list and the workflow status endpoints.
 - Adds the content of the ``REANA_GITLAB_HOST`` environment variable to the list of GitLab instances from which it is possible to launch a workflow.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -582,6 +582,18 @@
                 "message": {
                   "type": "string"
                 },
+                "validation_warnings": {
+                  "description": "Dictionary of validation warnings, if any. Each key is a property that was not correctly validated.",
+                  "properties": {
+                    "additional_properties": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
                 "workflow_id": {
                   "type": "string"
                 },
@@ -589,6 +601,11 @@
                   "type": "string"
                 }
               },
+              "required": [
+                "workflow_id",
+                "workflow_name",
+                "message"
+              ],
               "type": "object"
             }
           },

--- a/reana_server/validation.py
+++ b/reana_server/validation.py
@@ -10,7 +10,7 @@
 
 import itertools
 import pathlib
-from typing import Dict
+from typing import Dict, List
 
 from reana_commons.config import WORKSPACE_PATHS
 from reana_commons.errors import REANAValidationError
@@ -107,7 +107,7 @@ def validate_inputs(reana_yaml: Dict) -> None:
             )
 
 
-def validate_workflow(reana_yaml: Dict, input_parameters: Dict) -> None:
+def validate_workflow(reana_yaml: Dict, input_parameters: Dict) -> Dict:
     """Validate REANA workflow specification by calling all the validation utilities.
 
     :param reana_yaml: dictionary which represents REANA specification file.
@@ -119,12 +119,13 @@ def validate_workflow(reana_yaml: Dict, input_parameters: Dict) -> None:
     operational_options = reana_yaml.get("inputs", {}).get("options", {})
     original_parameters = reana_yaml.get("inputs", {}).get("parameters", {})
 
-    validate_reana_yaml(reana_yaml)
+    reana_yaml_warnings = validate_reana_yaml(reana_yaml)
     validate_operational_options(workflow_type, operational_options)
     validate_input_parameters(input_parameters, original_parameters)
     validate_compute_backends(reana_yaml)
     validate_workspace_path(reana_yaml)
     validate_inputs(reana_yaml)
+    return reana_yaml_warnings
 
 
 def validate_retention_rule(rule: str, days: int) -> None:


### PR DESCRIPTION
In case some warnings are issued when launching a workflow, the `launch` endpoint will now include them in the returned `message`. 
Closes reanahub/reana-client#660.