### PR TITLE
setup: remove upper pin for `SQLAlchemy-Utils`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ click==8.1.3              # via celery, click-didyoumean, click-plugins, click-r
 coloredlogs==15.0.1       # via cwltool
 configargparse==1.5.3     # via snakemake
 connection-pool==0.0.3    # via snakemake
-cryptography==39.0.2      # via invenio-accounts, pyopenssl, reana-db, requests, sqlalchemy-utils
+cryptography==39.0.2      # via invenio-accounts, pyopenssl, reana-db, requests
 cwltool==3.1.20210628163208  # via reana-commons
 datrie==0.8.2             # via snakemake
 decorator==5.1.1          # via ipython, jsonpath-rw, networkx, validators
@@ -157,8 +157,8 @@ pywebpack==1.2.0          # via flask-webpackext
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas
 ratelimiter==1.2.0.post0  # via snakemake
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons[cwl,kubernetes,snakemake,yadage]==0.9.3a4	# via reana-db, reana-server (setup.py)
-reana-db==0.9.1	# via reana-server (setup.py)
+reana-commons[cwl,kubernetes,snakemake,yadage]==0.9.3a4  # via reana-db, reana-server (setup.py)
+reana-db==0.9.1           # via reana-server (setup.py)
 redis==4.5.1              # via invenio-accounts, invenio-celery
 requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient, kubernetes
 requests[security]==2.25.0  # via bravado, bravado-core, cachecontrol, cwltool, kubernetes, packtivity, reana-server (setup.py), requests-oauthlib, schema-salad, snakemake, yadage, yadage-schemas
@@ -170,13 +170,13 @@ schema-salad==8.4.20230213094415  # via cwltool
 shellescape==3.8.1        # via cwltool
 simplejson==3.18.3        # via bravado, bravado-core
 simplekv==0.14.1          # via flask-kvsession-invenio, invenio-accounts
-six==1.16.0               # via bravado, bravado-core, click-repl, flask-breadcrumbs, flask-cors, flask-kvsession-invenio, flask-limiter, flask-menu, flask-talisman, fs, google-auth, isodate, jsonpath-rw, jsonschema, kubernetes, limits, mock, prov, python-dateutil, rdflib, reana-server (setup.py), sqlalchemy-utils, wtforms-components
+six==1.16.0               # via bravado, bravado-core, click-repl, flask-breadcrumbs, flask-cors, flask-kvsession-invenio, flask-limiter, flask-menu, flask-talisman, fs, google-auth, isodate, jsonpath-rw, jsonschema, kubernetes, limits, mock, prov, python-dateutil, rdflib, reana-server (setup.py), wtforms-components
 smart-open==6.3.0         # via snakemake
 smmap==5.0.0              # via gitdb
 snakemake==6.8.0          # via reana-commons
 speaklater==1.3           # via flask-babelex
 sqlalchemy-continuum==1.3.14  # via invenio-db
-sqlalchemy-utils[encrypted]==0.35.0  # via invenio-db, reana-db, reana-server (setup.py), sqlalchemy-continuum, wtforms-alchemy
+sqlalchemy-utils==0.38.3  # via invenio-db, reana-db, sqlalchemy-continuum, wtforms-alchemy
 sqlalchemy==1.3.24        # via alembic, flask-alembic, flask-sqlalchemy, invenio-db, reana-db, sqlalchemy-continuum, sqlalchemy-utils, wtforms-alchemy
 stack-data==0.6.2         # via ipython
 stopit==1.1.2             # via snakemake

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ install_requires = [
     "invenio-i18n>=1.3.3,<2.0.0",
     # Invenio database
     "invenio-db[postgresql]>=1.0.5,<1.1.0",
-    "SQLAlchemy-Utils[encrypted]>=0.33.0,<0.36.0",
     "six>=1.12.0",  # required by Flask-Breadcrumbs
 ]
 


### PR DESCRIPTION
Fix an issue with `reana-db init` failing while trying to connect to
`postgres` database, even if the database has a different name, by
upgrading `SQLAlchemy-Utils` to a version >=0.36.8.

Closes #614
