### PR TITLE
reana-admin: fix setting storage quota for users after global default…

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,6 +7,7 @@ The list of contributors in alphabetical order:
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
 - `Anton Khodak <https://orcid.org/0000-0003-3263-4553>`_
 - `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
+- `Daan Rosendal <https://github.com/DaanRosendal>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_
 - `Domenic Gosein <https://orcid.org/0000-0002-1546-0435>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.1 (UNRELEASED)
 --------------------------
 
+- Fixes ``quota-set-default-limits`` command to propagate default quota limits to all users without custom quota limit values..
 - Changes ``launch`` endpoint also include the warnings of the validation of the workflow specification.
 - Changes OpenAPI specification with respect to return the maximum inactivity time before automatic closure of interactive sessions in ``info`` endpoint.
 - Adds the timestamp of when the workflow was stopped (``run_stopped_at``) to the workflow list and the workflow status endpoints.


### PR DESCRIPTION
**Consideration**: the code assumes a default quota limit of zero. This assumption can lead to unexpected behaviour for admins when they change their default quota limit from a previously defined value to a new one. This is because any previously set default limits will be treated as custom limits and thus won't be automatically updated to match the new default limit.

I tested several scenarios:

**Single User Scenarios**
| Scenario                      | CPU Limit | Disk Limit | Outcome                    |
| ----------------------------- | --------- | ---------- | --------------------------- |
| 1 | 0         | Custom     | ✅ CPU updated to default      |
| 2 | Custom    | 0          | ✅ Disk updated to default     |
| 3      | 0         | 0          | ✅ Disk and CPU updated to default     |

**Multiple Users Scenarios**
| Scenario                                      | Outcome                  |
| --------------------------------------------- | ------------------------- |
| 1. Multiple Users (No Custom Quota Limits, all limits = 0)       | ✅ All updated to default   |
| 2. Multiple Users (All default Quota Limits)       | ✅ None updated             |
| 3. Multiple Users (All custom Quota Limits)       | ✅ None updated             |
| 4. CPU: 0, Disk: Custom (All Users)               | ✅ CPU updated for all users |
| 5. CPU: Custom, Disk: 0 (All Users)              | ✅ Disk updated for all users|
| 6. User 1: CPU: 0 for CPU and disk, User 2: Custom, User 3: Default| ✅ User 1 updated to default|

Closes #625