### PR TITLE
cli: fix graceful shutdown of `start-scheduler`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Version 0.9.1 (UNRELEASED)
 - Fixes GitLab integration to automatically redirect the user to the correct URL when the access request is accepted.
 - Fixes authentication flow to correctly deny access to past revoked tokens in case the same user has also other new active tokens.
 - Fixes the email templates to show the correct ``kubectl`` commands when REANA is deployed inside a non-default namespace or with a custom component name prefix.
+- Fixes ``start-scheduler`` command to gracefully stop when being terminated.
 - Adds logic to support SSO with third-party Keycloak authentication services to ``config.py``.
 
 Version 0.9.0 (2023-01-19)

--- a/reana_server/cli.py
+++ b/reana_server/cli.py
@@ -9,6 +9,7 @@
 """REANA Server command line tool."""
 
 import logging
+import signal
 
 import click
 from reana_commons.config import REANA_LOG_FORMAT, REANA_LOG_LEVEL
@@ -21,5 +22,12 @@ def start_scheduler():
     """Start a workflow execution scheduler process."""
     logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT, force=True)
     scheduler = WorkflowExecutionScheduler()
+
+    def stop_scheduler(signum, frame):
+        logging.info("Stopping scheduler...")
+        scheduler.should_stop = True
+
+    signal.signal(signal.SIGTERM, stop_scheduler)
+
     logging.info("Starting scheduler...")
     scheduler.run()


### PR DESCRIPTION
Handle SIGTERM in `start-scheduler` to gracefully stop consuming
the workflow submission queue.

Closes reanahub/reana-job-controller#347
