### PR TITLE
tests: allow execution of selected pytests only

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -85,6 +85,7 @@ check_sphinx () {
 check_pytest () {
     clean_old_db_container
     start_db_container
+    trap clean_old_db_container SIGINT SIGTERM SIGSEGV ERR
     python setup.py test
     stop_db_container
 }

--- a/tests/test_deleter.py
+++ b/tests/test_deleter.py
@@ -10,8 +10,6 @@ import pytest
 import pathlib
 import uuid
 
-import wdb
-
 from reana_server.deleter import Deleter, InOrOut
 from reana_commons.workspace import iterdir, is_directory, walk
 


### PR DESCRIPTION
Allows execution of selected pytests via PYTESTCMD environment variable. Example: `PYTESTARG="-k test_version" ./run-tests.sh --check-pytest`.

Cleans up running DB container when some pytest segfaults.

Removes forgotten `import wdb` statement that was breaking running tests when only the `.[tests]` installation target is called to set up the test prerequisites.

Closes reanahub/reana#755.