### PR TITLE
build(docker): non-editable submodules in "latest" mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,21 @@ ARG DEBUG=0
 RUN if [ "${DEBUG}" -gt 0 ]; then pip install --no-cache-dir -e ".[debug]"; else pip install --no-cache-dir .; fi;
 
 # Are we building with locally-checked-out shared modules?
-# hadolint ignore=SC2102
-RUN if test -e modules/reana-commons; then pip install --no-cache-dir -e modules/reana-commons[kubernetes,yadage,snakemake,cwl] --upgrade; fi
-RUN if test -e modules/reana-db; then pip install --no-cache-dir -e modules/reana-db --upgrade; fi
+# hadolint ignore=DL3013
+RUN if test -e modules/reana-commons; then \
+      if [ "${DEBUG}" -gt 0 ]; then \
+        pip install --no-cache-dir -e "modules/reana-commons[kubernetes,yadage,snakemake,cwl]" --upgrade; \
+      else \
+        pip install --no-cache-dir "modules/reana-commons[kubernetes,yadage,snakemake,cwl]" --upgrade; \
+      fi \
+    fi; \
+    if test -e modules/reana-db; then \
+      if [ "${DEBUG}" -gt 0 ]; then \
+        pip install --no-cache-dir -e "modules/reana-db" --upgrade; \
+      else \
+        pip install --no-cache-dir "modules/reana-db" --upgrade; \
+      fi \
+    fi
 
 # A quick fix to allow eduGAIN and social login users that wouldn't otherwise match Invenio username rules
 RUN sed -i 's|^username_regex = re.compile\(.*\)$|username_regex = re.compile("^\\S+$")|g' /usr/local/lib/python3.8/dist-packages/invenio_userprofiles/validators.py


### PR DESCRIPTION
When running development cluster in "latest" mode, install shared modules in non-editable mode. The editable mode should be reserved only for development clusters in "debug" mode with the live code reload.