### PR TITLE
deprecations setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update -y && \
       python3.8 \
       python3.8-dev \
       vim-tiny && \
-    pip install --no-cache-dir --upgrade pip setuptools && \
+    pip install --no-cache-dir --upgrade pip 'setuptools<71' && \
     pip install --no-cache-dir -r /code/requirements.txt && \
     apt-get remove -y \
       gcc \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -104,7 +104,7 @@ check_pytest () {
     clean_old_db_container
     start_db_container
     trap clean_old_db_container SIGINT SIGTERM SIGSEGV ERR
-    python setup.py test
+    pytest
     stop_db_container
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-[aliases]
-test = pytest
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,6 @@ from setuptools import find_packages, setup
 readme = open("README.md").read()
 history = open("CHANGELOG.md").read()
 
-tests_require = [
-    "pytest-reana>=0.95.0a2,<0.96.0",
-]
-
 extras_require = {
     "debug": [
         "wdb",
@@ -37,7 +33,9 @@ extras_require = {
         "sphinxcontrib-redoc>=1.5.1",
         "sphinx-click>=1.0.4",
     ],
-    "tests": tests_require,
+    "tests": [
+        "pytest-reana>=0.95.0a2,<0.96.0",
+    ],
 }
 
 extras_require["all"] = []
@@ -138,7 +136,6 @@ setup(
     python_requires=">=3.8",
     extras_require=extras_require,
     install_requires=install_requires,
-    tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,6 @@ for key, reqs in extras_require.items():
         continue
     extras_require["all"].extend(reqs)
 
-setup_requires = [
-    "pytest-runner>=2.7",
-]
-
 install_requires = [
     # These bounds on Flask/Werkzeug are needed because Werkzeug v2.1 removes `safe_str_cmp`,
     # which is needed by Flask-Login. This was fixed in Flask-Login v0.6.0 (see the issue
@@ -142,7 +138,6 @@ setup(
     python_requires=">=3.8",
     extras_require=extras_require,
     install_requires=install_requires,
-    setup_requires=setup_requires,
     tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
- **ci(pytest): invoke `pytest` directly instead of `setup.py test` (#696)**
- **build(python): remove deprecated `pytest-runner` (#696)**
- **build(python): use optional deps instead of `tests_require` (#696)**
- **build(python): add minimal `pyproject.toml` (#696)**
- **build(docker): pin setuptools to v70 (#696)**

Closes https://github.com/reanahub/reana/issues/814