### PR TITLE
feat(get_logs): add live_logs_enabled parameter (#705)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,6 +14,7 @@ The list of contributors in alphabetical order:
 - [Giuseppe Steduto](https://orcid.org/0009-0002-1258-8553)
 - [Harri Hirvonsalo](https://orcid.org/0000-0002-5503-510X)
 - [Jan Okraska](https://orcid.org/0000-0002-1416-3244)
+- [Jelizaveta Lemeševa](https://orcid.org/0009-0003-6606-9270)
 - [Leticia Wanderley](https://orcid.org/0000-0003-4649-6630)
 - [Marco Donadoni](https://orcid.org/0000-0003-2922-5505)
 - [Marco Vidal](https://orcid.org/0000-0002-9363-4971)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2637,6 +2637,7 @@
             "description": "Request succeeded. Info about a workflow, including the status is returned.",
             "examples": {
               "application/json": {
+                "live_logs_enabled": true,
                 "logs": "<Workflow engine log output>",
                 "user": "00000000-0000-0000-0000-000000000000",
                 "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
@@ -2645,6 +2646,9 @@
             },
             "schema": {
               "properties": {
+                "live_logs_enabled": {
+                  "type": "boolean"
+                },
                 "logs": {
                   "type": "string"
                 },

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -883,13 +883,16 @@ def get_workflow_logs(workflow_id_or_name, user, **kwargs):  # noqa
                 type: string
               user:
                 type: string
+              live_logs_enabled:
+                type: boolean
           examples:
             application/json:
               {
                 "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
                 "workflow_name": "mytest.1",
                 "logs": "<Workflow engine log output>",
-                "user": "00000000-0000-0000-0000-000000000000"
+                "user": "00000000-0000-0000-0000-000000000000",
+                "live_logs_enabled": true
               }
         400:
           description: >-


### PR DESCRIPTION
Related to https://github.com/reanahub/reana/issues/824

Add `live_logs_enabled` parameter to `get_workflow_logs` API endpoint.