### PR TITLE
feat(rest): add K8s resource requests & limits to info endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2022, 2024 CERN.
+# Copyright (C) 2020, 2021, 2022, 2024, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -129,6 +129,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
+          pip install --upgrade pip 'setuptools<71' py
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
@@ -147,6 +148,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
+          pip install --upgrade pip 'setuptools<71' py
           pip install twine wheel
           pip install -e .[all]
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -366,13 +366,37 @@
                   "title": "Default workspace",
                   "value": "/usr/share"
                 },
+                "kubernetes_cpu_limit": {
+                  "title": "Default CPU limit for Kubernetes jobs",
+                  "value": "2"
+                },
+                "kubernetes_cpu_request": {
+                  "title": "Default CPU request for Kubernetes jobs",
+                  "value": "1"
+                },
+                "kubernetes_max_cpu_limit": {
+                  "title": "Maximum allowed CPU limit for Kubernetes jobs",
+                  "value": "4"
+                },
+                "kubernetes_max_cpu_request": {
+                  "title": "Maximum allowed CPU request for Kubernetes jobs",
+                  "value": "2"
+                },
                 "kubernetes_max_memory_limit": {
                   "title": "Maximum allowed memory limit for Kubernetes jobs",
                   "value": "10Gi"
                 },
+                "kubernetes_max_memory_request": {
+                  "title": "Maximum allowed memory request for Kubernetes jobs",
+                  "value": "5Gi"
+                },
                 "kubernetes_memory_limit": {
                   "title": "Default memory limit for Kubernetes jobs",
                   "value": "3Gi"
+                },
+                "kubernetes_memory_request": {
+                  "title": "Default memory request for Kubernetes jobs",
+                  "value": "1Gi"
                 },
                 "maximum_kubernetes_jobs_timeout": {
                   "title": "Maximum timeout for Kubernetes jobs",
@@ -408,6 +432,30 @@
                   },
                   "type": "object"
                 },
+                "default_kubernetes_cpu_limit": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
+                "default_kubernetes_cpu_request": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
                 "default_kubernetes_jobs_timeout": {
                   "properties": {
                     "title": {
@@ -425,7 +473,20 @@
                       "type": "string"
                     },
                     "value": {
+                      "type": "string",
+                      "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
+                "default_kubernetes_memory_request": {
+                  "properties": {
+                    "title": {
                       "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "x-nullable": true
                     }
                   },
                   "type": "object"
@@ -441,7 +502,43 @@
                   },
                   "type": "object"
                 },
+                "kubernetes_max_cpu_limit": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
+                "kubernetes_max_cpu_request": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
                 "kubernetes_max_memory_limit": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
+                "kubernetes_max_memory_request": {
                   "properties": {
                     "title": {
                       "type": "string"

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -58,8 +58,38 @@ REANA_SSO_LOGIN_PROVIDERS_SECRETS = json.loads(
     os.getenv("LOGIN_PROVIDERS_SECRETS", "{}")
 )
 
+REANA_KUBERNETES_JOBS_CPU_REQUEST = os.getenv("REANA_KUBERNETES_JOBS_CPU_REQUEST")
+"""Default cpu request for user job containers."""
+
+REANA_KUBERNETES_JOBS_CPU_LIMIT = os.getenv("REANA_KUBERNETES_JOBS_CPU_LIMIT")
+"""Default cpu limit for user job containers."""
+
+REANA_KUBERNETES_JOBS_MEMORY_REQUEST = os.getenv("REANA_KUBERNETES_JOBS_MEMORY_REQUEST")
+"""Default memory request for user job containers."""
+
 REANA_KUBERNETES_JOBS_MEMORY_LIMIT = os.getenv("REANA_KUBERNETES_JOBS_MEMORY_LIMIT")
-"""Maximum memory limit for user job containers for workflow complexity estimation."""
+"""Default memory limit for user job containers."""
+
+REANA_KUBERNETES_JOBS_MAX_USER_CPU_REQUEST = os.getenv(
+    "REANA_KUBERNETES_JOBS_MAX_USER_CPU_REQUEST"
+)
+"""Maximum cpu request that users can assign to their job containers."""
+
+REANA_KUBERNETES_JOBS_MAX_USER_CPU_LIMIT = os.getenv(
+    "REANA_KUBERNETES_JOBS_MAX_USER_CPU_LIMIT"
+)
+"""Maximum cpu limit that users can assign to their job containers."""
+
+REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST = os.getenv(
+    "REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST"
+)
+"""Maximum memory request that users can assign to their job containers."""
+
+REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT = os.getenv(
+    "REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT"
+)
+"""Maximum memory limit that users can assign to their job containers."""
+
 
 REANA_KUBERNETES_JOBS_MEMORY_LIMIT_IN_BYTES = (
     kubernetes_memory_to_bytes(REANA_KUBERNETES_JOBS_MEMORY_LIMIT)
@@ -67,11 +97,6 @@ REANA_KUBERNETES_JOBS_MEMORY_LIMIT_IN_BYTES = (
     else 0
 )
 """Maximum memory limit for user job containers in bytes."""
-
-REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT = os.getenv(
-    "REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT"
-)
-"""Maximum memory limit that users can assign to their job containers."""
 
 REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT_IN_BYTES = (
     kubernetes_memory_to_bytes(REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT)

--- a/reana_server/rest/info.py
+++ b/reana_server/rest/info.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2021, 2022 CERN.
+# Copyright (C) 2021, 2022, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -19,7 +19,13 @@ from reana_commons.config import DEFAULT_WORKSPACE_PATH, WORKSPACE_PATHS
 from reana_server.config import (
     SUPPORTED_COMPUTE_BACKENDS,
     WORKSPACE_RETENTION_PERIOD,
+    REANA_KUBERNETES_JOBS_MAX_USER_CPU_REQUEST,
+    REANA_KUBERNETES_JOBS_MAX_USER_CPU_LIMIT,
+    REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST,
     REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT,
+    REANA_KUBERNETES_JOBS_CPU_REQUEST,
+    REANA_KUBERNETES_JOBS_CPU_LIMIT,
+    REANA_KUBERNETES_JOBS_MEMORY_REQUEST,
     REANA_KUBERNETES_JOBS_MEMORY_LIMIT,
     REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT,
     REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT,
@@ -71,12 +77,37 @@ def info(user, **kwargs):  # noqa
                   value:
                     type: string
                 type: object
+              default_kubernetes_cpu_request:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                    x-nullable: true
+                type: object
+              default_kubernetes_cpu_limit:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                    x-nullable: true
+                type: object
+              default_kubernetes_memory_request:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                    x-nullable: true
+                type: object
               default_kubernetes_memory_limit:
                 properties:
                   title:
                     type: string
                   value:
                     type: string
+                    x-nullable: true
                 type: object
               default_workspace:
                 properties:
@@ -84,6 +115,30 @@ def info(user, **kwargs):  # noqa
                     type: string
                   value:
                     type: string
+                type: object
+              kubernetes_max_cpu_request:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                    x-nullable: true
+                type: object
+              kubernetes_max_cpu_limit:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                    x-nullable: true
+                type: object
+              kubernetes_max_memory_request:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                    x-nullable: true
                 type: object
               kubernetes_max_memory_limit:
                 properties:
@@ -145,9 +200,33 @@ def info(user, **kwargs):  # noqa
                         "slurmcern"
                     ]
                 },
+                "kubernetes_cpu_request": {
+                    "title": "Default CPU request for Kubernetes jobs",
+                    "value": "1"
+                },
+                "kubernetes_cpu_limit": {
+                    "title": "Default CPU limit for Kubernetes jobs",
+                    "value": "2"
+                },
+                "kubernetes_memory_request": {
+                    "title": "Default memory request for Kubernetes jobs",
+                    "value": "1Gi"
+                },
                 "kubernetes_memory_limit": {
                     "title": "Default memory limit for Kubernetes jobs",
                     "value": "3Gi"
+                },
+                "kubernetes_max_cpu_request": {
+                    "title": "Maximum allowed CPU request for Kubernetes jobs",
+                    "value": "2"
+                },
+                "kubernetes_max_cpu_limit": {
+                    "title": "Maximum allowed CPU limit for Kubernetes jobs",
+                    "value": "4"
+                },
+                "kubernetes_max_memory_request": {
+                    "title": "Maximum allowed memory request for Kubernetes jobs",
+                    "value": "5Gi"
                 },
                 "kubernetes_max_memory_limit": {
                     "title": "Maximum allowed memory limit for Kubernetes jobs",
@@ -193,9 +272,33 @@ def info(user, **kwargs):  # noqa
                 title="List of supported compute backends",
                 value=SUPPORTED_COMPUTE_BACKENDS,
             ),
+            default_kubernetes_cpu_request=dict(
+                title="Default CPU request for Kubernetes jobs",
+                value=REANA_KUBERNETES_JOBS_CPU_REQUEST,
+            ),
+            default_kubernetes_cpu_limit=dict(
+                title="Default CPU limit for Kubernetes jobs",
+                value=REANA_KUBERNETES_JOBS_CPU_LIMIT,
+            ),
+            default_kubernetes_memory_request=dict(
+                title="Default memory request for Kubernetes jobs",
+                value=REANA_KUBERNETES_JOBS_MEMORY_REQUEST,
+            ),
             default_kubernetes_memory_limit=dict(
                 title="Default memory limit for Kubernetes jobs",
                 value=REANA_KUBERNETES_JOBS_MEMORY_LIMIT,
+            ),
+            kubernetes_max_cpu_request=dict(
+                title="Maximum allowed CPU request for Kubernetes jobs",
+                value=REANA_KUBERNETES_JOBS_MAX_USER_CPU_REQUEST,
+            ),
+            kubernetes_max_cpu_limit=dict(
+                title="Maximum allowed CPU limit for Kubernetes jobs",
+                value=REANA_KUBERNETES_JOBS_MAX_USER_CPU_LIMIT,
+            ),
+            kubernetes_max_memory_request=dict(
+                title="Maximum allowed memory request for Kubernetes jobs",
+                value=REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST,
             ),
             kubernetes_max_memory_limit=dict(
                 title="Maximum allowed memory limit for Kubernetes jobs",
@@ -252,7 +355,13 @@ class InfoSchema(Schema):
     workspaces_available = fields.Nested(ListStringInfoValue)
     default_workspace = fields.Nested(StringInfoValue)
     compute_backends = fields.Nested(ListStringInfoValue)
+    default_kubernetes_cpu_request = fields.Nested(StringNullableInfoValue)
+    default_kubernetes_cpu_limit = fields.Nested(StringNullableInfoValue)
+    default_kubernetes_memory_request = fields.Nested(StringNullableInfoValue)
     default_kubernetes_memory_limit = fields.Nested(StringInfoValue)
+    kubernetes_max_cpu_request = fields.Nested(StringNullableInfoValue)
+    kubernetes_max_cpu_limit = fields.Nested(StringNullableInfoValue)
+    kubernetes_max_memory_request = fields.Nested(StringNullableInfoValue)
     kubernetes_max_memory_limit = fields.Nested(StringNullableInfoValue)
     maximum_workspace_retention_period = fields.Nested(StringNullableInfoValue)
     default_kubernetes_jobs_timeout = fields.Nested(StringInfoValue)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,14 +14,14 @@ async-timeout==4.0.3      # via redis
 attrs==23.2.0             # via jsonschema
 babel==2.14.0             # via flask-babelex, invenio-i18n
 backcall==0.2.0           # via ipython
-backports-zoneinfo[tzdata]==0.2.1  # via celery, kombu
+backports-zoneinfo[tzdata]==0.2.1  # via kombu
 bagit==1.8.1              # via cwltool
 billiard==3.6.4.0         # via celery
 blinker==1.7.0            # via flask-mail, flask-principal, invenio-base, invenio-oauthclient
 bracex==2.4               # via wcmatch
 bravado==10.3.2           # via reana-commons
 bravado-core==6.1.0       # via bravado, reana-commons
-cachecontrol[filecache]==0.13.1  # via cachecontrol, schema-salad
+cachecontrol[filecache]==0.13.1  # via schema-salad
 cachelib==0.9.0           # via flask-caching, flask-oauthlib, invenio-oauth2server
 cachetools==5.3.3         # via google-auth
 celery==5.2.7             # via flask-celeryext, invenio-celery
@@ -159,8 +159,8 @@ pytz==2024.1              # via babel, bravado-core, celery
 pywebpack==1.2.0          # via flask-webpackext
 pyyaml==6.0.1             # via bravado, bravado-core, kubernetes, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas, yte
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons[cwl,kubernetes,snakemake,yadage]==0.9.9	# via reana-db, reana-server (setup.py)
-reana-db==0.9.5	# via reana-server (setup.py)
+reana-commons[cwl,kubernetes,snakemake,yadage]==0.9.11  # via reana-db, reana-server (setup.py)
+reana-db==0.9.5           # via reana-server (setup.py)
 redis==5.0.2              # via invenio-accounts, invenio-celery
 requests[security]==2.25.0  # via bravado, bravado-core, cachecontrol, cwltool, kubernetes, packtivity, reana-server (setup.py), requests-oauthlib, schema-salad, snakemake, yadage, yadage-schemas
 requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient, kubernetes
@@ -180,7 +180,7 @@ snakemake==7.32.4         # via reana-commons
 speaklater==1.3           # via flask-babelex
 sqlalchemy==1.3.24        # via alembic, flask-alembic, flask-sqlalchemy, invenio-db, reana-db, sqlalchemy-continuum, sqlalchemy-utils, wtforms-alchemy
 sqlalchemy-continuum==1.3.15  # via invenio-db
-sqlalchemy-utils[encrypted]==0.38.3  # via invenio-db, reana-db, sqlalchemy-continuum, sqlalchemy-utils, wtforms-alchemy
+sqlalchemy-utils[encrypted]==0.38.3  # via invenio-db, reana-db, sqlalchemy-continuum, wtforms-alchemy
 stack-data==0.6.3         # via ipython
 stopit==1.1.2             # via snakemake
 strict-rfc3339==0.7       # via jsonschema
@@ -191,7 +191,7 @@ throttler==1.2.2          # via snakemake
 toposort==1.10            # via snakemake
 traitlets==5.14.1         # via ipython, jupyter-core, matplotlib-inline, nbformat
 typing-extensions==4.10.0  # via alembic, bravado, cwltool, ipython, kombu, swagger-spec-validator
-tzdata==2024.1            # via backports-zoneinfo, celery
+tzdata==2024.1            # via backports-zoneinfo
 ua-parser==0.18.0         # via invenio-accounts
 uritools==4.0.2           # via invenio-app, invenio-oauthclient
 urllib3==1.26.18          # via kubernetes, requests

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -60,7 +60,7 @@ install_requires = [
     "flask-celeryext<0.5.0",
     "gitpython>=3.1",
     "marshmallow>2.13.0,<=2.20.1",
-    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.9.9,<0.10.0",
+    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.9.11,<0.10.0",
     "reana-db>=0.9.5,<0.10.0",
     "requests==2.25.0",
     "tablib>=0.12.1",


### PR DESCRIPTION
Validate CPU and memory requests/limits for job pods in each step. Expose limits and defaults in `info` endpoint.

Closes reanahub/reana#883