### PR TITLE
fix: typo in flake8 files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ exclude =
     dist
     docs
     coverage.xml
-    reana_job_controller.egg-info
+    reana_server.egg-info
     .*/
     env/
     .git


### PR DESCRIPTION
This PR contains the following modifications:
```
- AI Prompt: "There is a minor typo in the .flake8 file likely due to copy-pasting. Specifically, the exclusion list mistakenly includes reana_job_controller.egg-info, whereas it should reference the respective repository's actual name instead of reana_job_controller. 
Replace reana_job_controller.egg-info with the correct repository-specific .egg-info name
It should replace dashes with undrescores"
```
Do not add any new files" (Single file: Yes)

Generated by Morph (https://codemorph.dev/)