### PR TITLE
feat(validation): add workflow image vetting

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -521,6 +521,14 @@
                     "yadage"
                   ]
                 },
+                "vetted_container_images_allowlist": {
+                  "title": "List of container images allowed in user workflows",
+                  "value": []
+                },
+                "vetted_container_images_enabled": {
+                  "title": "Whether container image vetting is enabled",
+                  "value": "False"
+                },
                 "workspaces_available": {
                   "title": "List of available workspaces",
                   "value": [
@@ -806,6 +814,31 @@
                         "type": "string"
                       },
                       "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "vetted_container_images_allowlist": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "vetted_container_images_enabled": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "boolean"
                     }
                   },
                   "type": "object"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -553,6 +553,14 @@
                     "yadage"
                   ]
                 },
+                "vetted_container_images_allowlist": {
+                  "title": "List of vetted container images allowed in user workflows",
+                  "value": []
+                },
+                "vetted_container_images_enabled": {
+                  "title": "Vetted container images required for user workflows",
+                  "value": false
+                },
                 "workspaces_available": {
                   "title": "List of available workspaces",
                   "value": [
@@ -933,6 +941,31 @@
                         "type": "string"
                       },
                       "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "vetted_container_images_allowlist": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "vetted_container_images_enabled": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "boolean"
                     }
                   },
                   "type": "object"

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -466,6 +466,11 @@ REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS_CUSTOM_ALLOWED = (
 )
 """Whether users can set custom interactive session images or not."""
 
+REANA_VETTED_CONTAINER_IMAGES = json.loads(
+    os.getenv("REANA_VETTED_CONTAINER_IMAGES", "{}")
+)
+"""Container images that users are allowed to use in their workflows."""
+
 # Kubernetes jobs timeout
 # ==================
 REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT = os.getenv("REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT")

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -616,6 +616,14 @@ REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS_CUSTOM_ALLOWED = (
 )
 """Whether users can set custom interactive session images or not."""
 
+REANA_VETTED_CONTAINER_IMAGES = json.loads(
+    os.getenv(
+        "REANA_VETTED_CONTAINER_IMAGES",
+        '{"enabled": false, "allowlist": []}',
+    )
+)
+"""Container images that users are allowed to use in their workflows."""
+
 # Kubernetes jobs timeout
 # ==================
 REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT = os.getenv("REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT")

--- a/reana_server/rest/info.py
+++ b/reana_server/rest/info.py
@@ -27,6 +27,7 @@ from reana_server.config import (
     REANA_INTERACTIVE_SESSION_MAX_INACTIVITY_PERIOD,
     REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS,
     REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS_CUSTOM_ALLOWED,
+    REANA_VETTED_CONTAINER_IMAGES,
     DASK_ENABLED,
     DASK_AUTOSCALER_ENABLED,
     REANA_DASK_CLUSTER_DEFAULT_NUMBER_OF_WORKERS,
@@ -145,6 +146,22 @@ def info(user, **kwargs):  # noqa
                     x-nullable: true
                 type: object
               workspaces_available:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              vetted_container_images_enabled:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: boolean
+                type: object
+              vetted_container_images_allowlist:
                 properties:
                   title:
                     type: string
@@ -318,6 +335,14 @@ def info(user, **kwargs):  # noqa
                     "title": "Whether users are allowed to spawn custom interactive session images",
                     "value": "False"
                 },
+                "vetted_container_images_enabled": {
+                    "title": "Whether container image vetting is enabled",
+                    "value": "False"
+                },
+                "vetted_container_images_allowlist": {
+                    "title": "List of container images allowed in user workflows",
+                    "value": []
+                },
                 "supported_workflow_engines": {
                     "title": "List of supported workflow engines",
                     "value": [
@@ -452,6 +477,14 @@ def info(user, **kwargs):  # noqa
                     ]
                 ],
             ),
+            vetted_container_images_enabled=dict(
+                title="Whether container image vetting is enabled",
+                value=REANA_VETTED_CONTAINER_IMAGES["enabled"],
+            ),
+            vetted_container_images_allowlist=dict(
+                title="List of container images allowed in user workflows",
+                value=REANA_VETTED_CONTAINER_IMAGES["allowlist"],
+            ),
             supported_workflow_engines=dict(
                 title="List of supported workflow engines",
                 value=["cwl", "serial", "snakemake", "yadage"],
@@ -534,6 +567,13 @@ class StringInfoValue(Schema):
     value = fields.String(allow_none=False)
 
 
+class BooleanInfoValue(Schema):
+    """Schema for a value represented by a string."""
+
+    title = fields.String()
+    value = fields.Boolean(allow_none=False)
+
+
 class StringNullableInfoValue(Schema):
     """Schema for a value represented by a nullable string."""
 
@@ -558,6 +598,8 @@ class InfoSchema(Schema):
     kubernetes_max_memory_limit = fields.Nested(StringInfoValue)
     interactive_session_recommended_jupyter_images = fields.Nested(ListStringInfoValue)
     interactive_sessions_custom_image_allowed = fields.Nested(StringInfoValue)
+    vetted_container_images_enabled = fields.Nested(BooleanInfoValue)
+    vetted_container_images_allowlist = fields.Nested(ListStringInfoValue)
     supported_workflow_engines = fields.Nested(ListStringInfoValue)
     cwl_engine_tool = fields.Nested(StringInfoValue)
     cwl_engine_version = fields.Nested(StringInfoValue)

--- a/reana_server/rest/info.py
+++ b/reana_server/rest/info.py
@@ -34,6 +34,7 @@ from reana_server.config import (
     REANA_INTERACTIVE_SESSION_MAX_INACTIVITY_PERIOD,
     REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS,
     REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS_CUSTOM_ALLOWED,
+    REANA_VETTED_CONTAINER_IMAGES,
     DASK_ENABLED,
     DASK_AUTOSCALER_ENABLED,
     REANA_DASK_CLUSTER_DEFAULT_NUMBER_OF_WORKERS,
@@ -209,6 +210,22 @@ def info(user, **kwargs):  # noqa
                     x-nullable: true
                 type: object
               workspaces_available:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              vetted_container_images_enabled:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: boolean
+                type: object
+              vetted_container_images_allowlist:
                 properties:
                   title:
                     type: string
@@ -417,6 +434,14 @@ def info(user, **kwargs):  # noqa
                     "title": "Whether users are allowed to spawn custom interactive session images",
                     "value": "False"
                 },
+                "vetted_container_images_enabled": {
+                    "title": "Vetted container images required for user workflows",
+                    "value": false
+                },
+                "vetted_container_images_allowlist": {
+                    "title": "List of vetted container images allowed in user workflows",
+                    "value": []
+                },
                 "supported_workflow_engines": {
                     "title": "List of supported workflow engines",
                     "value": [
@@ -583,6 +608,14 @@ def info(user, **kwargs):  # noqa
                     ]
                 ],
             ),
+            vetted_container_images_enabled=dict(
+                title="Vetted container images required for user workflows",
+                value=REANA_VETTED_CONTAINER_IMAGES["enabled"],
+            ),
+            vetted_container_images_allowlist=dict(
+                title="List of vetted container images allowed in user workflows",
+                value=REANA_VETTED_CONTAINER_IMAGES["allowlist"],
+            ),
             supported_workflow_engines=dict(
                 title="List of supported workflow engines",
                 value=["cwl", "serial", "snakemake", "yadage"],
@@ -669,6 +702,13 @@ class StringInfoValue(Schema):
     value = fields.String(allow_none=False)
 
 
+class BooleanInfoValue(Schema):
+    """Schema for a value represented by a string."""
+
+    title = fields.String()
+    value = fields.Boolean(allow_none=False)
+
+
 class StringNullableInfoValue(Schema):
     """Schema for a value represented by a nullable string."""
 
@@ -707,6 +747,8 @@ class InfoSchema(Schema):
     kubernetes_max_memory_limit = fields.Nested(StringInfoValue)
     interactive_session_recommended_jupyter_images = fields.Nested(ListStringInfoValue)
     interactive_sessions_custom_image_allowed = fields.Nested(StringInfoValue)
+    vetted_container_images_enabled = fields.Nested(BooleanInfoValue)
+    vetted_container_images_allowlist = fields.Nested(ListStringInfoValue)
     supported_workflow_engines = fields.Nested(ListStringInfoValue)
     cwl_engine_tool = fields.Nested(StringInfoValue)
     cwl_engine_version = fields.Nested(StringInfoValue)

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -48,6 +48,7 @@ from reana_server.utils import (
     publish_workflow_submission,
 )
 from reana_server.validation import (
+    validate_images,
     validate_inputs,
     validate_workflow,
     validate_workspace_path,
@@ -572,6 +573,8 @@ def create_workflow(user):  # noqa
 
         validate_inputs(reana_spec_file)
 
+        validate_images(reana_spec_file)
+
         validate_dask_limits(reana_spec_file)
 
         retention_days = reana_spec_file.get("workspace", {}).get("retention_days")
@@ -608,6 +611,8 @@ def create_workflow(user):  # noqa
                     reana_yaml_path, workflow.workspace_path
                 )
                 Session.commit()
+
+            validate_images(workflow.reana_specification)
 
             parameters = request.json
             publish_workflow_submission(workflow, user.id_, parameters)

--- a/reana_server/validation.py
+++ b/reana_server/validation.py
@@ -13,6 +13,7 @@ import pathlib
 from typing import Dict, List
 
 from reana_commons.config import WORKSPACE_PATHS
+from reana_commons.validation.images import extract_images
 from reana_commons.errors import REANAValidationError
 from reana_commons.validation.compute_backends import build_compute_backends_validator
 from reana_commons.validation.operational_options import validate_operational_options
@@ -31,8 +32,8 @@ from reana_server.config import (
     REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_MEMORY,
     REANA_DASK_CLUSTER_DEFAULT_SINGLE_WORKER_THREADS,
     REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_THREADS,
+    REANA_VETTED_CONTAINER_IMAGES,
 )
-from reana_server import utils
 
 
 def validate_parameters(reana_yaml: Dict) -> None:
@@ -112,11 +113,27 @@ def validate_inputs(reana_yaml: Dict) -> None:
             raise REANAValidationError(f"Input path declared multiple times: {path}")
         unique_paths.add(path)
 
+    from reana_server import utils
+
     for x, y in itertools.permutations(paths, r=2):
         if utils.is_relative_to(x, y):
             raise REANAValidationError(
                 f"Duplicate input paths '{y}' and '{x}' found. Please deduplicate inputs first."
             )
+
+
+def validate_images(reana_yaml: Dict) -> None:
+    """Check whether the images used in the workflow are allowed or not.
+
+    :param reana_yaml: REANA specification.
+    """
+    if not REANA_VETTED_CONTAINER_IMAGES["enabled"]:
+        return
+
+    allowed_images = REANA_VETTED_CONTAINER_IMAGES["allowlist"]
+    for image in extract_images(reana_yaml):
+        if image and image not in allowed_images:
+            raise REANAValidationError(f"Image not allowed: {image}")
 
 
 def validate_workflow(reana_yaml: Dict, input_parameters: Dict) -> Dict:
@@ -137,6 +154,7 @@ def validate_workflow(reana_yaml: Dict, input_parameters: Dict) -> Dict:
     validate_compute_backends(reana_yaml)
     validate_workspace_path(reana_yaml)
     validate_inputs(reana_yaml)
+    validate_images(reana_yaml)
     return reana_yaml_warnings
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -171,7 +171,7 @@ pytz==2024.1              # via bravado-core, flask-babel, invenio-i18n
 pywebpack==2.2.1          # via flask-webpackext
 pyyaml==6.0.3             # via bravado, bravado-core, conda-inject, kubernetes, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas, yte
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons[cwl,kubernetes,snakemake,yadage]==0.95.0a17  # via reana-db, reana-server (setup.py)
+reana-commons[cwl,kubernetes,snakemake,yadage]==0.95.0a19  # via reana-db, reana-server (setup.py)
 reana-db==0.95.0a10       # via reana-server (setup.py)
 redis==7.4.0              # via invenio-celery
 referencing==0.37.0       # via snakemake

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extras_require = {
     "tests": [
         "apispec[yaml]>=3.0",
         "apispec-webframeworks",
-        "reana-commons[kubernetes,yadage,snakemake,cwl,tests]>=0.95.0a17,<0.96.0",
+        "reana-commons[kubernetes,yadage,snakemake,cwl,tests]>=0.95.0a19,<0.96.0",
         "reana-db[tests]>=0.95.0a10,<0.96.0",
     ],
 }
@@ -51,7 +51,7 @@ install_requires = [
     "Flask>=3.0.0,<4.0.0",
     "gitpython>=3.1",
     "marshmallow>=3.5.0,<4.0.0",
-    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.95.0a17,<0.96.0",
+    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.95.0a19,<0.96.0",
     "reana-db>=0.95.0a10,<0.96.0",
     "requests>=2.25.0",
     "tablib>=0.12.1",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -12,7 +12,11 @@ from contextlib import nullcontext as does_not_raise
 
 from reana_commons.errors import REANAValidationError
 
-from reana_server.validation import validate_inputs, validate_retention_rule
+from reana_server.validation import (
+    validate_inputs,
+    validate_images,
+    validate_retention_rule,
+)
 
 
 @pytest.mark.parametrize(
@@ -28,6 +32,239 @@ from reana_server.validation import validate_inputs, validate_retention_rule
 def test_validate_inputs(paths, error):
     with pytest.raises(REANAValidationError, match=error):
         validate_inputs({"inputs": {"directories": paths}})
+
+
+ALLOWLIST = {
+    "enabled": True,
+    "allowlist": ["docker.io/reanahub/reana-env-root6:6.18.04"],
+}
+DISALLOWED_IMAGE = "docker.io/bitcoin-miner:1.2.3"
+ALLOWED_IMAGE = "docker.io/reanahub/reana-env-root6:6.18.04"
+
+
+def serial_workflow(*images):
+    return {
+        "type": "serial",
+        "specification": {"steps": [{"environment": img} for img in images]},
+    }
+
+
+def snakemake_workflow(*images):
+    return {
+        "type": "snakemake",
+        "specification": {"steps": [{"environment": img} for img in images]},
+    }
+
+
+@pytest.mark.parametrize(
+    "config, workflow, error",
+    [
+        pytest.param(
+            {"enabled": False, "allowlist": []},
+            serial_workflow(DISALLOWED_IMAGE),
+            does_not_raise(),
+            id="disabled-anything-goes",
+        ),
+        # Serial: explicit environment field
+        pytest.param(
+            ALLOWLIST,
+            serial_workflow(ALLOWED_IMAGE),
+            does_not_raise(),
+            id="serial-allowed",
+        ),
+        pytest.param(
+            ALLOWLIST,
+            serial_workflow(DISALLOWED_IMAGE),
+            pytest.raises(REANAValidationError, match="not allowed"),
+            id="serial-disallowed",
+        ),
+        pytest.param(
+            ALLOWLIST,
+            serial_workflow(ALLOWED_IMAGE, DISALLOWED_IMAGE),
+            pytest.raises(REANAValidationError, match="not allowed"),
+            id="serial-mixed",
+        ),
+        # Snakemake: rules with explicit container directive
+        pytest.param(
+            ALLOWLIST,
+            snakemake_workflow(ALLOWED_IMAGE),
+            does_not_raise(),
+            id="snakemake-explicit-container-allowed",
+        ),
+        pytest.param(
+            ALLOWLIST,
+            snakemake_workflow(DISALLOWED_IMAGE),
+            pytest.raises(REANAValidationError, match="not allowed"),
+            id="snakemake-explicit-container-disallowed",
+        ),
+        # Snakemake: rule without container directive produces "" from the loader;
+        # the runtime uses the admin-controlled default image, so it is not vetted.
+        pytest.param(
+            {"enabled": True, "allowlist": []},
+            snakemake_workflow(""),
+            does_not_raise(),
+            id="snakemake-no-container-uses-admin-default",
+        ),
+        pytest.param(
+            ALLOWLIST,
+            snakemake_workflow(ALLOWED_IMAGE, ""),
+            does_not_raise(),
+            id="snakemake-mixed-with-and-without-container",
+        ),
+        pytest.param(
+            ALLOWLIST,
+            snakemake_workflow(DISALLOWED_IMAGE, ""),
+            pytest.raises(REANAValidationError, match="not allowed"),
+            id="snakemake-mixed-disallowed-explicit-plus-no-container",
+        ),
+        # CWL: images come from requirements[].dockerPull, not steps
+        pytest.param(
+            ALLOWLIST,
+            {
+                "type": "cwl",
+                "specification": {
+                    "$graph": [
+                        {
+                            "class": "Workflow",
+                            "requirements": [
+                                {
+                                    "class": "DockerRequirement",
+                                    "dockerPull": ALLOWED_IMAGE,
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+            does_not_raise(),
+            id="cwl-allowed",
+        ),
+        pytest.param(
+            ALLOWLIST,
+            {
+                "type": "cwl",
+                "specification": {
+                    "$graph": [
+                        {
+                            "class": "Workflow",
+                            "requirements": [
+                                {
+                                    "class": "DockerRequirement",
+                                    "dockerPull": DISALLOWED_IMAGE,
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+            pytest.raises(REANAValidationError, match="not allowed"),
+            id="cwl-disallowed",
+        ),
+        pytest.param(
+            {"enabled": True, "allowlist": []},
+            {
+                "type": "cwl",
+                "specification": {
+                    "$graph": [{"class": "Workflow", "requirements": []}]
+                },
+            },
+            does_not_raise(),
+            id="cwl-no-docker-requirement",
+        ),
+        # Yadage: images come from nested stages, not a flat steps list
+        pytest.param(
+            ALLOWLIST,
+            {
+                "type": "yadage",
+                "specification": {
+                    "stages": [
+                        {
+                            "name": "stage1",
+                            "scheduler": {
+                                "step": {
+                                    "environment": {
+                                        "environment_type": "docker-encapsulated",
+                                        "image": "docker.io/reanahub/reana-env-root6",
+                                        "imagetag": "6.18.04",
+                                    }
+                                }
+                            },
+                        }
+                    ]
+                },
+            },
+            does_not_raise(),
+            id="yadage-allowed",
+        ),
+        pytest.param(
+            ALLOWLIST,
+            {
+                "type": "yadage",
+                "specification": {
+                    "stages": [
+                        {
+                            "name": "stage1",
+                            "scheduler": {
+                                "step": {
+                                    "environment": {
+                                        "environment_type": "docker-encapsulated",
+                                        "image": "docker.io/bitcoin-miner",
+                                        "imagetag": "1.2.3",
+                                    }
+                                }
+                            },
+                        }
+                    ]
+                },
+            },
+            pytest.raises(REANAValidationError, match="not allowed"),
+            id="yadage-disallowed",
+        ),
+        pytest.param(
+            ALLOWLIST,
+            {
+                "type": "yadage",
+                "specification": {
+                    "stages": [
+                        {
+                            "name": "outer",
+                            "scheduler": {
+                                "workflow": {
+                                    "stages": [
+                                        {
+                                            "name": "inner",
+                                            "scheduler": {
+                                                "step": {
+                                                    "environment": {
+                                                        "environment_type": "docker-encapsulated",
+                                                        "image": "docker.io/bitcoin-miner",
+                                                        "imagetag": "1.2.3",
+                                                    }
+                                                }
+                                            },
+                                        }
+                                    ]
+                                }
+                            },
+                        }
+                    ]
+                },
+            },
+            pytest.raises(REANAValidationError, match="not allowed"),
+            id="yadage-nested-stage-disallowed",
+        ),
+        pytest.param(
+            {"enabled": True, "allowlist": []},
+            {"type": "yadage", "specification": {"stages": []}},
+            does_not_raise(),
+            id="yadage-no-stages",
+        ),
+    ],
+)
+def test_validate_images(config, workflow, error):
+    with patch("reana_server.validation.REANA_VETTED_CONTAINER_IMAGES", config):
+        with error:
+            validate_images({"workflow": workflow})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Extend `validate_workflow` to check that all images used in workflows are authorized. Such authorized images are specified via the `vetted_container_images` Helm value. Also add details of container vetting to the `info` API endpoint.

Closes #728 