### PR TITLE
feat(auth): add OpenID authentication endpoints and configuration

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,6 +7,23 @@
   "paths": {
     "/account/settings/linkedaccounts/": {},
     "/account/settings/linkedaccounts/static/{filename}": {},
+    "/api/.well-known/openid-configuration": {
+      "get": {
+        "description": "Returns the OpenID configuration for the REANA server.",
+        "responses": {
+          "200": {
+            "description": "OpenID configuration"
+          },
+          "404": {
+            "description": "OpenID configuration not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get OpenID Configuration"
+      }
+    },
     "/api/config": {
       "get": {
         "description": "This resource provides configuration needed by Reana-UI.",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10,9 +10,30 @@
     "/api/.well-known/openid-configuration": {
       "get": {
         "description": "Returns the OpenID configuration for the REANA server.",
+        "operationId": "get_openid_configuration",
+        "produces": [
+          "application/json"
+        ],
         "responses": {
           "200": {
-            "description": "OpenID configuration"
+            "description": "OpenID configuration",
+            "schema": {
+              "properties": {
+                "authorization_endpoint": {
+                  "type": "string"
+                },
+                "device_authorization_endpoint": {
+                  "type": "string"
+                },
+                "reana_client_id": {
+                  "type": "string"
+                },
+                "token_endpoint": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
           },
           "404": {
             "description": "OpenID configuration not found"

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -486,12 +486,19 @@ https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-a
 
 # Authentication configuration
 # =====================
+# TODO The env location will be changed after `reana-server` jwt PR is merged and env variable structure agreed
 REANA_AUTH = {
     "openid": {
         "config_url": os.getenv(
-            "OPENID_CONFIG_URL",
+            "REANA_AUTH_OPENID_CONFIG_URL",
             "https://auth.cern.ch/auth/realms/cern/.well-known/openid-configuration",
-        )
-    }
+        ),
+    },
+    "client_id": os.getenv(
+        "REANA_AUTH_CLIENT_ID",
+        # TODO Change me to something more reasonable (currently it is just temp client_id)
+        # Used for CLI authentication to avoid extra configuration on client environments
+        "f671a136-8e92-45e5-83bd-05af1942e396",
+    ),
 }
 """Authentication configuration for REANA."""

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -483,3 +483,15 @@ REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT = os.getenv(
 Please see the following URL for more details
 https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup.
 """
+
+# Authentication configuration
+# =====================
+REANA_AUTH = {
+    "openid": {
+        "config_url": os.getenv(
+            "OPENID_CONFIG_URL",
+            "https://auth.cern.ch/auth/realms/cern/.well-known/openid-configuration",
+        )
+    }
+}
+"""Authentication configuration for REANA."""

--- a/reana_server/factory.py
+++ b/reana_server/factory.py
@@ -63,6 +63,7 @@ def create_minimal_app(config_mapping=None):
 
     # Register API routes
     from .rest import (
+        auth,
         config,
         gitlab,
         ping,
@@ -83,6 +84,7 @@ def create_minimal_app(config_mapping=None):
     app.register_blueprint(status.blueprint, url_prefix="/api")
     app.register_blueprint(info.blueprint, url_prefix="/api")
     app.register_blueprint(launch.blueprint, url_prefix="/api")
+    app.register_blueprint(auth.blueprint, url_prefix="/api")
 
     @app.teardown_appcontext
     def shutdown_session(response_or_exc):

--- a/reana_server/rest/auth.py
+++ b/reana_server/rest/auth.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2017, 2018, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA-Server auth Flask-Blueprint."""
+
+import requests
+from flask import Blueprint, jsonify
+
+from reana_server.config import REANA_AUTH
+
+blueprint = Blueprint("auth", __name__)
+
+
+@blueprint.route("/.well-known/openid-configuration", methods=["GET"])
+def get_openid_configuration():
+    r"""Get OpenID Configuration.
+
+    ---
+    get:
+      summary: Get OpenID Configuration
+      description: >-
+        Returns the OpenID configuration for the REANA server.
+      responses:
+        '200':
+          description: >-
+            OpenID configuration
+        '404':
+          description: OpenID configuration not found
+        '500':
+          description: Internal server error
+    """
+    try:
+        url = REANA_AUTH["openid"]["config_url"]
+
+        if not url:
+            return jsonify({"message": "OpenID configuration URL is not set"}), 500
+        response = requests.get(url)
+        if response.status_code == 404:
+            return jsonify({"message": "OpenID configuration not found"}), 404
+        response.raise_for_status()
+        return jsonify(response.json()), 200
+    except requests.RequestException:
+        return jsonify({"message": "Failed to fetch OpenID configuration"}), 502

--- a/reana_server/rest/auth.py
+++ b/reana_server/rest/auth.py
@@ -25,16 +25,31 @@ def get_openid_configuration():
       summary: Get OpenID Configuration
       description: >-
         Returns the OpenID configuration for the REANA server.
+      operationId: get_openid_configuration
+      produces:
+       - application/json
       responses:
-        '200':
+        200:
           description: >-
             OpenID configuration
+          schema:
+            type: object
+            properties:
+              device_authorization_endpoint:
+                type: string
+              authorization_endpoint:
+                type: string
+              token_endpoint:
+                type: string
+              reana_client_id:
+                type: string
         '404':
           description: OpenID configuration not found
         '500':
           description: Internal server error
     """
     try:
+        # TODO The env location will be changed after `reana-server` jwt PR is merged and env variable structure agreed
         url = REANA_AUTH["openid"]["config_url"]
 
         if not url:
@@ -43,6 +58,9 @@ def get_openid_configuration():
         if response.status_code == 404:
             return jsonify({"message": "OpenID configuration not found"}), 404
         response.raise_for_status()
-        return jsonify(response.json()), 200
+        openid_config = response.json()
+        openid_config["reana_client_id"] = REANA_AUTH["client_id"]
+
+        return jsonify(openid_config), 200
     except requests.RequestException:
         return jsonify({"message": "Failed to fetch OpenID configuration"}), 502

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ setup(
             "reana_server_status = reana_server.rest.status:blueprint",
             "reana_server_info = reana_server.rest.info:blueprint",
             "reana_server_launch = reana_server.rest.launch:blueprint",
+            "reana_server_auth = reana_server.rest.auth:blueprint",
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
This pull request introduces initial support for authentication in the REANA Server by adding a new endpoint to proxy OpenID configuration from an identity provider (IdP). The main changes include defining authentication configuration, registering a new authentication blueprint, and implementing the proxy endpoint.

Authentication support:

* Added `REANA_AUTH` configuration in `reana_server/config.py` to specify the OpenID configuration URL, allowing the service to know where to fetch OpenID metadata. (This configuration will change when we align on config.py structure in `reana-server` JWT support PR)
* Created a new `auth` blueprint in `reana_server/rest/auth.py` with an endpoint to proxy the OpenID configuration from the configured IdP, including error handling for missing or unreachable URLs.

This endpoint will be used by REANA clients (e.g., reana-clients and REANA UI) to avoid requiring custom idp_url and other environment variables in each client

Depends-On: #741