### PR TITLE
feat(rest): add quota management endpoint

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -230,6 +230,7 @@ rest_api_modules = [
     "reana_server.rest.status",
     "reana_server.rest.users",
     "reana_server.rest.workflows",
+    "reana_server.rest.quota",
 ]
 
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1144,6 +1144,316 @@
         "summary": "Ping the server (healthcheck)"
       }
     },
+    "/api/quota": {
+      "get": {
+        "description": "This endpoint gets resource quota limits for a given user.",
+        "operationId": "get_quota_usage",
+        "parameters": [
+          {
+            "description": "REANA user quota management secret",
+            "in": "header",
+            "name": "X-Quota-Management-Secret",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Get the quota limit by user ID (mutually exclusive with `email` and `user_access_token`)",
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Get the quota limit by user email (mutually exclusive with `user_id` and `user_access_token`)",
+            "in": "query",
+            "name": "email",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Get the quota limit by user access token (mutually exclusive with `user_id` and `email`)",
+            "in": "query",
+            "name": "user_access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "The type of resource",
+            "in": "query",
+            "name": "resource_type",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. Raw resource quota limit is returned.",
+            "examples": {
+              "application/json": {
+                "limit": 1000000000,
+                "message": "OK",
+                "usage": 500000000
+              }
+            },
+            "schema": {
+              "properties": {
+                "limit": {
+                  "type": "number"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "usage": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed.",
+            "examples": {
+              "application/json": {
+                "message": "No user specified."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Request failed. Unauthorized.",
+            "examples": {
+              "application/json": {
+                "message": "Unauthorized"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. Forbidden.",
+            "examples": {
+              "application/json": {
+                "message": "Quota management endpoint is not configured."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. User not found.",
+            "examples": {
+              "application/json": {
+                "message": "User not found."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal server error.",
+            "examples": {
+              "application/json": {
+                "message": "Internal server error."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Get resource quota limits."
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "This endpoint sets resource quota limits for a given user.",
+        "operationId": "set_quota_limit",
+        "parameters": [
+          {
+            "description": "REANA user quota management secret",
+            "in": "header",
+            "name": "X-Quota-Management-Secret",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Data required to set quota limits (exactly one of `user_id` or `email` must be provided).",
+            "in": "body",
+            "name": "data",
+            "required": true,
+            "schema": {
+              "properties": {
+                "email": {
+                  "description": "Email of the target user (mutually exclusive with `user_id`)",
+                  "type": "string"
+                },
+                "limit": {
+                  "description": "Raw quota limit to set",
+                  "type": "integer"
+                },
+                "resource_type": {
+                  "description": "Resource type to set",
+                  "type": "string"
+                },
+                "user_id": {
+                  "description": "ID of the target user (mutually exclusive with `email`)",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "resource_type",
+                "limit"
+              ],
+              "type": "object"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource quotas successfully set.",
+            "examples": {
+              "application/json": {
+                "limit": 1000000000,
+                "message": "OK",
+                "usage": 500000000
+              }
+            },
+            "schema": {
+              "properties": {
+                "limit": {
+                  "type": "number"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "usage": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed.",
+            "examples": {
+              "application/json": {
+                "message": "Invalid request."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Request failed. Unauthorized.",
+            "examples": {
+              "application/json": {
+                "message": "Unauthorized"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. Forbidden.",
+            "examples": {
+              "application/json": {
+                "message": "Quota management endpoint is not configured."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. User not found.",
+            "examples": {
+              "application/json": {
+                "message": "User not found."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal server error.",
+            "examples": {
+              "application/json": {
+                "message": "Quota could not be set: {error}"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Set resource quota limits."
+      }
+    },
     "/api/secrets": {
       "get": {
         "description": "Get user secrets.",

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -121,6 +121,9 @@ REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_THREADS = int(
 )
 """Maximum number of threads for one Dask worker."""
 
+REANA_QUOTA_MANAGEMENT_SECRET = os.getenv("REANA_QUOTA_MANAGEMENT_SECRET", "")
+"""Secret used to authenticate quota-management REST API requests."""
+
 REANA_KUBERNETES_JOBS_CPU_REQUEST = os.getenv("REANA_KUBERNETES_JOBS_CPU_REQUEST")
 """Default cpu request for user job containers."""
 

--- a/reana_server/factory.py
+++ b/reana_server/factory.py
@@ -72,6 +72,7 @@ def create_minimal_app(config_mapping=None):
         workflows,
         info,
         launch,
+        quota,
     )  # noqa
 
     app.register_blueprint(ping.blueprint, url_prefix="/api")
@@ -83,6 +84,7 @@ def create_minimal_app(config_mapping=None):
     app.register_blueprint(status.blueprint, url_prefix="/api")
     app.register_blueprint(info.blueprint, url_prefix="/api")
     app.register_blueprint(launch.blueprint, url_prefix="/api")
+    app.register_blueprint(quota.blueprint, url_prefix="/api")
 
     @app.teardown_appcontext
     def shutdown_session(response_or_exc):

--- a/reana_server/reana_admin/cli.py
+++ b/reana_server/reana_admin/cli.py
@@ -37,7 +37,6 @@ from reana_db.models import (
     AuditLogAction,
     QuotaHealth,
     Resource,
-    ResourceType,
     User,
     UserResource,
     UserTokenStatus,
@@ -68,6 +67,7 @@ from reana_server.utils import (
     _validate_password,
     create_user_workspace,
     grant_access_token_to_user,
+    _set_quota_limit,
 )
 
 
@@ -559,76 +559,20 @@ def set_quota_limit(
     ctx, emails, resource_type, resource_name, limit, admin_access_token
 ):
     """Set quota limits to the given users per resource."""
-    try:
-        for email in emails:
-            error_msg = None
-            resource = None
-            user = _get_user_by_criteria(None, email)
+    msg, status_code, fatal = _set_quota_limit(
+        limit=limit,
+        resource_type=resource_type,
+        resource_name=resource_name,
+        emails=emails,
+    )
+    click.secho(
+        msg,
+        fg="green" if status_code == 200 else "red",
+        err=False if status_code == 200 else True,
+    )
 
-            if resource_name:
-                resource = Resource.query.filter_by(name=resource_name).one_or_none()
-            elif resource_type in ResourceType._member_names_:
-                resources = Resource.query.filter_by(type_=resource_type).all()
-                if resources and len(resources) > 1:
-                    click.secho(
-                        f"ERROR: There are more than one `{resource_type}` resource. "
-                        "Please provide resource name with `--resource-name` option to specify the exact resource.",
-                        fg="red",
-                        err=True,
-                    )
-                    sys.exit(1)
-                else:
-                    resource = resources[0]
-
-            if not user:
-                error_msg = f"ERROR: Provided user {email} does not exist."
-            elif not resource:
-                resources = [
-                    f"{resource.type_.name} ({resource.name})"
-                    for resource in Resource.query
-                ]
-                error_msg = (
-                    f"ERROR: Provided resource `{resource_name or resource_type}` does not exist. "
-                    if resource_name or resource_type
-                    else "ERROR: Please provide a resource. "
-                )
-                error_msg += f"Available resources are: {', '.join(resources)}."
-            if error_msg:
-                click.secho(
-                    error_msg,
-                    fg="red",
-                    err=True,
-                )
-                sys.exit(1)
-
-            user_resource = UserResource.query.filter_by(
-                user=user, resource=resource
-            ).one_or_none()
-            if user_resource:
-                user_resource.quota_limit = limit
-                Session.add(user_resource)
-            else:
-                # Create user resource in case there isn't one. Useful for old users.
-                user.resources.append(
-                    UserResource(
-                        user_id=user.id_,
-                        resource_id=resource.id_,
-                        quota_limit=limit,
-                        quota_used=0,
-                    )
-                )
-        Session.commit()
-        click.secho(
-            f"Quota limit {limit} for '{resource.type_.name} ({resource.name})' successfully set to users {emails}.",
-            fg="green",
-        )
-    except Exception as e:
-        logging.debug(traceback.format_exc())
-        logging.debug(str(e))
-        click.echo(
-            click.style("Quota could not be set: \n{}".format(str(e)), fg="red"),
-            err=True,
-        )
+    if fatal:
+        sys.exit(1)
 
 
 @reana_admin.command(

--- a/reana_server/rest/quota.py
+++ b/reana_server/rest/quota.py
@@ -1,0 +1,425 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2017, 2018, 2020, 2021, 2025 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Reana-Server quota functionality Flask-Blueprint."""
+
+import secrets
+from typing import Optional
+
+from flask import Blueprint, jsonify, request, Response
+from marshmallow import fields, Schema
+from reana_db.models import ResourceType
+
+from reana_server.config import REANA_QUOTA_MANAGEMENT_SECRET
+from reana_server.utils import _set_quota_limit, _get_users
+
+blueprint = Blueprint("quota", __name__)
+
+
+class SetQuotaLimitBodySchema(Schema):
+    """Schema for set_quota_limit endpoint body."""
+
+    user_id = fields.Str()
+    email = fields.Str()
+    resource_type = fields.Str(required=True)
+    limit = fields.Int(required=True)
+
+
+def _check_quota_management_secret() -> tuple[Response, int] | None:
+    if not REANA_QUOTA_MANAGEMENT_SECRET:
+        return jsonify(message="Quota management endpoint is not configured."), 403
+
+    # Check if secret is provided and matches the one in the config
+    secret = request.headers.get("X-Quota-Management-Secret", "")
+    if not secrets.compare_digest(secret, REANA_QUOTA_MANAGEMENT_SECRET):
+        return jsonify(message="Unauthorized"), 401
+
+    return None
+
+
+def _get_quota(
+    resource_type: str,
+    user_id: Optional[str] = None,
+    email: Optional[str] = None,
+    user_access_token: Optional[str] = None,
+) -> tuple[int | None, int | None, str | None, int]:
+    """
+    Get quota limit and usage for a given user and resource type.
+
+    :param resource_type: Type of the resource.
+    :param user_id: ID of the user.
+    :param email: Email of the user.
+    :param user_access_token: Access token of the user.
+    :return: Tuple with the limit, usage, the error message (or None if no error), and the status code.
+    """
+    users = _get_users(user_id, email, user_access_token) or None
+    user = users[0] if users else None
+
+    if not user:
+        return None, None, "User not found.", 404
+
+    if resource_type not in ResourceType._member_names_:
+        return (
+            None,
+            None,
+            f"Resource type '{resource_type}' is not one of the valid types: {', '.join(ResourceType._member_names_)}",
+            400,
+        )
+
+    quota_usage = user.get_quota_usage()
+    limit: int | None = quota_usage.get(resource_type, {}).get("limit", {}).get("raw")
+    usage: int | None = quota_usage.get(resource_type, {}).get("usage", {}).get("raw")
+    return limit, usage, None, 200
+
+
+@blueprint.route("/quota", methods=["GET"])
+def get_quota_usage():  # noqa
+    r"""Endpoint to get quota limits.
+
+    ---
+    get:
+      summary: Get resource quota limits.
+      description: >-
+        This endpoint gets resource quota limits for a given user.
+      operationId: get_quota_usage
+      produces:
+        - application/json
+      parameters:
+        - name: X-Quota-Management-Secret
+          in: header
+          description: REANA user quota management secret
+          required: true
+          type: string
+        - name: user_id
+          in: query
+          description: Get the quota limit by user ID (mutually exclusive with `email` and `user_access_token`)
+          required: false
+          type: string
+        - name: email
+          in: query
+          description: Get the quota limit by user email (mutually exclusive with `user_id` and `user_access_token`)
+          required: false
+          type: string
+        - name: user_access_token
+          in: query
+          description: Get the quota limit by user access token (mutually exclusive with `user_id` and `email`)
+          required: false
+          type: string
+        - name: resource_type
+          in: query
+          description: The type of resource
+          required: true
+          type: string
+      responses:
+        200:
+          description: >-
+            Request succeeded. Raw resource quota limit is returned.
+          schema:
+            type: object
+            properties:
+              limit:
+                type: number
+              message:
+                type: string
+              usage:
+                type: number
+          examples:
+            application/json:
+              {
+                "limit": 1000000000,
+                "message": "OK",
+                "usage": 500000000,
+              }
+        400:
+          description: >-
+            Request failed. The incoming data specification seems malformed.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "Resource type is required."
+              }
+            application/json:
+              {
+                "message": "No user specified."
+              }
+        401:
+          description: >-
+            Request failed. Unauthorized.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "Unauthorized"
+              }
+        403:
+          description: >-
+            Request failed. Forbidden.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "Quota management endpoint is not configured."
+              }
+        404:
+          description: >-
+            Request failed. User not found.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "User not found."
+              }
+        500:
+          description: >-
+            Request failed. Internal server error.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "Internal server error."
+              }
+    """
+    response = _check_quota_management_secret()
+    if response:
+        return response
+
+    # Get params from query string
+    user_id = request.args.get("user_id")
+    email = request.args.get("email")
+    user_access_token = request.args.get("user_access_token")
+    resource_type = request.args.get("resource_type")
+
+    # Check if at least one of the user criteria is provided
+    if not user_id and not email and not user_access_token:
+        return jsonify(message="No user specified"), 400
+
+    # Check if all user criteria are provided
+    if int(bool(user_id)) + int(bool(email)) + int(bool(user_access_token)) > 1:
+        return (
+            jsonify(
+                message="Exactly one of `user_id`, `email` or `user_access_token` must be provided.",
+            ),
+            400,
+        )
+
+    # Validate resource type
+    if not resource_type:
+        return jsonify(message="Resource type is required."), 400
+
+    if resource_type not in ResourceType._member_names_:
+        return (
+            jsonify(
+                message=f"Resource type '{resource_type}' does not exist. Available resource types are: {', '.join(ResourceType._member_names_)}"
+            ),
+            400,
+        )
+
+    limit, usage, error_msg, status = _get_quota(
+        resource_type, user_id, email, user_access_token
+    )
+    if error_msg:
+        return jsonify(message=error_msg), status
+
+    if usage is None:
+        return jsonify(message="Resource usage is not available."), 500
+
+    if limit is None:
+        return jsonify(limit=-1, usage=usage, message="Resource limit is not set."), 200
+
+    return jsonify(limit=limit, usage=usage, message="OK"), 200
+
+
+@blueprint.route("/quota", methods=["POST"])
+def set_quota_limit():  # noqa
+    r"""Endpoint to set quota limits.
+
+    ---
+    post:
+      summary: Set resource quota limits.
+      description: >-
+        This endpoint sets resource quota limits for a given user.
+      operationId: set_quota_limit
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: X-Quota-Management-Secret
+          in: header
+          description: REANA user quota management secret
+          required: true
+          type: string
+        - name: data
+          in: body
+          description: Data required to set quota limits (exactly one of `user_id` or `email` must be provided).
+          required: true
+          schema:
+            type: object
+            properties:
+              user_id:
+                type: string
+                description: ID of the target user (mutually exclusive with `email`)
+              email:
+                type: string
+                description: Email of the target user (mutually exclusive with `user_id`)
+              resource_type:
+                type: string
+                description: Resource type to set
+              limit:
+                type: integer
+                description: Raw quota limit to set
+            required:
+              - resource_type
+              - limit
+      responses:
+        200:
+          description: >-
+            Resource quotas successfully set.
+          schema:
+            type: object
+            properties:
+              limit:
+                type: number
+              message:
+                type: string
+              usage:
+                type: number
+          examples:
+            application/json:
+              {
+                "limit": 1000000000,
+                "message": "OK",
+                "usage": 500000000,
+              }
+        400:
+          description: >-
+            Request failed. The incoming data specification seems malformed.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "Invalid request."
+              }
+        401:
+          description: >-
+            Request failed. Unauthorized.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "Unauthorized"
+              }
+        403:
+          description: >-
+            Request failed. Forbidden.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "Quota management endpoint is not configured."
+              }
+        404:
+          description: >-
+            Request failed. User not found.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "User not found."
+              }
+        500:
+          description: >-
+            Request failed. Internal server error.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "Quota could not be set: {error}"
+              }
+    """
+    response = _check_quota_management_secret()
+    if response:
+        return response
+
+    json_body = request.get_json(silent=True)
+    if not isinstance(json_body, dict):
+        return jsonify(message="Invalid request. Expected application/json body."), 400
+
+    errors = SetQuotaLimitBodySchema().validate(json_body)
+    if errors:
+        return jsonify(message=f"Invalid request. Errors: {errors}"), 400
+
+    limit = json_body.get("limit")
+    resource_type = json_body.get("resource_type")
+    user_id = json_body.get("user_id")
+    email = json_body.get("email")
+
+    if int(bool(user_id)) + int(bool(email)) != 1:
+        return (
+            jsonify(
+                message="Exactly one of `user_id` or `email` must be provided.",
+            ),
+            400,
+        )
+
+    msg, status_code, _ = _set_quota_limit(
+        limit,
+        resource_type=resource_type,
+        user_ids=[user_id] if user_id else None,
+        emails=[email] if email else None,
+    )
+
+    if status_code != 200:
+        return jsonify(message=msg), status_code
+
+    _, usage, error_msg, status_code = _get_quota(resource_type, user_id, email)
+    if status_code != 200:
+        return jsonify(message=error_msg), status_code
+
+    return jsonify(limit=limit, usage=usage, message="OK"), status_code

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -14,9 +14,11 @@ import logging
 import os
 import pathlib
 import secrets
-import sys
 import shutil
 from typing import Dict, List, Optional, Tuple, Union
+import sys
+import traceback
+
 from uuid import UUID, uuid4
 
 import click
@@ -26,7 +28,6 @@ from invenio_oauthclient.errors import OAuthClientUnAuthorized
 from jinja2 import Environment, PackageLoader, select_autoescape
 from marshmallow.exceptions import ValidationError
 from marshmallow.validate import Email
-
 from reana_commons.config import REANAConfig, REANA_WORKFLOW_UMASK, SHARED_VOLUME_PATH
 from reana_commons.email import send_email, REANA_EMAIL_SENDER
 from reana_commons.errors import (
@@ -48,6 +49,7 @@ from reana_db.models import (
     UserTokenType,
     Workflow,
     AuditLogAction,
+    Resource,
 )
 from reana_db.utils import get_default_quota_resource
 from sqlalchemy.exc import (
@@ -767,6 +769,129 @@ def _validate_email(ctx, param, value):
         click.secho("ERROR: Invalid email format", fg="red")
         sys.exit(1)
     return value
+
+
+def _set_quota_limit(
+    limit: int,
+    resource_type: Optional[str] = None,
+    resource_name: Optional[str] = None,
+    emails: Optional[list[str]] = None,
+    user_ids: Optional[list[str]] = None,
+) -> tuple[Optional[str], int, bool]:
+    """
+    Set a quota limit for the given users and resource type.
+
+    :param limit: Value of new limit.
+    :param resource_type: Type of the resource.
+    :param resource_name: Name of the resource.
+    :param emails: List of user emails.
+    :param user_ids: List of user IDs.
+    :return: Tuple message, status code and whether the error is fatal.
+    """
+    if (emails is None and user_ids is None) or (emails and user_ids):
+        return (
+            "ERROR: Exactly one of `emails` or `user_ids` must be provided.",
+            400,
+            True,
+        )
+
+    if emails is not None and len(emails) == 0:
+        return "ERROR: `emails` must not be empty.", 400, True
+
+    if user_ids is not None and len(user_ids) == 0:
+        return "ERROR: `user_ids` must not be empty.", 400, True
+
+    if (not resource_type and not resource_name) or (resource_type and resource_name):
+        return (
+            "ERROR: Exactly one of `resource_type` or `resource_name` must be provided.",
+            400,
+            True,
+        )
+
+    if limit < 0:
+        return "ERROR: Provided `limit` must be a positive number.", 400, True
+
+    if user_ids and any(is_valid_email(uid) for uid in user_ids):
+        return (
+            f"ERROR: One or more `user_ids` look like an email: {', '.join(user_ids)}",
+            400,
+            True,
+        )
+
+    try:
+        users = (
+            [_get_user_by_criteria(None, email) for email in emails]
+            if emails
+            else [_get_user_by_criteria(uid, None) for uid in user_ids]
+        )
+
+        if any(user is None for user in users):
+            users_not_found = [
+                id_ for id_, user in zip(emails or user_ids, users) if user is None
+            ]
+            return (
+                f"ERROR: The following users do not exist: {', '.join(users_not_found)}",
+                404,
+                True,
+            )
+
+        # Get resource by name or type
+        resource = None
+        if resource_name:
+            resource = Resource.query.filter_by(name=resource_name).one_or_none()
+        elif resource_type in ResourceType._member_names_:
+            available_resources = Resource.query.filter_by(type_=resource_type).all()
+            if len(available_resources) > 1:
+                return (
+                    f"ERROR: There are more than one `{resource_type}` resource. Please provide resource name to specify the exact resource.",
+                    400,
+                    True,
+                )
+            elif len(available_resources) == 1:
+                resource = available_resources[0]
+
+        if not resource:
+            # Resource was not found
+            available_resources = [
+                (resource.type_.name if resource_type else resource.name)
+                for resource in Resource.query
+            ]
+
+            return (
+                f"ERROR: Provided resource '{resource_name or resource_type}' does not exist. Available resources: {', '.join(available_resources)}",
+                400,
+                True,
+            )
+
+        for user in users:
+            user_resource = UserResource.query.filter_by(
+                user=user, resource=resource
+            ).one_or_none()
+
+            if user_resource:
+                user_resource.quota_limit = limit
+                Session.add(user_resource)
+            else:
+                # Create user resource in case there isn't one. Useful for old users.
+                user.resources.append(
+                    UserResource(
+                        user_id=user.id_,
+                        resource_id=resource.id_,
+                        quota_limit=limit,
+                        quota_used=0,
+                    )
+                )
+
+        Session.commit()
+        return (
+            f"Quota limit {limit} for '{resource.type_.name} ({resource.name})' successfully set to user(s): {', '.join([user.email if emails else str(user.id_) for user in users])}.",
+            200,
+            False,
+        )
+    except Exception as e:
+        logging.debug(traceback.format_exc())
+        logging.debug(str(e))
+        return "Error setting quota limit: \n{}".format(str(e)), 500, False
 
 
 class JinjaEnv:

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
             "reana_server_status = reana_server.rest.status:blueprint",
             "reana_server_info = reana_server.rest.info:blueprint",
             "reana_server_launch = reana_server.rest.launch:blueprint",
+            "reana_server_quota = reana_server.rest.quota:blueprint",
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
To use the endpoints, the secret `REANA_ADMIN_QUOTA_MANAGER` secret set in your Helm `values.yaml` under `components.reana_server.environment` must be included in the `X-Quota-Management-Secret` header of each request.

### `GET` user quota info

Other query params:
```
- name: user_id
  description: Get the quota limit by user ID (mutually exclusive with `email` and `user_access_token`)
- name: email
  description: Get the quota limit by user email (mutually exclusive with `user_id` and `user_access_token`)
- name: user_access_token
  description: Get the quota limit by user access token (mutually exclusive with `user_id` and `email`)
- name: resource_type
  description: The type of resource
```

### `POST` user quota limit

Body format:

```
user_id:
  type: string
  description: ID of the target user (mutually exclusive with `email`)
email:
  type: string
  description: Email of the target user (mutually exclusive with `user_id`)
resource_type:
  type: string
  description: Resource type to set
limit:
  type: integer
  description: Raw quota limit to set
```

### Examples

Fetch CPU quota info for user with email 'test@test.com':

```
GET /quota?email=test@test.com&resource_type=cpu

X-Quota-Management-Secret your_secret
```

Set disk quota limit for user with ID 'abcde':

```
POST /quota

X-Quota-Management-Secret your_secret

{
    "user_id": "abcde",
    "limit": 12345678,
    "resource_type": "disk"
}
```

Closes reanahub/reana-server#747