### PR TITLE
feat(config): add EOSC EU Node AAI SSO login method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -65,7 +65,12 @@ RUN if test -e modules/reana-commons; then \
       fi \
     fi
 
+# Install custom invenio-oauthclient branch
+# hadolint ignore=DL3013
+RUN pip install --no-cache-dir --force-reinstall --no-deps "git+https://github.com/tiborsimko/invenio-oauthclient.git@reana-een-aai"
+
 # A quick fix to allow eduGAIN and social login users that wouldn't otherwise match Invenio username rules
+# hadolint ignore=DL3059
 RUN sed -i 's|^username_regex = re.compile\(.*\)$|username_regex = re.compile("^\\S+$")|g' /usr/local/lib/python3.12/dist-packages/invenio_userprofiles/validators.py
 
 # Check for any broken Python dependencies

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN. 
+Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ install_requires = [
     # From auth bundle
     "invenio-accounts>=2.0.0",
     "invenio-oauth2server>=1.3.0",
-    "invenio-oauthclient>=1.5.0",
+    "invenio-oauthclient @ git+https://github.com/tiborsimko/invenio-oauthclient.git@reana-een-aai",
     "invenio-userprofiles>=1.2.0",
     "invenio-userprofiles>=1.2.0",
     "invenio-theme>=1.4.7",


### PR DESCRIPTION
Add support for EOSC EU Node AAI as a new SSO login provider by importing and configuring the EOSC AAI OAuth provider from `invenio-oauthclient`. The implementation introduces `EOSC_*` environment variables for consumer credentials and endpoint URLs and configures the remote REST app with proper OAuth URLs and scopes. A custom `invenio-oauthclient` branch is installed to provide the necessary EOSC AAI support without having to upgrade the full Invenio stack.