### PR TITLE
fix(rest): add gitlab_host schema definition to info endpoint

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -778,6 +778,17 @@
                   },
                   "type": "object"
                 },
+                "gitlab_host": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
                 "interactive_session_recommended_jupyter_images": {
                   "properties": {
                     "title": {

--- a/reana_server/api_client.py
+++ b/reana_server/api_client.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """REST API client generator."""
+
 from functools import partial
 
 from reana_commons.api_client import get_current_api_client

--- a/reana_server/reana_admin/check_workflows.py
+++ b/reana_server/reana_admin/check_workflows.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2022 CERN.
+# Copyright (C) 2022, 2023, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA Server administrative tool - check workflows command."""
-
 
 import datetime
 from pathlib import Path

--- a/reana_server/reana_admin/retention_rule_deleter.py
+++ b/reana_server/reana_admin/retention_rule_deleter.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2022, 2023 CERN.
+# Copyright (C) 2022, 2023, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 """REANA utilities to apply retention rules."""
-
 
 import errno
 from pathlib import Path

--- a/reana_server/rest/config.py
+++ b/reana_server/rest/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021 CERN.
+# Copyright (C) 2020, 2021, 2022, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,7 +13,6 @@ import traceback
 
 from flask import Blueprint, jsonify
 from reana_commons.config import REANAConfig
-
 
 blueprint = Blueprint("config", __name__)
 

--- a/reana_server/rest/gitlab.py
+++ b/reana_server/rest/gitlab.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -46,7 +46,6 @@ from reana_server.utils import (
     _format_gitlab_secrets,
     _get_gitlab_hook_id,
 )
-
 
 blueprint = Blueprint("gitlab", __name__)
 

--- a/reana_server/rest/info.py
+++ b/reana_server/rest/info.py
@@ -323,6 +323,13 @@ def info(user, **kwargs):  # noqa
                   value:
                     type: string
                 type: object
+              gitlab_host:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: string
+                type: object
             type: object
           examples:
             application/json:
@@ -435,10 +442,6 @@ def info(user, **kwargs):  # noqa
                     "title": "Dask workflows allowed in the cluster",
                     "value": "False"
                 },
-                "gitlab_host": {
-                    "title": "GitLab host",
-                    "value": "gitlab.cern.ch"
-                },
                 "dask_autoscaler_enabled": {
                     "title": "Dask autoscaler enabled in the cluster",
                     "value": "False"
@@ -470,6 +473,10 @@ def info(user, **kwargs):  # noqa
                 "dask_cluster_max_single_worker_threads": {
                     "title": "The maximum number of threads that users can ask for the single Dask worker",
                     "value": "8"
+                },
+                "gitlab_host": {
+                    "title": "GitLab host",
+                    "value": "gitlab.cern.ch"
                 },
               }
         500:

--- a/reana_server/rest/launch.py
+++ b/reana_server/rest/launch.py
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2022 CERN.
+# Copyright (C) 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -44,7 +44,6 @@ from reana_server.utils import (
     get_workspace_retention_rules,
 )
 from reana_server.validation import validate_workflow
-
 
 blueprint = Blueprint("launch", __name__)
 

--- a/reana_server/rest/secrets.py
+++ b/reana_server/rest/secrets.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -20,7 +20,6 @@ from webargs.flaskparser import use_kwargs
 from marshmallow import Schema, validate
 
 from reana_server.decorators import signin_required
-
 
 blueprint = Blueprint("secrets", __name__)
 

--- a/reana_server/rest/users.py
+++ b/reana_server/rest/users.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -26,7 +26,6 @@ from reana_server import __version__
 from reana_server.config import REANA_HOSTNAME
 from reana_server.decorators import signin_required
 from reana_server.utils import JinjaEnv
-
 
 blueprint = Blueprint("users", __name__)
 

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Reana-Server workflow-functionality Flask-Blueprint."""
+
 import json
 import logging
 import os

--- a/tests/test_deleter.py
+++ b/tests/test_deleter.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2023 CERN.
+# Copyright (C) 2023, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 """REANA-Server deleter tests."""
+
 import pathlib
 import uuid
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA-Server Workflow Execution Scheduler."""
+
 import base64
 import json
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2023 CERN.
+# Copyright (C) 2023, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test users endpoints."""
-
 
 import pytest
 from flask import url_for


### PR DESCRIPTION
Add missing schema for `gitlab_host` in the `info` endpoint docstring so that the generated OpenAPI docs would include the schema definition properly. Complements db12634.