### PR TITLE
build(python): pin setuptools below 81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
+          pip install 'setuptools<81'
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
@@ -218,6 +219,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
+          pip install 'setuptools<81'
           pip install twine wheel
           pip install -e .[all]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update -y && \
       python3.12 \
       python3.12-dev \
       vim-tiny && \
-    pip install --no-cache-dir --upgrade setuptools && \
+    pip install --no-cache-dir --upgrade 'setuptools<81' && \
     pip install --no-cache-dir -r /code/requirements.txt && \
     apt-get remove -y \
       gcc \

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,5 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+setuptools<81
 -e .[all]


### PR DESCRIPTION
Pin setuptools<81 in Dockerfile, CI workflows, and
ReadTheDocs configuration. This is because the recent
setuptools 81.0.0 upgrade removed the pkg_resources
module that is needed at runtime by some dependencies.