### PR TITLE
feat(config): add security headers and restrict CORS origins

### DIFF
--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -307,9 +307,13 @@ SECURITY_MSG_PASSWORD_INVALID_LENGTH = failed_signin_msg
 # CORS
 # ====
 REST_ENABLE_CORS = True
-# change this only while developing
-CORS_SEND_WILDCARD = True
+# See: https://flask-cors.readthedocs.io/en/latest/configuration.html
+# Echo the request's origin back only if it matches CORS_ORIGINS.
+# If True, it would send Access-Control-Allow-Origin: *
+# unconditionally, and let any website read API responses in the browser
+CORS_SEND_WILDCARD = False
 CORS_SUPPORTS_CREDENTIALS = False
+CORS_ORIGINS = [REANA_URL]
 
 # Flask configuration
 # ===================
@@ -348,7 +352,26 @@ if REANA_HOSTNAME:
 # ======================
 PROXYFIX_CONFIG = json.loads(os.getenv("PROXYFIX_CONFIG", '{"x_proto": 1}'))
 
-APP_DEFAULT_SECURE_HEADERS["content_security_policy"] = {}
+# See:
+# - Invenio docs: https://invenio-app.readthedocs.io/en/latest/configuration.html
+# - flask-talisman docs: https://github.com/GoogleCloudPlatform/flask-talisman
+APP_DEFAULT_SECURE_HEADERS["frame_options"] = "DENY"
+APP_DEFAULT_SECURE_HEADERS["strict_transport_security"] = True
+APP_DEFAULT_SECURE_HEADERS["strict_transport_security_max_age"] = 31536000
+APP_DEFAULT_SECURE_HEADERS["strict_transport_security_include_subdomains"] = True
+APP_DEFAULT_SECURE_HEADERS["referrer_policy"] = "strict-origin-when-cross-origin"
+# NOTE: keep in sync with reana-ui nginx/reana-ui.conf content security policy headers
+APP_DEFAULT_SECURE_HEADERS["content_security_policy"] = {
+    "default-src": "'self'",
+    "script-src": "'self'",
+    "style-src": ["'self'", "'unsafe-inline'"],
+    "img-src": ["'self'", "data:"],
+    "font-src": "'self'",
+    "connect-src": "'self'",
+    "frame-ancestors": "'none'",
+    "object-src": "'none'",
+    "base-uri": "'self'",
+}
 APP_DEFAULT_SECURE_HEADERS.update(
     json.loads(os.getenv("APP_DEFAULT_SECURE_HEADERS", "{}"))
 )

--- a/reana_server/ext.py
+++ b/reana_server/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022, 2024 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -137,6 +137,18 @@ class REANA(object):
 
         account_info_received.connect(_create_and_associate_oauth_user)
         user_registered.connect(_create_and_associate_local_user)
+
+        @app.after_request
+        def add_security_headers(response):
+            response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+            response.headers["Cross-Origin-Resource-Policy"] = "same-origin"
+            response.headers["Cache-Control"] = "no-store"
+            response.headers["Permissions-Policy"] = (
+                "accelerometer=(), ambient-light-sensor=(), camera=(), "
+                "display-capture=(), geolocation=(), gyroscope=(), "
+                "magnetometer=(), microphone=(), payment=(), usb=()"
+            )
+            return response
 
         @app.teardown_appcontext
         def shutdown_reana_db_session(response_or_exc):

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for the REANA Flask extension (security headers and CORS)."""
+
+import pytest
+from flask import Flask
+from invenio_rest import InvenioREST
+
+_TEST_ORIGIN = "https://example.com:30443"
+
+_EXPECTED_SECURITY_HEADERS = {
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Cross-Origin-Resource-Policy": "same-origin",
+    "Cache-Control": "no-store",
+}
+
+
+@pytest.fixture
+def ext_app():
+    """Minimal Flask app with the REANA extension and CORS enabled."""
+    from reana_server.ext import REANA
+
+    app = Flask(__name__)
+    app.config.update(
+        {
+            "TESTING": True,
+            "SECRET_KEY": "test-secret",
+            "REST_ENABLE_CORS": True,
+            "REST_CSRF_ENABLED": False,
+            "CORS_ORIGINS": [_TEST_ORIGIN],
+            "CORS_SEND_WILDCARD": False,
+            "CORS_SUPPORTS_CREDENTIALS": False,
+        }
+    )
+
+    @app.route("/test")
+    def test_route():
+        return "OK"
+
+    InvenioREST(app)
+    REANA().init_app(app)
+    return app
+
+
+@pytest.mark.parametrize("header,value", _EXPECTED_SECURITY_HEADERS.items())
+def test_security_headers_on_normal_response(ext_app, header, value):
+    """Each security header is set to the expected value on every response."""
+    with ext_app.test_client() as client:
+        res = client.get("/test")
+    assert res.headers.get(header) == value
+
+
+def test_permissions_policy_present(ext_app):
+    """Permissions-Policy header is present on every response."""
+    with ext_app.test_client() as client:
+        res = client.get("/test")
+    assert "Permissions-Policy" in res.headers
+
+
+def test_cors_matching_origin_echoed_back(ext_app):
+    """A request from the allowed origin gets Access-Control-Allow-Origin echoed."""
+    with ext_app.test_client() as client:
+        res = client.get("/test", headers={"Origin": _TEST_ORIGIN})
+    assert res.headers.get("Access-Control-Allow-Origin") == _TEST_ORIGIN
+
+
+def test_cors_non_matching_origin_rejected(ext_app):
+    """A request from a different origin does not get Access-Control-Allow-Origin."""
+    with ext_app.test_client() as client:
+        res = client.get("/test", headers={"Origin": "https://example.com"})
+    assert "Access-Control-Allow-Origin" not in res.headers


### PR DESCRIPTION
Add more security headers to Invenio's APP_DEFAULT_SECURE_HEADERS. Restrict CORS to REANA_HOSTNAME and disable wildcard origins. Add COOP and CORS headers in the REANA flask extension.