### PR TITLE
fix(dask): ensure workflows have a Dask service row

### DIFF
--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -30,11 +30,21 @@ from reana_db.config import SQLALCHEMY_DATABASE_URI
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 """Track modifications flag."""
 
+
+def compose_reana_url(hostname: str, hostport: str | int) -> str:
+    """Compose a REANA URL while omitting the default port."""
+    if str(hostport) == "443":
+        return f"https://{hostname}"
+    return f"https://{hostname}:{hostport}"
+
+
 ADMIN_USER_ID = "00000000-0000-0000-0000-000000000000"
 
 SHARED_VOLUME_PATH = os.getenv("SHARED_VOLUME_PATH", "/var/reana")
 
 REANA_HOSTNAME = os.getenv("REANA_HOSTNAME", "localhost")
+REANA_HOSTPORT = os.getenv("REANA_HOSTPORT", "30443")
+REANA_URL = compose_reana_url(REANA_HOSTNAME, REANA_HOSTPORT)
 
 REANA_SSO_CERN_CONSUMER_KEY = os.getenv("CERN_CONSUMER_KEY", "CHANGE_ME")
 REANA_SSO_CERN_CONSUMER_SECRET = os.getenv("CERN_CONSUMER_SECRET", "CHANGE_ME")

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -40,6 +40,7 @@ from reana_server.utils import (
     _get_reana_yaml_from_gitlab,
     _load_and_save_yadage_spec,
     clone_workflow,
+    ensure_dask_service,
     get_quota_excess_message,
     get_workspace_retention_rules,
     is_uuid_v4,
@@ -1220,6 +1221,10 @@ def _start_workflow(workflow_id_or_name, user, **parameters):
         validate_workflow(
             workflow.reana_specification, input_parameters=input_parameters
         )
+
+        # Backfill the Dask service row for legacy workflows created before this fix
+        if ensure_dask_service(workflow):
+            Session.object_session(workflow).commit()
 
         # when starting the workflow, the scheduler will call RWC's `set_workflow_status`
         # with the given `parameters`

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -35,13 +35,16 @@ from reana_commons.errors import (
     REANAValidationError,
     REANAEmailNotificationError,
 )
-from reana_commons.utils import get_quota_resource_usage
+from reana_commons.utils import get_dask_component_name, get_quota_resource_usage
 from reana_commons.yadage import yadage_load_from_workspace
 from reana_db.database import Session
 from reana_db.models import (
     ResourceType,
     ResourceUnit,
     RunStatus,
+    Service,
+    ServiceStatus,
+    ServiceType,
     User,
     UserResource,
     UserToken,
@@ -68,6 +71,7 @@ from reana_server.complexity import (
 from reana_server.config import (
     ADMIN_USER_ID,
     REANA_HOSTNAME,
+    REANA_URL,
     REANA_SSO_EOSC_REQUIRED_ENTITLEMENT,
     REANA_USER_EMAIL_CONFIRMATION,
     REANA_WORKFLOW_SCHEDULING_POLICY,
@@ -704,6 +708,36 @@ def get_workspace_retention_rules(
     return retention_rules
 
 
+def workflow_uses_dask(reana_specification: Dict) -> bool:
+    """Check whether a workflow specification requests a Dask service."""
+    return bool(
+        reana_specification.get("workflow", {}).get("resources", {}).get("dask")
+    )
+
+
+def build_dask_service(workflow: Workflow) -> Service:
+    """Build the Dask service DB row for a workflow."""
+    return Service(
+        name=get_dask_component_name(workflow.id_, "database_model_service"),
+        uri=f"{REANA_URL}/{workflow.id_}/dashboard/status",
+        type_=ServiceType.dask,
+        status=ServiceStatus.created,
+    )
+
+
+def ensure_dask_service(workflow: Workflow) -> bool:
+    """Ensure that a Dask workflow has a matching service DB row."""
+    if not workflow_uses_dask(workflow.reana_specification):
+        return False
+
+    service_name = get_dask_component_name(workflow.id_, "database_model_service")
+    if any(s.name == service_name for s in workflow.services):
+        return False
+
+    workflow.services.append(build_dask_service(workflow))
+    return True
+
+
 def clone_workflow(workflow, reana_spec, restart_type):
     """Create a copy of workflow in DB for restarting."""
     reana_specification = reana_spec or workflow.reana_specification
@@ -723,6 +757,8 @@ def clone_workflow(workflow, reana_spec, restart_type):
             restart=True,
             run_number=workflow.run_number,
         )
+        if workflow_uses_dask(reana_specification):
+            cloned_workflow.services.append(build_dask_service(cloned_workflow))
         Session.add(cloned_workflow)
         Session.object_session(cloned_workflow).commit()
         workflow.inactivate_workspace_retention_rules()


### PR DESCRIPTION
Restarted Dask workflows can be created without a linked dask-service-* database row, which leaves the operator with nowhere to attach service logs. Fixed this by creating the Dask service row when cloning restarted workflows and by ensuring it exists again just before workflow submission.

Closes reanahub/reana-ui#493