### PR TITLE
build(python): upgrade to Flask 3.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,30 +44,30 @@ RUN apt-get update -y && \
 WORKDIR /code
 COPY . /code
 
-# Are we debugging?
-ARG DEBUG=0
-RUN if [ "${DEBUG}" -gt 0 ]; then pip install --no-cache-dir -e ".[debug]"; else pip install --no-cache-dir .; fi;
-
 # Are we building with locally-checked-out shared modules?
+# Install shared modules before the main package so that pip resolves
+# dependencies against the local versions (e.g. reana-db with updated
+# SQLAlchemy pins) rather than pulling published versions from PyPI.
 # hadolint ignore=DL3013
-RUN if test -e modules/reana-commons; then \
-      if [ "${DEBUG}" -gt 0 ]; then \
-        pip install --no-cache-dir -e "modules/reana-commons[kubernetes,yadage,snakemake,cwl]" --upgrade; \
-      else \
-        pip install --no-cache-dir "modules/reana-commons[kubernetes,yadage,snakemake,cwl]" --upgrade; \
-      fi \
-    fi; \
-    if test -e modules/reana-db; then \
+ARG DEBUG=0
+RUN if test -e modules/reana-db; then \
       if [ "${DEBUG}" -gt 0 ]; then \
         pip install --no-cache-dir -e "modules/reana-db" --upgrade; \
       else \
         pip install --no-cache-dir "modules/reana-db" --upgrade; \
       fi \
+    fi; \
+    if test -e modules/reana-commons; then \
+      if [ "${DEBUG}" -gt 0 ]; then \
+        pip install --no-cache-dir -e "modules/reana-commons[kubernetes,yadage,snakemake,cwl]" --upgrade; \
+      else \
+        pip install --no-cache-dir "modules/reana-commons[kubernetes,yadage,snakemake,cwl]" --upgrade; \
+      fi \
     fi
 
-# Install custom invenio-oauthclient branch
+# Install the main package
 # hadolint ignore=DL3013
-RUN pip install --no-cache-dir --force-reinstall --no-deps "git+https://github.com/tiborsimko/invenio-oauthclient.git@reana-een-aai"
+RUN if [ "${DEBUG}" -gt 0 ]; then pip install --no-cache-dir -e ".[debug]"; else pip install --no-cache-dir .; fi;
 
 # A quick fix to allow eduGAIN and social login users that wouldn't otherwise match Invenio username rules
 # hadolint ignore=DL3059

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -305,7 +305,7 @@ SESSION_COOKIE_SAMESITE = "Lax"
 #: In production use the following configuration plus adding  the hostname/ip
 #: of the reverse proxy in front of REANA-Server.
 if REANA_HOSTNAME:
-    APP_ALLOWED_HOSTS = [REANA_HOSTNAME]
+    TRUSTED_HOSTS = [REANA_HOSTNAME]
 
 # Security configuration
 # ======================

--- a/reana_server/reana_admin/check_workflows.py
+++ b/reana_server/reana_admin/check_workflows.py
@@ -361,12 +361,12 @@ def check_workspaces() -> List[CheckResult]:
 
         # find possible user/workflow owner
         try:
-            user = User.query.filter_by(id_=user_id).one_or_none()
+            user = Session.query(User).filter_by(id_=user_id).one_or_none()
         except StatementError:
             # user_id is not a valid UUID
             user = None
         try:
-            workflow = Workflow.query.filter_by(id_=workflow_id).one_or_none()
+            workflow = Session.query(Workflow).filter_by(id_=workflow_id).one_or_none()
         except StatementError:
             # workflow_id is not a valid UUID
             workflow = None

--- a/reana_server/reana_admin/cli.py
+++ b/reana_server/reana_admin/cli.py
@@ -99,7 +99,7 @@ def users_create_default(email, password, id_):
         "email": email,
     }
     try:
-        user = User.query.filter_by(**reana_user_characteristics).first()
+        user = Session.query(User).filter_by(**reana_user_characteristics).first()
         if not user:
             reana_user_characteristics["access_token"] = secrets.token_urlsafe(16)
             user = User(**reana_user_characteristics)
@@ -239,7 +239,7 @@ def token_grant(admin_access_token, id_, email):
     """Grant a token to the selected user."""
     try:
         # token grant is committed before email is sent
-        admin = User.query.filter_by(id_=ADMIN_USER_ID).one_or_none()
+        admin = Session.query(User).filter_by(id_=ADMIN_USER_ID).one_or_none()
         user = _get_user_by_criteria(id_, email)
         error_msg = None
         if not user:
@@ -294,7 +294,7 @@ def token_grant(admin_access_token, id_, email):
 def token_revoke(admin_access_token, id_, email):
     """Revoke selected user's token."""
     try:
-        admin = User.query.filter_by(id_=ADMIN_USER_ID).one_or_none()
+        admin = Session.query(User).filter_by(id_=ADMIN_USER_ID).one_or_none()
         user = _get_user_by_criteria(id_, email)
         error_msg = None
         if not user:
@@ -528,7 +528,7 @@ def list_quota_usage(
 def list_quota_resources(ctx):
     """List quota resources."""
     click.echo("Available resources are:")
-    for resource in Resource.query:
+    for resource in Session.query(Resource):
         click.echo(f"{resource.type_.name} ({resource.name})")
 
 
@@ -604,13 +604,15 @@ def set_default_quota_limit(ctx, admin_access_token: str):
         click.secho("There are no users without quota limits.", fg="green")
         sys.exit(0)
 
-    resources = Resource.query.all()
+    resources = Session.query(Resource).all()
 
     for user in users_without_quota_limits:
         for resource in resources:
-            user_resource = UserResource.query.filter_by(
-                user_id=user.id_, resource_id=resource.id_
-            ).first()
+            user_resource = (
+                Session.query(UserResource)
+                .filter_by(user_id=user.id_, resource_id=resource.id_)
+                .first()
+            )
 
             if user_resource and user_resource.quota_limit == 0:
                 # If no limit exists, set the default limit
@@ -760,11 +762,13 @@ def retention_rules_apply(
         current_time = force_date
         click.echo(f"The current time is forced to be {current_time}")
 
-    candidate_rules = WorkspaceRetentionRule.query
+    candidate_rules = Session.query(WorkspaceRetentionRule)
     if workflow:
         candidate_rules = workflow.retention_rules
     elif user:
-        candidate_rules = WorkspaceRetentionRule.query.join(user.workflows.subquery())
+        candidate_rules = Session.query(WorkspaceRetentionRule).join(
+            user.workflows.subquery()
+        )
 
     click.echo("Setting the status of all the rules that will be applied to `pending`")
     active_rules = candidate_rules.filter(
@@ -830,10 +834,14 @@ def retention_rules_extend(
 ) -> None:
     """Extend active retentions rules."""
     click.echo("Fetching all the active rules")
-    active_rules = WorkspaceRetentionRule.query.filter(
-        WorkspaceRetentionRule.status == WorkspaceRetentionRuleStatus.active,
-        WorkspaceRetentionRule.workflow_id == workflow.id_,
-    ).all()
+    active_rules = (
+        Session.query(WorkspaceRetentionRule)
+        .filter(
+            WorkspaceRetentionRule.status == WorkspaceRetentionRuleStatus.active,
+            WorkspaceRetentionRule.workflow_id == workflow.id_,
+        )
+        .all()
+    )
 
     if not active_rules:
         click.echo("There are no rules to be extended for this workflow!")

--- a/reana_server/reana_admin/options.py
+++ b/reana_server/reana_admin/options.py
@@ -12,6 +12,7 @@ import os
 import sys
 
 import click
+from reana_db.database import Session
 from reana_db.models import Workflow
 
 from reana_server.utils import (
@@ -80,7 +81,11 @@ def add_workflow_option(**attrs):
                 if not is_uuid_v4(workflow_uuid):
                     click.secho("Invalid workflow UUID.", fg="red")
                     sys.exit(1)
-                workflow = Workflow.query.filter(Workflow.id_ == workflow_uuid).first()
+                workflow = (
+                    Session.query(Workflow)
+                    .filter(Workflow.id_ == workflow_uuid)
+                    .first()
+                )
                 if not workflow:
                     click.secho("Workflow not found.", fg="red")
                     sys.exit(1)

--- a/reana_server/rest/gitlab.py
+++ b/reana_server/rest/gitlab.py
@@ -24,9 +24,10 @@ from flask import (
 )
 from flask_login.utils import _create_identifier
 from invenio_oauthclient.utils import get_safe_redirect_target
-from itsdangerous import BadData, TimedJSONWebSignatureSerializer
+from itsdangerous import BadData, URLSafeTimedSerializer
 from reana_commons.k8s.secrets import UserSecretsStore
 from werkzeug.local import LocalProxy
+import marshmallow
 from webargs import fields, validate
 from webargs.flaskparser import use_kwargs
 
@@ -51,7 +52,7 @@ blueprint = Blueprint("gitlab", __name__)
 
 
 serializer = LocalProxy(
-    lambda: TimedJSONWebSignatureSerializer(current_app.config["SECRET_KEY"])
+    lambda: URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
 )
 
 
@@ -202,10 +203,12 @@ def gitlab_oauth(user):  # noqa
 @blueprint.route("/gitlab/projects", methods=["GET"])
 @use_kwargs(
     {
-        "search": fields.Str(location="query"),
-        "page": fields.Int(validate=validate.Range(min=1), location="query"),
-        "size": fields.Int(validate=validate.Range(min=1), location="query"),
-    }
+        "search": fields.Str(),
+        "page": fields.Int(validate=validate.Range(min=1)),
+        "size": fields.Int(validate=validate.Range(min=1)),
+    },
+    location="query",
+    unknown=marshmallow.EXCLUDE,
 )
 @signin_required()
 def gitlab_projects(

--- a/reana_server/rest/launch.py
+++ b/reana_server/rest/launch.py
@@ -16,6 +16,7 @@ import traceback
 from bravado.exception import HTTPError
 from flask import Blueprint, jsonify
 from jsonschema import ValidationError
+import marshmallow
 from marshmallow import Schema
 from webargs import fields
 from webargs.flaskparser import use_kwargs
@@ -58,7 +59,9 @@ load_reana_spec_lock = threading.Lock()
         "name": fields.Str(),
         "parameters": fields.Str(),
         "specification": fields.Str(),
-    }
+    },
+    location="query",
+    unknown=marshmallow.EXCLUDE,
 )
 @signin_required()
 @check_quota

--- a/reana_server/rest/secrets.py
+++ b/reana_server/rest/secrets.py
@@ -17,6 +17,7 @@ from reana_commons.errors import REANASecretAlreadyExists, REANASecretDoesNotExi
 from reana_commons.k8s.secrets import UserSecretsStore, Secret
 from webargs import fields
 from webargs.flaskparser import use_kwargs
+import marshmallow
 from marshmallow import Schema, validate
 
 from reana_server.decorators import signin_required
@@ -47,8 +48,10 @@ class AddSecretsBodySchema(Schema):
 @signin_required()
 @use_kwargs(
     {
-        "overwrite": fields.Bool(missing=False, location="query"),
-    }
+        "overwrite": fields.Bool(load_default=False),
+    },
+    location="query",
+    unknown=marshmallow.EXCLUDE,
 )
 def add_secrets(user, overwrite=False):
     r"""Endpoint to create user secrets.
@@ -150,7 +153,7 @@ def add_secrets(user, overwrite=False):
               }
     """
     json_body = request.json
-    AddSecretsBodySchema(strict=True).validate({"body": json_body})
+    AddSecretsBodySchema().validate({"body": json_body})
 
     try:
         secrets = [
@@ -366,7 +369,7 @@ def delete_secrets(user):  # noqa
               }
     """
     json_body = request.json
-    DeleteSecretsBodySchema(strict=True).validate({"body": json_body})
+    DeleteSecretsBodySchema().validate({"body": json_body})
     secrets = json_body
 
     try:

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -52,6 +52,7 @@ from reana_server.validation import (
     validate_workspace_path,
     validate_dask_limits,
 )
+import marshmallow
 from webargs import fields, validate
 from webargs.flaskparser import use_kwargs
 
@@ -68,13 +69,15 @@ blueprint = Blueprint("workflows", __name__)
     {
         "page": fields.Int(validate=validate.Range(min=1)),
         "size": fields.Int(validate=validate.Range(min=1)),
-        "include_progress": fields.Bool(location="query"),
-        "include_workspace_size": fields.Bool(location="query"),
+        "include_progress": fields.Bool(),
+        "include_workspace_size": fields.Bool(),
         "workflow_id_or_name": fields.Str(),
-        "shared": fields.Bool(location="query"),
-        "shared_by": fields.Str(location="query"),
-        "shared_with": fields.Str(location="query"),
-    }
+        "shared": fields.Bool(),
+        "shared_by": fields.Str(),
+        "shared_with": fields.Str(),
+    },
+    location="query",
+    unknown=marshmallow.EXCLUDE,
 )
 @signin_required(token_required=False)
 def get_workflows(user, **kwargs):  # noqa
@@ -826,7 +829,9 @@ def get_workflow_specification(workflow_id_or_name, user):  # noqa
     {
         "page": fields.Int(validate=validate.Range(min=1)),
         "size": fields.Int(validate=validate.Range(min=1)),
-    }
+    },
+    location="query",
+    unknown=marshmallow.EXCLUDE,
 )
 @signin_required()
 def get_workflow_logs(workflow_id_or_name, user, **kwargs):  # noqa
@@ -1246,11 +1251,12 @@ def _start_workflow(workflow_id_or_name, user, **parameters):
 @signin_required()
 @use_kwargs(
     {
-        "operational_options": fields.Dict(location="json"),
-        "input_parameters": fields.Dict(location="json"),
-        "restart": fields.Boolean(location="json"),
-        "reana_specification": fields.Raw(location="json"),
-    }
+        "operational_options": fields.Dict(),
+        "input_parameters": fields.Dict(),
+        "restart": fields.Boolean(),
+        "reana_specification": fields.Raw(),
+    },
+    location="json",
 )
 @check_quota
 def start_workflow(workflow_id_or_name, user, **parameters):  # noqa
@@ -1420,16 +1426,19 @@ def start_workflow(workflow_id_or_name, user, **parameters):  # noqa
 @blueprint.route("/workflows/<workflow_id_or_name>/status", methods=["PUT"])
 @signin_required()
 @use_kwargs(
+    {"status": fields.Str(required=True)}, location="query", unknown=marshmallow.EXCLUDE
+)
+@use_kwargs(
     {
-        "status": fields.Str(required=True, location="query"),
         # parameters for "start"
-        "input_parameters": fields.Dict(location="json"),
-        "operational_options": fields.Dict(location="json"),
-        "restart": fields.Boolean(location="json"),
+        "input_parameters": fields.Dict(),
+        "operational_options": fields.Dict(),
+        "restart": fields.Boolean(),
         # parameters for "deleted"
-        "all_runs": fields.Boolean(location="json"),
-        "workspace": fields.Boolean(location="json"),
-    }
+        "all_runs": fields.Boolean(),
+        "workspace": fields.Boolean(),
+    },
+    location="json",
 )
 def set_workflow_status(workflow_id_or_name, user, status, **parameters):  # noqa
     r"""Set workflow status.
@@ -2055,7 +2064,9 @@ def delete_file(workflow_id_or_name, file_name, user):  # noqa
         "page": fields.Int(validate=validate.Range(min=1)),
         "size": fields.Int(validate=validate.Range(min=1)),
         "search": fields.String(),
-    }
+    },
+    location="query",
+    unknown=marshmallow.EXCLUDE,
 )
 @signin_required()
 def get_files(workflow_id_or_name, user, **kwargs):  # noqa
@@ -3237,7 +3248,9 @@ def get_workflow_retention_rules(workflow_id_or_name, user):
     {
         "include_inputs": fields.Boolean(),
         "include_outputs": fields.Boolean(),
-    }
+    },
+    location="json",
+    unknown=marshmallow.EXCLUDE,
 )
 @signin_required()
 def prune_workspace(
@@ -3389,10 +3402,11 @@ def prune_workspace(
 @signin_required()
 @use_kwargs(
     {
-        "user_email_to_share_with": fields.Str(required=True, location="json"),
-        "message": fields.Str(location="json"),
-        "valid_until": fields.Str(location="json"),
+        "user_email_to_share_with": fields.Str(required=True),
+        "message": fields.Str(),
+        "valid_until": fields.Str(),
     },
+    location="json",
 )
 def share_workflow(workflow_id_or_name, user, **kwargs):
     r"""Share a workflow with another user.
@@ -3549,7 +3563,9 @@ def share_workflow(workflow_id_or_name, user, **kwargs):
 @use_kwargs(
     {
         "user_email_to_unshare_with": fields.String(),
-    }
+    },
+    location="json",
+    unknown=marshmallow.EXCLUDE,
 )
 @signin_required()
 def unshare_workflow(workflow_id_or_name, user, user_email_to_unshare_with):

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -140,9 +140,11 @@ def prevent_disk_quota_excess(user, bytes_to_sum: Optional[int], action=Optional
     :param action: Optional action description used for custom error messages.
     """
     disk_resource = get_default_quota_resource(ResourceType.disk.name)
-    user_resource = UserResource.query.filter_by(
-        user_id=user.id_, resource_id=disk_resource.id_
-    ).first()
+    user_resource = (
+        Session.query(UserResource)
+        .filter_by(user_id=user.id_, resource_id=disk_resource.id_)
+        .first()
+    )
 
     if bytes_to_sum is None:
         bytes_to_sum = 0
@@ -235,9 +237,11 @@ def filter_input_files(workspace: Union[str, pathlib.Path], reana_spec: Dict) ->
 
 def get_user_from_token(access_token):
     """Validate that the token provided is valid."""
-    user_token = UserToken.query.filter_by(
-        token=access_token, type_=UserTokenType.reana
-    ).one_or_none()
+    user_token = (
+        Session.query(UserToken)
+        .filter_by(token=access_token, type_=UserTokenType.reana)
+        .one_or_none()
+    )
     if not user_token:
         raise ValueError("Token not valid.")
     if user_token.status == UserTokenStatus.revoked:
@@ -401,7 +405,7 @@ def _export_users():
     """
     csv_file_obj = io.StringIO()
     csv_writer = csv.writer(csv_file_obj, dialect="unix")
-    for user in User.query.all():
+    for user in Session.query(User).all():
         csv_writer.writerow(
             [user.id_, user.email, user.access_token, user.username, user.full_name]
         )
@@ -741,7 +745,7 @@ def _get_user_by_criteria(id_: Optional[str], email: Optional[str]) -> Optional[
     if not criteria:
         return None
     try:
-        return User.query.filter_by(**criteria).one_or_none()
+        return Session.query(User).filter_by(**criteria).one_or_none()
     except StatementError as e:
         print(e)
         return None
@@ -838,9 +842,13 @@ def _set_quota_limit(
         # Get resource by name or type
         resource = None
         if resource_name:
-            resource = Resource.query.filter_by(name=resource_name).one_or_none()
+            resource = (
+                Session.query(Resource).filter_by(name=resource_name).one_or_none()
+            )
         elif resource_type in ResourceType._member_names_:
-            available_resources = Resource.query.filter_by(type_=resource_type).all()
+            available_resources = (
+                Session.query(Resource).filter_by(type_=resource_type).all()
+            )
             if len(available_resources) > 1:
                 return (
                     f"ERROR: There are more than one `{resource_type}` resource. Please provide resource name to specify the exact resource.",
@@ -854,7 +862,7 @@ def _set_quota_limit(
             # Resource was not found
             available_resources = [
                 (resource.type_.name if resource_type else resource.name)
-                for resource in Resource.query
+                for resource in Session.query(Resource)
             ]
 
             return (
@@ -864,9 +872,11 @@ def _set_quota_limit(
             )
 
         for user in users:
-            user_resource = UserResource.query.filter_by(
-                user=user, resource=resource
-            ).one_or_none()
+            user_resource = (
+                Session.query(UserResource)
+                .filter_by(user=user, resource=resource)
+                .one_or_none()
+            )
 
             if user_resource:
                 user_resource.quota_limit = limit

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,29 +5,31 @@
 #    pip-compile --annotation-style=line --output-file=requirements.txt setup.py
 #
 adage==0.11.0             # via reana-commons, reana-server (setup.py), yadage
-alembic==1.10.4           # via flask-alembic, invenio-db, reana-db
+alembic==1.18.4           # via flask-alembic, invenio-db, reana-db
 amqp==5.3.1               # via kombu
 appdirs==1.4.4            # via fs, snakemake
 argcomplete==3.6.3        # via cwltool
 argparse-dataclass==2.0.0  # via snakemake-interface-common, snakemake-interface-executor-plugins, yte
-arrow==1.4.0              # via isoduration
+arrow==1.4.0              # via isoduration, marshmallow-utils
 asttokens==3.0.1          # via stack-data
 attrs==26.1.0             # via jsonschema, referencing
-babel==2.18.0             # via flask-babel, invenio-i18n
+babel==2.18.0             # via babel-edtf, flask-babel, invenio-i18n, marshmallow-utils
+babel-edtf==1.2.1         # via marshmallow-utils
 bagit==1.9.0              # via cwltool
 billiard==4.2.4           # via celery
-blinker==1.9.0            # via flask-mail, flask-principal, invenio-base, invenio-oauthclient
+bleach[css]==6.3.0        # via marshmallow-utils
+blinker==1.9.0            # via flask, flask-mail, flask-principal, invenio-base, invenio-oauthclient
 bracex==2.6               # via wcmatch
 bravado==10.3.2           # via reana-commons
 bravado-core==6.1.0       # via bravado, reana-commons
 cachecontrol[filecache]==0.14.4  # via cachecontrol, schema-salad
-cachelib==0.13.0          # via flask-caching, flask-oauthlib, invenio-oauth2server
-celery==5.3.6             # via flask-celeryext, invenio-celery
-certifi==2026.2.25        # via kubernetes, requests
+cachelib==0.13.0          # via flask-caching, flask-oauthlib-invenio, invenio-oauth2server
+celery==5.4.0             # via flask-celeryext, invenio-celery
+certifi==2026.4.22        # via kubernetes, requests
 cffi==2.0.0               # via cryptography
-charset-normalizer==3.4.6  # via requests
+charset-normalizer==3.4.7  # via requests
 checksumdir==1.1.9        # via packtivity, reana-commons, yadage
-click==8.3.1              # via celery, click-didyoumean, click-plugins, click-repl, flask, flask-shell-ipython, packtivity, reana-commons, yadage, yadage-schemas
+click==8.3.3              # via celery, click-didyoumean, click-plugins, click-repl, flask, flask-shell-ipython, packtivity, reana-commons, rich-click, yadage, yadage-schemas
 click-didyoumean==0.3.1   # via celery
 click-plugins==1.1.1.2    # via celery
 click-repl==0.3.0         # via celery
@@ -36,76 +38,81 @@ commonmark==0.9.1         # via rich
 conda-inject==1.3.2       # via snakemake
 configargparse==1.7.5     # via snakemake, snakemake-interface-common
 connection-pool==0.0.3    # via snakemake
-cryptography==46.0.6      # via google-auth, invenio-accounts, pyjwt, sqlalchemy-utils
+cryptography==47.0.0      # via invenio-accounts, pyjwt, sqlalchemy-utils
 cwltool==3.1.20210628163208  # via reana-commons
 decorator==5.2.1          # via ipython, jsonpath-rw
 deprecated==1.3.1         # via limits
 dnspython==2.8.0          # via email-validator
 docutils==0.22.4          # via snakemake
 dpath==2.2.0              # via snakemake, yte
-email-validator==2.3.0    # via flask-security-invenio, wtforms-components
+durationpy==0.10          # via kubernetes
+edtf==5.0.1               # via babel-edtf, marshmallow-utils
+email-validator==2.3.0    # via flask-security-invenio
 executing==2.2.1          # via stack-data
 fastjsonschema==2.21.2    # via nbformat
-filelock==3.25.2          # via cachecontrol
-flask==2.2.5              # via flask-alembic, flask-babel, flask-caching, flask-celeryext, flask-collect-invenio, flask-cors, flask-kvsession-invenio, flask-limiter, flask-login, flask-mail, flask-menu, flask-oauthlib, flask-principal, flask-security-invenio, flask-shell-ipython, flask-sqlalchemy, flask-webpackext, flask-wtf, invenio-base, invenio-config, invenio-mail, reana-server (setup.py)
-flask-alembic==2.0.1      # via invenio-db
+filelock==3.29.0          # via cachecontrol
+flask==3.1.3              # via flask-alembic, flask-babel, flask-caching, flask-celeryext, flask-collect-invenio, flask-cors, flask-kvsession-invenio, flask-limiter, flask-login, flask-mail, flask-menu, flask-oauthlib-invenio, flask-principal, flask-security-invenio, flask-shell-ipython, flask-sqlalchemy, flask-webpackext, flask-wtf, invenio-app, invenio-base, invenio-config, invenio-mail, reana-server (setup.py)
+flask-alembic==3.1.1      # via invenio-db
 flask-babel==4.0.0        # via flask-security-invenio, invenio-i18n
-flask-caching==2.3.1      # via invenio-cache
+flask-caching==2.4.0      # via invenio-cache
 flask-celeryext==0.5.0    # via invenio-celery
 flask-collect-invenio==1.4.0  # via invenio-assets
 flask-cors==6.0.2         # via invenio-rest
-flask-kvsession-invenio==0.6.4  # via invenio-accounts
+flask-kvsession-invenio==1.0.0  # via invenio-accounts
 flask-limiter==2.9.2      # via invenio-app, reana-server (setup.py)
 flask-login==0.6.3        # via flask-security-invenio
 flask-mail==0.9.1         # via flask-security-invenio, invenio-mail
 flask-menu==2.0.0         # via invenio-theme
-flask-oauthlib==0.9.6     # via invenio-oauth2server, invenio-oauthclient
+flask-oauthlib-invenio==2.0.0  # via invenio-oauth2server, invenio-oauthclient
 flask-principal==0.4.0    # via flask-security-invenio
-flask-security-invenio==3.8.3  # via invenio-accounts, reana-server (setup.py)
+flask-security-invenio==4.2.1  # via invenio-accounts, reana-server (setup.py)
 flask-shell-ipython==0.5.3  # via invenio-app
-flask-sqlalchemy==2.5.1   # via flask-alembic, invenio-db
+flask-sqlalchemy==3.1.1   # via invenio-db
 flask-talisman==0.8.1     # via invenio-app
 flask-webpackext==2.1.0   # via invenio-assets
-flask-wtf==1.2.2          # via flask-security-invenio, invenio-oauth2server
+flask-wtf==1.3.0          # via flask-security-invenio, invenio-oauth2server
 fqdn==1.5.1               # via jsonschema
 fs==2.4.16                # via reana-commons
+ftfy==6.3.1               # via marshmallow-utils
 future==1.0.0             # via invenio-oauth2server
+geojson==3.2.0            # via marshmallow-utils
 gherkin-official==39.0.0  # via reana-commons
 gitdb==4.0.12             # via gitpython
 github3-py==4.0.1         # via invenio-oauthclient
-gitpython==3.1.46         # via reana-server (setup.py), snakemake
+gitpython==3.1.48         # via reana-server (setup.py), snakemake
 glob2==0.7                # via packtivity, yadage
-google-auth==2.49.1       # via kubernetes
-greenlet==3.3.2           # via sqlalchemy
+greenlet==3.5.0           # via sqlalchemy
 humanfriendly==10.0       # via coloredlogs, snakemake, snakemake-interface-storage-plugins
-idna==3.11                # via email-validator, jsonschema, requests
+idna==3.13                # via email-validator, jsonschema, requests
+idutils==1.6.0            # via marshmallow-utils
 immutables==0.21          # via snakemake
-importlib-metadata==4.13.0  # via invenio-base, invenio-oauth2server, reana-server (setup.py)
-importlib-resources==6.5.2  # via invenio-base, swagger-spec-validator
+importlib-metadata==9.0.0  # via invenio-base, invenio-oauth2server
+importlib-resources==7.1.0  # via invenio-base, swagger-spec-validator
 infinity==1.5             # via intervals
 intervals==0.9.2          # via wtforms-components
-invenio-access==3.0.2     # via reana-server (setup.py)
-invenio-accounts==5.2.2   # via invenio-access, invenio-oauth2server, invenio-oauthclient, invenio-userprofiles, reana-server (setup.py)
-invenio-app==1.5.1        # via reana-server (setup.py)
-invenio-assets==3.2.0     # via invenio-theme
-invenio-base==1.4.0       # via invenio-access, invenio-app, invenio-assets, invenio-cache, invenio-celery, invenio-db, invenio-i18n, invenio-oauth2server, invenio-oauthclient, invenio-rest, invenio-theme, reana-server (setup.py)
-invenio-cache==1.3.1      # via invenio-app, reana-server (setup.py)
-invenio-celery==1.3.2     # via invenio-accounts, invenio-app, invenio-logging
-invenio-config==1.0.4     # via invenio-app, reana-server (setup.py)
-invenio-db[postgresql]==1.3.1  # via invenio-logging, reana-server (setup.py)
-invenio-i18n==2.2.0       # via invenio-access, invenio-accounts, invenio-oauth2server, invenio-oauthclient, invenio-theme, invenio-userprofiles, reana-server (setup.py)
-invenio-logging==2.1.5    # via invenio-rest, reana-server (setup.py)
+invenio-access==5.1.0     # via reana-server (setup.py)
+invenio-accounts==7.2.1   # via invenio-access, invenio-oauth2server, invenio-oauthclient, invenio-userprofiles, reana-server (setup.py)
+invenio-app==3.0.0        # via reana-server (setup.py)
+invenio-assets==4.2.1     # via invenio-theme
+invenio-base==2.4.0       # via invenio-access, invenio-app, invenio-assets, invenio-cache, invenio-celery, invenio-config, invenio-db, invenio-i18n, invenio-oauth2server, invenio-oauthclient, invenio-rest, invenio-theme, reana-server (setup.py)
+invenio-cache==3.0.0      # via invenio-app, reana-server (setup.py)
+invenio-celery==2.2.0     # via invenio-accounts, invenio-app, invenio-logging
+invenio-config==1.1.0     # via invenio-app, reana-server (setup.py)
+invenio-db[postgresql]==2.5.0  # via invenio-logging, reana-server (setup.py)
+invenio-i18n==3.5.0       # via invenio-access, invenio-accounts, invenio-oauth2server, invenio-oauthclient, invenio-theme, invenio-userprofiles, reana-server (setup.py)
+invenio-logging==4.1.1    # via invenio-rest, reana-server (setup.py)
 invenio-mail==2.3.0       # via invenio-accounts, invenio-oauthclient, reana-server (setup.py)
-invenio-oauth2server==2.3.1  # via reana-server (setup.py)
-invenio-oauthclient @ git+https://github.com/tiborsimko/invenio-oauthclient.git@reana-een-aai  # via reana-server (setup.py)
-invenio-rest==1.5.2       # via invenio-accounts
-invenio-theme==3.6.1      # via invenio-accounts, invenio-oauth2server, invenio-oauthclient, reana-server (setup.py)
-invenio-userprofiles==3.1.0  # via reana-server (setup.py)
-ipython==9.11.0           # via flask-shell-ipython
+invenio-oauth2server==4.0.0  # via reana-server (setup.py)
+invenio-oauthclient==7.0.0  # via reana-server (setup.py)
+invenio-rest==3.0.1       # via invenio-accounts
+invenio-theme==4.7.0      # via invenio-accounts, invenio-oauth2server, invenio-oauthclient, reana-server (setup.py)
+invenio-userprofiles==5.1.0  # via reana-server (setup.py)
+ipython==9.13.0           # via flask-shell-ipython
 ipython-pygments-lexers==1.1.1  # via ipython
+isbnlib==3.10.14          # via idutils
 isodate==0.7.2            # via rdflib
 isoduration==20.11.0      # via jsonschema
-itsdangerous==2.0.1       # via flask, flask-kvsession-invenio, flask-security-invenio, flask-wtf, invenio-base, invenio-rest
+itsdangerous==2.2.0       # via flask, flask-kvsession-invenio, flask-security-invenio, flask-wtf, invenio-base, invenio-rest
 jedi==0.19.2              # via ipython
 jinja2==3.1.6             # via flask, flask-babel, snakemake
 jq==1.11.0                # via packtivity, yadage
@@ -116,16 +123,19 @@ jsonref==1.1.0            # via bravado-core, packtivity, yadage, yadage-schemas
 jsonschema[format]==4.9.1  # via bravado-core, nbformat, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas
 jupyter-core==5.9.1       # via nbformat
 kombu==5.6.2              # via celery, reana-commons
-kubernetes==26.1.0        # via reana-commons
-limits==5.8.0             # via flask-limiter
-lxml==6.0.2               # via prov
-mako==1.3.10              # via alembic
-markupsafe==3.0.3         # via flask-security-invenio, invenio-base, invenio-oauthclient, jinja2, mako, werkzeug, wtforms, wtforms-components
-marshmallow==2.21.0       # via invenio-rest, reana-server (setup.py), webargs
+kubernetes==35.0.0        # via reana-commons
+libpass==1.9.3            # via flask-security-invenio
+limits==5.8.0             # via flask-limiter, invenio-accounts
+lxml==6.1.0               # via prov
+mako==1.3.11              # via alembic
+markupsafe==3.0.3         # via flask, flask-security-invenio, invenio-base, invenio-oauthclient, jinja2, mako, werkzeug, wtforms, wtforms-components
+marshmallow==3.26.2       # via invenio-rest, marshmallow-oneofschema, marshmallow-utils, reana-server (setup.py), webargs
+marshmallow-oneofschema==3.2.0  # via marshmallow-utils
+marshmallow-utils==0.14.1  # via invenio-rest
 matplotlib-inline==0.2.1  # via ipython
 maxminddb==3.1.1          # via maxminddb-geolite2
 maxminddb-geolite2==2018.703  # via invenio-accounts
-mistune==3.1.4            # via schema-salad
+mistune==3.2.0            # via schema-salad
 mock==3.0.5               # via packtivity, reana-commons
 monotonic==1.6            # via bravado
 msgpack==1.1.2            # via bravado-core, cachecontrol, invenio-celery
@@ -133,55 +143,56 @@ msgpack-python==0.5.6     # via bravado
 mypy-extensions==1.1.0    # via cwltool, schema-salad
 nbformat==5.10.4          # via snakemake
 networkx==3.6.1           # via adage, prov
-oauthlib==2.1.0           # via flask-oauthlib, invenio-oauthclient, requests-oauthlib
+oauthlib==3.3.1           # via flask-oauthlib-invenio, invenio-oauthclient, requests-oauthlib
 ordered-set==4.1.0        # via flask-limiter
-packaging==25.0           # via kombu, limits, snakemake, snakemake-interface-common
+packaging==25.0           # via kombu, limits, marshmallow, snakemake, snakemake-interface-common, webargs
 packtivity==0.16.2        # via reana-server (setup.py), yadage
 parse==1.21.1             # via reana-commons
 parso==0.8.6              # via jedi
-passlib==1.7.4            # via flask-security-invenio
 pexpect==4.9.0            # via ipython
-platformdirs==4.9.4       # via jupyter-core
+platformdirs==4.9.6       # via jupyter-core
 ply==3.11                 # via jsonpath-rw
+polib==1.2.0              # via invenio-i18n
 prompt-toolkit==3.0.52    # via click-repl, ipython
 prov==1.5.1               # via cwltool
-psutil==7.2.2             # via cwltool, snakemake, yadage
-psycopg2-binary==2.9.11   # via invenio-db, reana-db
+psutil==7.2.2             # via cwltool, ipython, snakemake, yadage
+psycopg2-binary==2.9.12   # via invenio-db, reana-db
 ptyprocess==0.7.0         # via pexpect
 pulp==3.3.0               # via snakemake
 pure-eval==0.2.3          # via stack-data
-pyasn1==0.6.3             # via pyasn1-modules
-pyasn1-modules==0.4.2     # via google-auth
+pycountry==26.2.16        # via marshmallow-utils
 pycparser==3.0            # via cffi
 pydot==4.0.1              # via cwltool
-pygments==2.19.2          # via ipython, ipython-pygments-lexers, rich
+pygments==2.20.0          # via ipython, ipython-pygments-lexers, rich
 pyjwt[crypto]==2.12.1     # via github3-py, invenio-accounts, invenio-oauth2server
 pynpm==0.3.0              # via pywebpack
-pyparsing==3.3.2          # via pydot, rdflib
+pyparsing==3.3.2          # via edtf, pydot, rdflib
 pyrsistent==0.20.0        # via jsonschema
-python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, celery, github3-py, kubernetes, prov
+python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, celery, edtf, github3-py, kubernetes, prov
 pytz==2024.1              # via bravado-core, flask-babel, invenio-i18n
 pywebpack==2.2.1          # via flask-webpackext
 pyyaml==6.0.3             # via bravado, bravado-core, conda-inject, kubernetes, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas, yte
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons[cwl,kubernetes,snakemake,yadage]==0.95.0a14  # via reana-db, reana-server (setup.py)
-reana-db==0.95.0a6        # via reana-server (setup.py)
+reana-commons[cwl,kubernetes,snakemake,yadage]==0.95.0a15  # via reana-db, reana-server (setup.py)
+reana-db==0.95.0a7        # via reana-server (setup.py)
 redis==7.4.0              # via invenio-celery
 referencing==0.37.0       # via snakemake
-requests[security]==2.33.0  # via bravado, bravado-core, cachecontrol, cwltool, github3-py, kubernetes, packtivity, reana-server (setup.py), requests-oauthlib, schema-salad, snakemake, yadage, yadage-schemas
-requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient, kubernetes
+requests[security]==2.33.1  # via bravado, bravado-core, cachecontrol, cwltool, github3-py, kubernetes, packtivity, reana-server (setup.py), requests-oauthlib, schema-salad, snakemake, yadage, yadage-schemas
+requests-oauthlib==2.0.0  # via flask-oauthlib-invenio, invenio-oauth2server, invenio-oauthclient, kubernetes
 reretry==0.11.8           # via snakemake
 rfc3339-validator==0.1.4  # via jsonschema
 rfc3987==1.3.8            # via jsonschema
-rich==12.6.0              # via flask-limiter
+rich==12.6.0              # via flask-limiter, rich-argparse, rich-click
+rich-argparse==1.7.2      # via schema-salad
+rich-click==1.9.7         # via invenio-i18n
 rpds-py==0.30.0           # via referencing
 ruamel-yaml==0.17.10      # via cwltool, schema-salad
-schema-salad==8.9.20251102115403  # via cwltool
+schema-salad==8.9.20260417192335  # via cwltool
 shellescape==3.8.1        # via cwltool
-simplejson==3.20.2        # via bravado, bravado-core
+simplejson==4.1.1         # via bravado, bravado-core
 simplekv==0.14.1          # via flask-kvsession-invenio, invenio-accounts
-six==1.17.0               # via bravado, bravado-core, flask-kvsession-invenio, flask-talisman, fs, jsonpath-rw, kubernetes, mock, prov, python-dateutil, rdflib, reana-server (setup.py), rfc3339-validator, wtforms-components
-smart-open==7.5.1         # via snakemake
+six==1.17.0               # via bravado, bravado-core, flask-talisman, fs, jsonpath-rw, kubernetes, mock, prov, python-dateutil, rdflib, reana-server (setup.py), rfc3339-validator
+smart-open==7.6.0         # via snakemake
 smmap==5.0.3              # via gitdb
 snakemake==9.16.3         # via reana-commons
 snakemake-interface-common==1.23.0  # via snakemake, snakemake-interface-executor-plugins, snakemake-interface-logger-plugins, snakemake-interface-report-plugins, snakemake-interface-scheduler-plugins, snakemake-interface-storage-plugins
@@ -191,44 +202,46 @@ snakemake-interface-report-plugins==1.3.0  # via snakemake
 snakemake-interface-scheduler-plugins==2.0.2  # via snakemake
 snakemake-interface-storage-plugins==4.4.1  # via snakemake
 speaklater==1.3           # via flask-security-invenio
-sqlalchemy[asyncio]==1.4.54  # via alembic, flask-alembic, flask-sqlalchemy, invenio-db, reana-db, sqlalchemy-continuum, sqlalchemy-utils, wtforms-alchemy
-sqlalchemy-continuum==1.6.0  # via invenio-db
-sqlalchemy-utils[encrypted]==0.38.3  # via invenio-db, reana-db, sqlalchemy-utils, wtforms-alchemy
+sqlalchemy[asyncio]==2.0.49  # via alembic, flask-alembic, flask-sqlalchemy, invenio-db, reana-db, sqlalchemy-continuum, sqlalchemy-utils, wtforms-alchemy
+sqlalchemy-continuum==1.5.2  # via invenio-db
+sqlalchemy-utils[encrypted]==0.41.2  # via invenio-db, reana-db, sqlalchemy-utils, wtforms-alchemy
 stack-data==0.6.3         # via ipython
 swagger-spec-validator==3.0.4  # via bravado-core
 tablib==3.9.0             # via reana-server (setup.py)
 tabulate==0.10.0          # via snakemake
 tenacity==9.1.4           # via snakemake-interface-storage-plugins
 throttler==1.2.3          # via snakemake, snakemake-interface-executor-plugins, snakemake-interface-storage-plugins
+tinycss2==1.4.0           # via bleach
 traitlets==5.14.3         # via ipython, jupyter-core, matplotlib-inline, nbformat
-typing-extensions==4.15.0  # via alembic, bravado, cwltool, flask-limiter, gherkin-official, limits, referencing, swagger-spec-validator
-tzdata==2025.3            # via arrow, celery, kombu
-ua-parser==1.0.1          # via invenio-accounts
+typing-extensions==4.15.0  # via alembic, bravado, cwltool, flask-limiter, gherkin-official, limits, referencing, sqlalchemy, swagger-spec-validator
+tzdata==2026.2            # via arrow, celery, kombu
+ua-parser==1.0.2          # via invenio-accounts
 ua-parser-builtins==202603  # via ua-parser
 uri-template==1.3.0       # via jsonschema
-uritemplate==4.2.0        # via github3-py, invenio-oauthclient
-uritools==6.0.1           # via invenio-app, invenio-oauthclient
+uritemplate==4.2.0        # via github3-py, invenio-oauthclient, marshmallow-utils
+uritools==6.0.2           # via invenio-app, invenio-oauthclient
 urllib3==2.6.3            # via kubernetes, requests
 uwsgi==2.0.31             # via reana-server (setup.py)
 uwsgi-tools==1.1.1        # via reana-server (setup.py)
 uwsgitop==0.12            # via reana-server (setup.py)
 validators==0.35.0        # via wtforms-components
 vine==5.1.0               # via amqp, celery, kombu
-watchdog==2.2.1           # via invenio-base
+watchdog==6.0.0           # via invenio-base
 wcmatch==8.4.1            # via reana-commons
-wcwidth==0.6.0            # via prompt-toolkit
-webargs==5.5.3            # via invenio-rest
+wcwidth==0.6.0            # via ftfy, prompt-toolkit
+webargs==8.7.1            # via invenio-rest
 webcolors==25.10.0        # via jsonschema
+webencodings==0.5.1       # via bleach, tinycss2
 websocket-client==1.9.0   # via kubernetes
-werkzeug==2.2.3           # via flask, flask-cors, flask-kvsession-invenio, flask-login, invenio-base, reana-commons
+werkzeug==3.1.8           # via flask, flask-cors, flask-kvsession-invenio, flask-login, invenio-base, marshmallow-utils, reana-commons
 wrapt==2.1.2              # via deprecated, smart-open, snakemake, snakemake-interface-storage-plugins
-wtforms==2.3.3            # via flask-wtf, invenio-oauth2server, reana-server (setup.py), wtforms-alchemy, wtforms-components
-wtforms-alchemy==0.18.0   # via invenio-oauth2server
-wtforms-components==0.10.5  # via wtforms-alchemy
+wtforms==3.2.1            # via flask-wtf, invenio-oauth2server, wtforms-alchemy, wtforms-components
+wtforms-alchemy==0.19.1   # via invenio-oauth2server
+wtforms-components==0.11.0  # via wtforms-alchemy
 yadage==0.20.1            # via reana-commons, reana-server (setup.py)
 yadage-schemas==0.10.6    # via packtivity, reana-commons, reana-server (setup.py), yadage
 yte==1.9.4                # via snakemake
-zipp==3.23.0              # via importlib-metadata
+zipp==3.23.1              # via importlib-metadata
 zxcvbn==4.5.0             # via flask-security-invenio
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -32,7 +32,7 @@ clean_old_db_container() {
     OLD="$(docker ps --all --quiet --filter=name=postgres__reana-server)"
     if [ -n "$OLD" ]; then
         echo '==> [INFO] Cleaning old DB container...'
-        docker stop postgres__reana-server
+        docker rm -f postgres__reana-server >/dev/null 2>&1 || true
     fi
 }
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -34,7 +34,7 @@ extras_require = {
         "sphinx-click>=1.0.4",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a4,<0.96.0",
+        "pytest-reana>=0.95.0a9,<0.96.0",
     ],
 }
 
@@ -45,18 +45,17 @@ for key, reqs in extras_require.items():
     extras_require["all"].extend(reqs)
 
 install_requires = [
-    "Flask>=2.1.1,<2.3.0",  # same upper pin as invenio-base
+    "Flask>=3.0.0,<4.0.0",
     "gitpython>=3.1",
-    "marshmallow>2.13.0,<3.0.0",
-    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.95.0a14,<0.96.0",
-    "reana-db>=0.95.0a6,<0.96.0",
+    "marshmallow>=3.5.0,<4.0.0",
+    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.95.0a15,<0.96.0",
+    "reana-db>=0.95.0a7,<0.96.0",
     "requests>=2.25.0",
     "tablib>=0.12.1",
     "uWSGI>=2.0.17",
     "uwsgi-tools>=1.1.1",
     "uwsgitop>=0.10",
-    "flask-security-invenio<4.0.0",
-    "wtforms<3.0.0",
+    "flask-security-invenio>=4.0.0,<5.0.0",
     # Yadage dependencies
     # Pinning adage/packtivity/yadage/yadage-schemas to make sure we use compatible versions.
     # See https://github.com/reanahub/reana-workflow-engine-yadage/pull/236#discussion_r992475484
@@ -65,26 +64,24 @@ install_requires = [
     "yadage==0.20.1",  # matches the version in r-w-e-yadage
     "yadage-schemas==0.10.6",  # matches the version in r-w-e-yadage
     # Invenio dependencies
-    "invenio-app>=1.5.0",  # 1.5 needed for Python 3.12 support
-    "flask-limiter>=2.3",  # dependency of invenio-app, 2.3 needed for Python 3.12 support
-    "invenio-base>=1.2.0",
-    "importlib-metadata<5.0.0",  # needed by `invenio instance migrate-secret-key`
-    "invenio-cache>=1.1.0",
-    "invenio-config>=1.0.3",
+    "invenio-app>=3.0.0,<4.0.0",
+    "flask-limiter>=2.3,<3",
+    "invenio-base>=2.3.0,<3.0.0",
+    "invenio-cache>=3.0.0,<4.0.0",
+    "invenio-config>=1.0.3,<2.0.0",
     # From base bundle
-    "invenio-logging>=1.3.0",
-    "invenio-mail>=1.0.2",
+    "invenio-logging>=4.0.0,<5.0.0",
+    "invenio-mail>=1.0.2,<3.0.0",
     # From auth bundle
-    "invenio-accounts>=2.0.0,<6.0.0",
-    "invenio-oauth2server>=1.3.0",
-    "invenio-oauthclient @ git+https://github.com/tiborsimko/invenio-oauthclient.git@reana-een-aai",
-    "invenio-userprofiles>=1.2.0",
-    "invenio-userprofiles>=1.2.0",
-    "invenio-theme>=1.4.7",
-    "invenio-i18n>=1.3.3",
-    "invenio-access>=2.0.0",
+    "invenio-accounts>=7.0.0,<8.0.0",
+    "invenio-oauth2server>=4.0.0,<5.0.0",
+    "invenio-oauthclient>=7.0.0,<8.0.0",
+    "invenio-userprofiles>=5.0.0,<6.0.0",
+    "invenio-theme>=4.0.0,<5.0.0",
+    "invenio-i18n>=3.0.0,<4.0.0",
+    "invenio-access>=5.0.0,<6.0.0",
     # Invenio database
-    "invenio-db[postgresql]>=1.0.5",
+    "invenio-db[postgresql]>=2.5.0,<3.0.0",
     "six>=1.12.0",  # required by Flask-Breadcrumbs
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def base_app(tmp_shared_volume_path):
         "SERVER_NAME": "localhost:5000",
         "SECRET_KEY": "SECRET_KEY",
         "TESTING": True,
-        "FLASK_ENV": "development",
+        "DEBUG": True,
         "SHARED_VOLUME_PATH": tmp_shared_volume_path,
         "SQLALCHEMY_DATABASE_URI": os.getenv("REANA_SQLALCHEMY_DATABASE_URI"),
         "SQLALCHEMY_TRACK_MODIFICATIONS": False,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -18,7 +18,9 @@ from reana_server.decorators import signin_required
 def test_signing_required_with_token(user0: User):
     """Test `signin_required` when user does not have a valid token."""
     # Delete user tokens
-    UserToken.query.filter(UserToken.user_id == user0.id_).delete()
+    from reana_db.database import Session
+
+    Session.query(UserToken).filter(UserToken.user_id == user0.id_).delete()
 
     mock_endpoint = Mock(return_value=(jsonify(message="Ok"), 200))
     mock_current_user = Mock()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -352,7 +352,7 @@ def test_set_workflow_status(app, user0, _get_user_mock):
                     "access_token": user0.access_token,
                     "status": "stop",
                 },
-                data=json.dumps(dict(parameters=None)),
+                data=json.dumps({}),
             )
             assert res.status_code == 200
 


### PR DESCRIPTION
Upgrade Flask from `<2.3.0` to `>=3.0.0`, together with the full Invenio package stack to its latest major versions. This includes invenio-app 3.x, invenio-base 2.x, invenio-accounts 7.x, invenio-access 5.x, invenio-oauth2server 4.x, invenio-oauthclient 7.x, invenio-userprofiles 5.x, invenio-theme 4.x, invenio-i18n 3.x, invenio-logging 4.x, invenio-cache 3.x, invenio-mail 2.x, and invenio-db 2.5.0 (which in turn brings SQLAlchemy 2.x and Flask-SQLAlchemy 3.x). The flask-security-invenio dependency is bumped from `<4.0.0` to `>=4.0.0,<5.0.0` accordingly.

Switch the OAuth client back to the upstream `invenio-oauthclient` package, since the EOSC EU Node AAI provider that previously required a custom REANA fork is now included in upstream 7.x. Drop the corresponding `git+https://...` install line from the Dockerfile.

Replace the `TimedJSONWebSignatureSerializer` used in the GitLab OAuth flow with `URLSafeTimedSerializer`, since the former was removed in itsdangerous 2.x. Migrate marshmallow 2 patterns in the REST endpoints to marshmallow 3 (replace the deprecated `strict=True` flag, replace `missing=` with `load_default=`, move `location=` from individual fields to the `@use_kwargs` decorator, and add `unknown=marshmallow.EXCLUDE` to query-string parsers so that extra REANA-specific parameters such as `access_token` are ignored). Update endpoints whose function bodies read query parameters from `request.args` so that those parameters are also declared on `@use_kwargs`, since webargs 8 no longer falls through to undeclared fields. Replace several remaining `Model.query` calls in admin commands and helpers with explicit `Session.query(Model)` queries for SQLAlchemy 2.x.

Drop the obsolete `wtforms<3.0.0` and `importlib-metadata<5.0.0` pins, which were only there to constrain the older Invenio versions, and replace `APP_ALLOWED_HOSTS` with the new `TRUSTED_HOSTS` setting introduced by invenio-app 3.x.

Replace the deprecated `FLASK_ENV` setting with `DEBUG` in the test configuration. Remove pinned `reana-commons`, `reana-db`, and other Invenio/Flask ecosystem packages from `requirements.txt` so that `pip install .` resolves them freshly from `setup.py` against the locally-mounted `modules/reana-db` and `modules/reana-commons` shared sources during development.

Closes reanahub/reana-server#770.