### PR TITLE
refactor(admin): replace dynamic subquery with explicit join

### DIFF
--- a/reana_server/reana_admin/cli.py
+++ b/reana_server/reana_admin/cli.py
@@ -764,10 +764,10 @@ def retention_rules_apply(
 
     candidate_rules = Session.query(WorkspaceRetentionRule)
     if workflow:
-        candidate_rules = workflow.retention_rules
+        candidate_rules = candidate_rules.filter_by(workflow_id=workflow.id_)
     elif user:
-        candidate_rules = Session.query(WorkspaceRetentionRule).join(
-            user.workflows.subquery()
+        candidate_rules = candidate_rules.join(Workflow).filter(
+            Workflow.owner_id == user.id_
         )
 
     click.echo("Setting the status of all the rules that will be applied to `pending`")

--- a/reana_server/reana_admin/cli.py
+++ b/reana_server/reana_admin/cli.py
@@ -1049,8 +1049,8 @@ def interactive_session_cleanup(
 
         last_activity = datetime.datetime.strptime(
             session_status["last_activity"], "%Y-%m-%dT%H:%M:%S.%f%z"
-        ).replace(tzinfo=None)
-        duration = datetime.datetime.utcnow() - last_activity
+        )
+        duration = datetime.datetime.now(datetime.UTC) - last_activity
         if duration.days >= days:
             if dry_run:
                 click.echo(


### PR DESCRIPTION
-    refactor(admin): replace deprecated datetime.utcnow() 

    `datetime.utcnow()` is deprecated since Python 3.12 in favour of
    the timezone-aware `datetime.now(datetime.UTC)`.

    Drop the `.replace(tzinfo=None)` that stripped the timezone from
    `last_activity` to make it match the naive `utcnow()` result.
    Both `last_activity` (parsed with `%z`) and the new
    `datetime.now(datetime.UTC)` are now timezone-aware UTC values,
    so the subtraction yields the same `timedelta` as before.

-    refactor(admin): replace dynamic subquery with explicit join 

    `reana-admin retention-rules-apply` selected candidate retention
    rules either from `workflow.retention_rules` (a query object,
    under the old `lazy="dynamic"` setting on
    `Workflow.retention_rules`) or by joining onto
    `user.workflows.subquery()` (a subquery built from the dynamic
    `User.workflows` query).

    After dropping `lazy="dynamic"` in reana-db so these
    relationships return regular lists, the previous code no longer
    works: lists have neither a `.subquery()` method nor the
    follow-up `.filter(...)` chain that the rest of the function
    relies on.

    Replace both branches with explicit queries on
    `WorkspaceRetentionRule`: filter by `workflow_id` for the
    single-workflow case, and join `Workflow` filtered by
    `owner_id` for the per-user case. Result is the same set of
    rows, but expressed through standard `Session.query(...)`
    calls.
