### PR TITLE
fix(status): use Raw fields in ClusterHealthSchema dict values

### DIFF
--- a/reana_server/status.py
+++ b/reana_server/status.py
@@ -685,10 +685,10 @@ class ClusterHealth:
 class ClusterHealthSchema(Schema):
     """Cluster health marshmallow schema."""
 
-    node = fields.Dict(keys=fields.Str(), values=fields.Int())
-    job = fields.Dict(keys=fields.Str(), values=fields.Int())
-    workflow = fields.Dict(keys=fields.Str(), values=fields.Int())
-    session = fields.Dict(keys=fields.Str(), values=fields.Int())
+    node = fields.Dict(keys=fields.Str(), values=fields.Raw())
+    job = fields.Dict(keys=fields.Str(), values=fields.Raw())
+    workflow = fields.Dict(keys=fields.Str(), values=fields.Raw())
+    session = fields.Dict(keys=fields.Str(), values=fields.Raw())
 
 
 STATUS_OBJECT_TYPES = {


### PR DESCRIPTION
ClusterHealthSchema declared each dict's values as fields.Int(), but the dicts also carry a "health" key whose value is a string ("healthy", "warning", "critical"). Older marshmallow tolerated this on dump(); marshmallow 3.26 strictly coerces each dict value to the declared type and fails with a ValueError.

Switching the value type to fields.Raw() lets each entry pass through with its native Python type, which is what the endpoint already produces and what the OpenAPI spec already documents.