### PR TITLE
refactor(pytest): drop pytest-reana for reana-commons[tests]

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
-addopts = --ignore=docs --cov=reana_server --cov-report=term-missing --cov-report=xml
+addopts = --ignore=docs --ignore=modules --cov=reana_server --cov-report=term-missing --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ amqp==5.3.1               # via kombu
 appdirs==1.4.4            # via fs, snakemake
 argcomplete==3.6.3        # via cwltool
 argparse-dataclass==2.0.0  # via snakemake-interface-common, snakemake-interface-executor-plugins, yte
-arrow==1.4.0              # via isoduration, marshmallow-utils
+arrow==1.4.0              # via marshmallow-utils
 asttokens==3.0.1          # via stack-data
 attrs==26.1.0             # via jsonschema, referencing
 babel==2.18.0             # via babel-edtf, flask-babel, invenio-i18n, marshmallow-utils
@@ -23,7 +23,7 @@ bracex==2.6               # via wcmatch
 bravado==10.3.2           # via reana-commons
 bravado-core==6.1.0       # via bravado, reana-commons
 cachecontrol[filecache]==0.14.4  # via cachecontrol, schema-salad
-cachelib==0.13.0          # via flask-caching, flask-oauthlib-invenio, invenio-oauth2server
+cachelib==0.14.0          # via flask-caching, flask-oauthlib-invenio, invenio-oauth2server
 celery==5.4.0             # via flask-celeryext, invenio-celery
 certifi==2026.4.22        # via kubernetes, requests
 cffi==2.0.0               # via cryptography
@@ -38,7 +38,7 @@ commonmark==0.9.1         # via rich
 conda-inject==1.3.2       # via snakemake
 configargparse==1.7.5     # via snakemake, snakemake-interface-common
 connection-pool==0.0.3    # via snakemake
-cryptography==47.0.0      # via invenio-accounts, pyjwt, sqlalchemy-utils
+cryptography==48.0.0      # via invenio-accounts, pyjwt, sqlalchemy-utils
 cwltool==3.1.20210628163208  # via reana-commons
 decorator==5.2.1          # via ipython, jsonpath-rw
 deprecated==1.3.1         # via limits
@@ -71,19 +71,18 @@ flask-sqlalchemy==3.1.1   # via invenio-db
 flask-talisman==0.8.1     # via invenio-app
 flask-webpackext==2.1.0   # via invenio-assets
 flask-wtf==1.3.0          # via flask-security-invenio, invenio-oauth2server
-fqdn==1.5.1               # via jsonschema
 fs==2.4.16                # via reana-commons
 ftfy==6.3.1               # via marshmallow-utils
 future==1.0.0             # via invenio-oauth2server
 geojson==3.2.0            # via marshmallow-utils
-gherkin-official==39.0.0  # via reana-commons
+gherkin-official==39.1.0  # via reana-commons
 gitdb==4.0.12             # via gitpython
 github3-py==4.0.1         # via invenio-oauthclient
-gitpython==3.1.48         # via reana-server (setup.py), snakemake
+gitpython==3.1.50         # via reana-server (setup.py), snakemake
 glob2==0.7                # via packtivity, yadage
 greenlet==3.5.0           # via sqlalchemy
 humanfriendly==10.0       # via coloredlogs, snakemake, snakemake-interface-storage-plugins
-idna==3.13                # via email-validator, jsonschema, requests
+idna==3.14                # via email-validator, jsonschema, requests
 idutils==1.6.0            # via marshmallow-utils
 immutables==0.21          # via snakemake
 importlib-metadata==9.0.0  # via invenio-base, invenio-oauth2server
@@ -111,31 +110,30 @@ ipython==9.13.0           # via flask-shell-ipython
 ipython-pygments-lexers==1.1.1  # via ipython
 isbnlib==3.10.14          # via idutils
 isodate==0.7.2            # via rdflib
-isoduration==20.11.0      # via jsonschema
 itsdangerous==2.2.0       # via flask, flask-kvsession-invenio, flask-security-invenio, flask-wtf, invenio-base, invenio-rest
-jedi==0.19.2              # via ipython
+jedi==0.20.0              # via ipython
 jinja2==3.1.6             # via flask, flask-babel, snakemake
 jq==1.11.0                # via packtivity, yadage
 jsmin==3.0.1              # via invenio-theme
 jsonpath-rw==1.4.0        # via packtivity, yadage
 jsonpointer==3.1.1        # via jsonschema, packtivity, yadage
 jsonref==1.1.0            # via bravado-core, packtivity, yadage, yadage-schemas
-jsonschema[format]==4.9.1  # via bravado-core, nbformat, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas
+jsonschema[format]==3.2.0  # via bravado-core, nbformat, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas
 jupyter-core==5.9.1       # via nbformat
 kombu==5.6.2              # via celery, reana-commons
 kubernetes==35.0.0        # via reana-commons
 libpass==1.9.3            # via flask-security-invenio
 limits==5.8.0             # via flask-limiter, invenio-accounts
 lxml==6.1.0               # via prov
-mako==1.3.11              # via alembic
+mako==1.3.12              # via alembic
 markupsafe==3.0.3         # via flask, flask-security-invenio, invenio-base, invenio-oauthclient, jinja2, mako, werkzeug, wtforms, wtforms-components
 marshmallow==3.26.2       # via invenio-rest, marshmallow-oneofschema, marshmallow-utils, reana-server (setup.py), webargs
 marshmallow-oneofschema==3.2.0  # via marshmallow-utils
 marshmallow-utils==0.14.1  # via invenio-rest
-matplotlib-inline==0.2.1  # via ipython
+matplotlib-inline==0.2.2  # via ipython
 maxminddb==3.1.1          # via maxminddb-geolite2
 maxminddb-geolite2==2018.703  # via invenio-accounts
-mistune==3.2.0            # via schema-salad
+mistune==3.2.1            # via schema-salad
 mock==3.0.5               # via packtivity, reana-commons
 monotonic==1.6            # via bravado
 msgpack==1.1.2            # via bravado-core, cachecontrol, invenio-celery
@@ -147,8 +145,8 @@ oauthlib==3.3.1           # via flask-oauthlib-invenio, invenio-oauthclient, req
 ordered-set==4.1.0        # via flask-limiter
 packaging==25.0           # via kombu, limits, marshmallow, snakemake, snakemake-interface-common, webargs
 packtivity==0.16.2        # via reana-server (setup.py), yadage
-parse==1.21.1             # via reana-commons
-parso==0.8.6              # via jedi
+parse==1.22.0             # via reana-commons
+parso==0.8.7              # via jedi
 pexpect==4.9.0            # via ipython
 platformdirs==4.9.6       # via jupyter-core
 ply==3.11                 # via jsonpath-rw
@@ -158,7 +156,7 @@ prov==1.5.1               # via cwltool
 psutil==7.2.2             # via cwltool, ipython, snakemake, yadage
 psycopg2-binary==2.9.12   # via invenio-db, reana-db
 ptyprocess==0.7.0         # via pexpect
-pulp==3.3.0               # via snakemake
+pulp==3.3.1               # via snakemake
 pure-eval==0.2.3          # via stack-data
 pycountry==26.2.16        # via marshmallow-utils
 pycparser==3.0            # via cffi
@@ -175,16 +173,14 @@ pyyaml==6.0.3             # via bravado, bravado-core, conda-inject, kubernetes,
 rdflib==5.0.0             # via cwltool, prov, schema-salad
 reana-commons[cwl,kubernetes,snakemake,yadage]==0.95.0a17  # via reana-db, reana-server (setup.py)
 reana-db==0.95.0a9        # via reana-server (setup.py)
-reana-db==0.95.0a9	# via reana-server (setup.py)
 redis==7.4.0              # via invenio-celery
 referencing==0.37.0       # via snakemake
-requests[security]==2.33.1  # via bravado, bravado-core, cachecontrol, cwltool, github3-py, kubernetes, packtivity, reana-server (setup.py), requests-oauthlib, schema-salad, snakemake, yadage, yadage-schemas
+requests[security]==2.34.0  # via bravado, bravado-core, cachecontrol, cwltool, github3-py, kubernetes, packtivity, reana-server (setup.py), requests-oauthlib, schema-salad, snakemake, yadage, yadage-schemas
 requests-oauthlib==2.0.0  # via flask-oauthlib-invenio, invenio-oauth2server, invenio-oauthclient, kubernetes
 reretry==0.11.8           # via snakemake
-rfc3339-validator==0.1.4  # via jsonschema
 rfc3987==1.3.8            # via jsonschema
 rich==12.6.0              # via flask-limiter, rich-argparse, rich-click
-rich-argparse==1.7.2      # via schema-salad
+rich-argparse==1.8.0      # via schema-salad
 rich-click==1.9.7         # via invenio-i18n
 rpds-py==0.30.0           # via referencing
 ruamel-yaml==0.17.10      # via cwltool, schema-salad
@@ -192,8 +188,8 @@ schema-salad==8.9.20260417192335  # via cwltool
 shellescape==3.8.1        # via cwltool
 simplejson==4.1.1         # via bravado, bravado-core
 simplekv==0.14.1          # via flask-kvsession-invenio, invenio-accounts
-six==1.17.0               # via bravado, bravado-core, flask-talisman, fs, jsonpath-rw, kubernetes, mock, prov, python-dateutil, rdflib, reana-server (setup.py), rfc3339-validator
-smart-open==7.6.0         # via snakemake
+six==1.17.0               # via bravado, bravado-core, flask-talisman, fs, jsonpath-rw, jsonschema, kubernetes, mock, prov, python-dateutil, rdflib, reana-server (setup.py)
+smart-open==7.6.1         # via snakemake
 smmap==5.0.3              # via gitdb
 snakemake==9.16.3         # via reana-commons
 snakemake-interface-common==1.23.0  # via snakemake, snakemake-interface-executor-plugins, snakemake-interface-logger-plugins, snakemake-interface-report-plugins, snakemake-interface-scheduler-plugins, snakemake-interface-storage-plugins
@@ -207,21 +203,21 @@ sqlalchemy[asyncio]==2.0.49  # via alembic, flask-alembic, flask-sqlalchemy, inv
 sqlalchemy-continuum==1.5.2  # via invenio-db
 sqlalchemy-utils[encrypted]==0.41.2  # via invenio-db, reana-db, sqlalchemy-utils, wtforms-alchemy
 stack-data==0.6.3         # via ipython
+strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==3.0.4  # via bravado-core
 tablib==3.9.0             # via reana-server (setup.py)
 tabulate==0.10.0          # via snakemake
 tenacity==9.1.4           # via snakemake-interface-storage-plugins
 throttler==1.2.3          # via snakemake, snakemake-interface-executor-plugins, snakemake-interface-storage-plugins
 tinycss2==1.4.0           # via bleach
-traitlets==5.14.3         # via ipython, jupyter-core, matplotlib-inline, nbformat
+traitlets==5.15.0         # via ipython, jupyter-core, matplotlib-inline, nbformat
 typing-extensions==4.15.0  # via alembic, bravado, cwltool, flask-limiter, gherkin-official, limits, referencing, sqlalchemy, swagger-spec-validator
 tzdata==2026.2            # via arrow, celery, kombu
 ua-parser==1.0.2          # via invenio-accounts
-ua-parser-builtins==202603  # via ua-parser
-uri-template==1.3.0       # via jsonschema
+ua-parser-builtins==202605  # via ua-parser
 uritemplate==4.2.0        # via github3-py, invenio-oauthclient, marshmallow-utils
-uritools==6.0.2           # via invenio-app, invenio-oauthclient
-urllib3==2.6.3            # via kubernetes, requests
+uritools==6.1.0           # via invenio-app, invenio-oauthclient
+urllib3==2.7.0            # via kubernetes, requests
 uwsgi==2.0.31             # via reana-server (setup.py)
 uwsgi-tools==1.1.1        # via reana-server (setup.py)
 uwsgitop==0.12            # via reana-server (setup.py)
@@ -229,14 +225,14 @@ validators==0.35.0        # via wtforms-components
 vine==5.1.0               # via amqp, celery, kombu
 watchdog==6.0.0           # via invenio-base
 wcmatch==8.4.1            # via reana-commons
-wcwidth==0.6.0            # via ftfy, prompt-toolkit
+wcwidth==0.7.0            # via ftfy, prompt-toolkit
 webargs==8.7.1            # via invenio-rest
 webcolors==25.10.0        # via jsonschema
 webencodings==0.5.1       # via bleach, tinycss2
 websocket-client==1.9.0   # via kubernetes
 werkzeug==3.1.8           # via flask, flask-cors, flask-kvsession-invenio, flask-login, invenio-base, marshmallow-utils, reana-commons
 wrapt==2.1.2              # via deprecated, smart-open, snakemake, snakemake-interface-storage-plugins
-wtforms==3.2.1            # via flask-wtf, invenio-oauth2server, wtforms-alchemy, wtforms-components
+wtforms==3.2.2            # via flask-wtf, invenio-oauth2server, wtforms-alchemy, wtforms-components
 wtforms-alchemy==0.19.1   # via invenio-oauth2server
 wtforms-components==0.11.0  # via wtforms-alchemy
 yadage==0.20.1            # via reana-commons, reana-server (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -173,8 +173,9 @@ pytz==2024.1              # via bravado-core, flask-babel, invenio-i18n
 pywebpack==2.2.1          # via flask-webpackext
 pyyaml==6.0.3             # via bravado, bravado-core, conda-inject, kubernetes, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas, yte
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons[cwl,kubernetes,snakemake,yadage]==0.95.0a15  # via reana-db, reana-server (setup.py)
-reana-db==0.95.0a7        # via reana-server (setup.py)
+reana-commons[cwl,kubernetes,snakemake,yadage]==0.95.0a17  # via reana-db, reana-server (setup.py)
+reana-db==0.95.0a9        # via reana-server (setup.py)
+reana-db==0.95.0a9	# via reana-server (setup.py)
 redis==7.4.0              # via invenio-celery
 referencing==0.37.0       # via snakemake
 requests[security]==2.33.1  # via bravado, bravado-core, cachecontrol, cwltool, github3-py, kubernetes, packtivity, reana-server (setup.py), requests-oauthlib, schema-salad, snakemake, yadage, yadage-schemas

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,10 @@ extras_require = {
         "sphinx-click>=1.0.4",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a9,<0.96.0",
+        "apispec[yaml]>=3.0",
+        "apispec-webframeworks",
+        "reana-commons[kubernetes,yadage,snakemake,cwl,tests]>=0.95.0a17,<0.96.0",
+        "reana-db[tests]>=0.95.0a9,<0.96.0",
     ],
 }
 
@@ -48,8 +51,8 @@ install_requires = [
     "Flask>=3.0.0,<4.0.0",
     "gitpython>=3.1",
     "marshmallow>=3.5.0,<4.0.0",
-    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.95.0a15,<0.96.0",
-    "reana-db>=0.95.0a7,<0.96.0",
+    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.95.0a17,<0.96.0",
+    "reana-db>=0.95.0a9,<0.96.0",
     "requests>=2.25.0",
     "tablib>=0.12.1",
     "uWSGI>=2.0.17",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from click.testing import CliRunner
-from pytest_reana.test_utils import make_mock_api_client
+from reana_commons.testing import make_mock_api_client
 from reana_db.models import (
     AuditLogAction,
     InteractiveSession,

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -11,7 +11,7 @@
 import pytest
 from flask import url_for
 from mock import patch
-from pytest_reana.test_utils import make_mock_api_client
+from reana_commons.testing import make_mock_api_client
 
 
 def test_get_users_shared_with_you(app, user1):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 import pytest
 from flask import Flask, url_for
 from mock import Mock, patch
-from pytest_reana.test_utils import make_mock_api_client
+from reana_commons.testing import make_mock_api_client
 
 from reana_db.models import User, InteractiveSessionType, RunStatus
 from reana_commons.k8s.secrets import UserSecrets, Secret


### PR DESCRIPTION
Replace pytest-reana in extras_require[tests] with the new
reana-commons[kubernetes,yadage,snakemake,cwl,tests] and
reana-db[tests] extras. The fixtures used by the test suite
(tmp_shared_volume_path, session, user0, sample_serial_workflow_in_db,
in_memory_queue_connection, default_in_memory_producer, consume_queue,
snakemake_workflow_spec_loaded) are auto-loaded via the pytest11
entry points the two libraries now register. The make_mock_api_client
helper imports in test_cli.py, test_users.py, test_views.py are
rewritten to come from reana_commons.testing.

Closes https://github.com/reanahub/pytest-reana/issues/156