### PR TITLE
feat(rest): surface info on minimum Kubernetes job user ID

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -528,6 +528,10 @@
                   "title": "Default memory request for Kubernetes jobs",
                   "value": "1Gi"
                 },
+                "kubernetes_min_user_uid": {
+                  "title": "Minimum allowed user runtime container UID for Kubernetes jobs",
+                  "value": 100
+                },
                 "maximum_kubernetes_jobs_timeout": {
                   "title": "Maximum timeout for Kubernetes jobs",
                   "value": "1209600"
@@ -858,6 +862,17 @@
                     "value": {
                       "type": "string",
                       "x-nullable": true
+                    }
+                  },
+                  "type": "object"
+                },
+                "kubernetes_min_user_uid": {
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "integer"
                     }
                   },
                   "type": "object"

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -349,6 +349,23 @@ def _get_rate_limit(env_variable: str, default: str) -> str:
         return default
 
 
+def _get_int_env_variable(env_variable: str, default: int) -> int:
+    """Return an integer environment variable value or fall back to default."""
+    env_value = os.getenv(env_variable)
+    if env_value is None:
+        return default
+    try:
+        return int(env_value)
+    except ValueError:
+        logging.warning(
+            "Invalid %s=%r; falling back to %s.",
+            env_variable,
+            env_value,
+            default,
+        )
+        return default
+
+
 # Note: users that are connecting via reana-client will be treated as guests by the Invenio framework
 RATELIMIT_GUEST_USER = _get_rate_limit("REANA_RATELIMIT_GUEST_USER", "20 per second")
 RATELIMIT_AUTHENTICATED_USER = _get_rate_limit(
@@ -580,6 +597,16 @@ REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT = os.getenv(
 
 Please see the following URL for more details
 https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup.
+"""
+
+REANA_KUBERNETES_JOBS_MIN_USER_UID = _get_int_env_variable(
+    "REANA_KUBERNETES_JOBS_MIN_USER_UID", 100
+)
+"""Minimum accepted user runtime container UID that users can assign to their job
+containers via ``kubernetes_uid`` in ``reana.yaml``. Jobs requesting a smaller
+UID are refused at submission time with a clear error message. Surfaced via
+the ``/info`` endpoint so that users and administrators can verify the
+configured value.
 """
 
 # Access token issuance policy:

--- a/reana_server/rest/info.py
+++ b/reana_server/rest/info.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2021, 2022, 2024, 2025 CERN.
+# Copyright (C) 2021, 2022, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -30,6 +30,7 @@ from reana_server.config import (
     REANA_KUBERNETES_JOBS_MEMORY_LIMIT,
     REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT,
     REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT,
+    REANA_KUBERNETES_JOBS_MIN_USER_UID,
     REANA_INTERACTIVE_SESSION_MAX_INACTIVITY_PERIOD,
     REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS,
     REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS_CUSTOM_ALLOWED,
@@ -191,6 +192,13 @@ def info(user, **kwargs):  # noqa
                     type: string
                   value:
                     type: string
+                type: object
+              kubernetes_min_user_uid:
+                properties:
+                  title:
+                    type: string
+                  value:
+                    type: integer
                 type: object
               maximum_workspace_retention_period:
                 properties:
@@ -394,6 +402,10 @@ def info(user, **kwargs):  # noqa
                     "title": "Maximum timeout for Kubernetes jobs",
                     "value": "1209600"
                 },
+                "kubernetes_min_user_uid": {
+                    "title": "Minimum allowed user runtime container UID for Kubernetes jobs",
+                    "value": 100
+                },
                 "interactive_session_recommended_jupyter_images": {
                   "title": "Recommended Jupyter images for interactive sessions",
                   "value": [
@@ -550,6 +562,10 @@ def info(user, **kwargs):  # noqa
                 title="Maximum timeout for Kubernetes jobs",
                 value=REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT,
             ),
+            kubernetes_min_user_uid=dict(
+                title="Minimum allowed user runtime container UID for Kubernetes jobs",
+                value=REANA_KUBERNETES_JOBS_MIN_USER_UID,
+            ),
             maximum_interactive_session_inactivity_period=dict(
                 title="Maximum inactivity period in days before automatic closure of interactive sessions",
                 value=REANA_INTERACTIVE_SESSION_MAX_INACTIVITY_PERIOD,
@@ -660,6 +676,13 @@ class StringNullableInfoValue(Schema):
     value = fields.String(allow_none=True)
 
 
+class IntegerInfoValue(Schema):
+    """Schema for a value represented by an integer."""
+
+    title = fields.String()
+    value = fields.Integer(allow_none=False)
+
+
 class InfoSchema(Schema):
     """Marshmallow schema for ``info`` endpoint."""
 
@@ -677,6 +700,7 @@ class InfoSchema(Schema):
     maximum_workspace_retention_period = fields.Nested(StringNullableInfoValue)
     default_kubernetes_jobs_timeout = fields.Nested(StringInfoValue)
     maximum_kubernetes_jobs_timeout = fields.Nested(StringInfoValue)
+    kubernetes_min_user_uid = fields.Nested(IntegerInfoValue)
     maximum_interactive_session_inactivity_period = fields.Nested(
         StringNullableInfoValue
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test REANA-Server configuration helpers."""
+
+import logging
+
+import pytest
+
+from reana_server.config import _get_int_env_variable
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        (None, 100),
+        ("", 100),
+        ("not-an-integer", 100),
+        ("1234", 1234),
+    ],
+)
+def test_get_int_env_variable(monkeypatch, caplog, env_value, expected):
+    """Test integer environment variable parsing with default fallback."""
+    env_variable = "REANA_TEST_INT_ENV_VARIABLE"
+    if env_value is None:
+        monkeypatch.delenv(env_variable, raising=False)
+    else:
+        monkeypatch.setenv(env_variable, env_value)
+
+    with caplog.at_level(logging.WARNING):
+        assert _get_int_env_variable(env_variable, 100) == expected
+
+    if env_value in {"", "not-an-integer"}:
+        assert f"Invalid {env_variable}" in caplog.text
+    else:
+        assert f"Invalid {env_variable}" not in caplog.text

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -219,6 +219,29 @@ def test_restart_workflow_validates_specification(
             data=json.dumps(body),
         )
         assert res.status_code == 400
+
+
+def test_info_surfaces_kubernetes_min_user_uid(app, user0, _get_user_mock):
+    """Test /info exposes the configured minimum Kubernetes user ID."""
+    with app.test_client() as client:
+        with patch(
+            "reana_server.rest.info.REANA_KUBERNETES_JOBS_MIN_USER_UID", 1234
+        ), patch(
+            "reana_server.rest.info.REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS",
+            {"jupyter": {"recommended": []}},
+        ):
+            res = client.get(
+                url_for("info.info"),
+                query_string={"access_token": user0.access_token},
+            )
+    assert res.status_code == 200
+    payload = res.json
+    assert "kubernetes_min_user_uid" in payload
+    assert payload["kubernetes_min_user_uid"]["value"] == 1234
+    assert (
+        payload["kubernetes_min_user_uid"]["title"]
+        == "Minimum allowed user runtime container UID for Kubernetes jobs"
+    )
 
 
 def test_patch_quota_rejects_invalid_json_body(app):


### PR DESCRIPTION
Expose the cluster-configured minimum accepted runtime container user ID (`REANA_KUBERNETES_JOBS_MIN_USER_UID`, default 100) on the `/info` endpoint so that users and administrators can verify the configured value before submitting workflows with `kubernetes_uid` hints.

Closes reanahub/reana#951