### PR TITLE
feat(scheduler): cap concurrent workflows per compute backend

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1919,14 +1919,39 @@
                   "sort": 3
                 },
                 "workflow": {
-                  "available": 24,
+                  "available": 4,
+                  "backends": {
+                    "dask": {
+                      "available": 4,
+                      "health": "healthy",
+                      "percentage": 80,
+                      "total": 5,
+                      "used": 1
+                    },
+                    "htcondorcern": {
+                      "available": 197,
+                      "health": "healthy",
+                      "percentage": 99,
+                      "total": 200,
+                      "used": 3
+                    },
+                    "kubernetes": {
+                      "available": 24,
+                      "health": "healthy",
+                      "percentage": 80,
+                      "total": 30,
+                      "used": 6
+                    }
+                  },
+                  "bottleneck": "dask",
                   "health": "healthy",
                   "pending": 2,
                   "percentage": 80,
                   "queued": 2,
                   "running": 4,
                   "sort": 2,
-                  "total": 30
+                  "total": 5,
+                  "used": 1
                 }
               }
             },
@@ -1997,6 +2022,32 @@
                     "available": {
                       "type": "number"
                     },
+                    "backends": {
+                      "additionalProperties": {
+                        "properties": {
+                          "available": {
+                            "type": "number"
+                          },
+                          "health": {
+                            "type": "string"
+                          },
+                          "percentage": {
+                            "type": "number"
+                          },
+                          "total": {
+                            "type": "number"
+                          },
+                          "used": {
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "object"
+                    },
+                    "bottleneck": {
+                      "type": "string"
+                    },
                     "health": {
                       "type": "string"
                     },
@@ -2016,6 +2067,9 @@
                       "type": "number"
                     },
                     "total": {
+                      "type": "number"
+                    },
+                    "used": {
                       "type": "number"
                     }
                   },

--- a/reana_server/complexity.py
+++ b/reana_server/complexity.py
@@ -26,9 +26,10 @@ def validate_job_memory_limits(complexity: List[Tuple[int, float]]) -> None:
     :param complexity: workflow complexity list which consists of number of initial jobs and the memory in bytes they require. (e.g. [(8, 1073741824), (5, 2147483648)])
     :raises REANAKubernetesMemoryLimitExceeded: If workflow job memory limits exceed the maximum memory limit that users can assign to their job containers.
     """
-    if not complexity:
+    k8s_memories = [mem for jobs, mem in complexity if jobs > 0]
+    if not k8s_memories:
         return None
-    max_job_memory = max(complexity, key=lambda x: x[1])[1]
+    max_job_memory = max(k8s_memories)
 
     if (
         REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT_IN_BYTES
@@ -41,14 +42,33 @@ def validate_job_memory_limits(complexity: List[Tuple[int, float]]) -> None:
 
 
 def get_workflow_min_job_memory(complexity):
-    """Return minimal job memory from workflow complexity.
+    """Return the smallest per-job memory requirement among initial Kubernetes steps.
 
-    :param complexity: workflow complexity list which consists of number of initial jobs and the memory in bytes they require. (e.g. [(8, 1073741824), (5, 2147483648)])
-    :return: minimal job memory (e.g. 1073741824)
+    :param complexity: list of (k8s_jobs, memory_bytes) tuples, one per initial
+        workflow step. k8s_jobs is 0 for steps that run on external backends
+        (HTCondor, Slurm) and >0 for steps that run on Kubernetes.
+    :return: minimum memory in bytes across initial Kubernetes steps, or 0 if
+        there are no initial Kubernetes steps (e.g. the workflow starts on an
+        external backend). A return value of 0 causes the Kubernetes node memory
+        check to be skipped entirely.
     """
-    if not complexity:
+    k8s_memories = [mem for jobs, mem in complexity if jobs > 0]
+    if not k8s_memories:
         return 0
-    return min(complexity, key=lambda x: x[1])[1]
+    return min(k8s_memories)
+
+
+def _build_estimator(workflow_type, reana_yaml):
+    if workflow_type == "serial":
+        return SerialComplexityEstimator(reana_yaml)
+    elif workflow_type == "yadage":
+        return YadageComplexityEstimator(reana_yaml)
+    elif workflow_type == "cwl":
+        return CWLComplexityEstimator(reana_yaml)
+    elif workflow_type == "snakemake":
+        return SnakemakeComplexityEstimator(reana_yaml)
+    else:
+        raise Exception("Workflow type '{0}' is not supported".format(workflow_type))
 
 
 def estimate_complexity(workflow_type, reana_yaml):
@@ -57,27 +77,25 @@ def estimate_complexity(workflow_type, reana_yaml):
     :param workflow_type: A supported workflow specification type.
     :param reana_yaml: REANA YAML specification.
     """
-
-    def build_estimator(workflow_type, reana_yaml):
-        if workflow_type == "serial":
-            return SerialComplexityEstimator(reana_yaml)
-        elif workflow_type == "yadage":
-            return YadageComplexityEstimator(reana_yaml)
-        elif workflow_type == "cwl":
-            return CWLComplexityEstimator(reana_yaml)
-        elif workflow_type == "snakemake":
-            return SnakemakeComplexityEstimator(reana_yaml)
-        else:
-            raise Exception(
-                "Workflow type '{0}' is not supported".format(workflow_type)
-            )
-
-    estimator = build_estimator(workflow_type, reana_yaml)
+    estimator = _build_estimator(workflow_type, reana_yaml)
     try:
         complexity = estimator.estimate_complexity()
     except Exception:
         return []
     return complexity
+
+
+def workflow_compute_backends(workflow_type: str, reana_yaml: dict) -> List[str]:
+    """Return the sorted set of step-level compute backends a workflow uses.
+
+    Scans all steps so that hybrid workflows are classified with every
+    backend they touch (e.g. ``["htcondor", "kubernetes"]``).
+    """
+    try:
+        backends = _build_estimator(workflow_type, reana_yaml).compute_backends()
+    except Exception:
+        return ["kubernetes"]
+    return sorted(backends) if backends else ["kubernetes"]
 
 
 class ComplexityEstimatorBase:
@@ -97,6 +115,10 @@ class ComplexityEstimatorBase:
         """Parse REANA workflow specification tree."""
         raise NotImplementedError
 
+    def compute_backends(self) -> set:
+        """Return the set of compute backends used across the whole workflow."""
+        raise NotImplementedError
+
     def estimate_complexity(self, initial_step="init"):
         """Estimate complexity in parsed REANA workflow tree."""
         steps = self.parse_specification(initial_step)
@@ -109,10 +131,13 @@ class ComplexityEstimatorBase:
             complexity += step["complexity"]
         return complexity
 
+    def _get_step_backend(self, step):
+        """Get the compute backend a step runs on, defaulting to Kubernetes."""
+        return step.get("compute_backend") or "kubernetes"
+
     def _get_number_of_jobs(self, step):
         """Get number of jobs based on compute backend."""
-        backend = step.get("compute_backend")
-        if backend and backend != "kubernetes":
+        if self._get_step_backend(step) != "kubernetes":
             return 0
         return 1
 
@@ -138,6 +163,13 @@ class SerialComplexityEstimator(ComplexityEstimatorBase):
             tree.append({name: {"complexity": complexity}})
         return tree
 
+    def compute_backends(self) -> set:
+        """Return the set of compute backends used across the workflow."""
+        steps = self.specification.get("steps", [])
+        if not steps:
+            return {"kubernetes"}
+        return {self._get_step_backend(step) for step in steps}
+
     def parse_specification(self, initial_step):
         """Parse and filter out serial workflow specification tree."""
         spec_steps = self.specification.get("steps", [])
@@ -149,6 +181,39 @@ class SerialComplexityEstimator(ComplexityEstimatorBase):
 
 class YadageComplexityEstimator(ComplexityEstimatorBase):
     """REANA Yadage workflow complexity estimation."""
+
+    @staticmethod
+    def _get_stage_resources(stage):
+        """Return the list of resources declared for a Yadage stage."""
+        resources = (
+            stage.get("scheduler", {})
+            .get("step", {})
+            .get("environment", {})
+            .get("resources", [])
+        )
+        return resources if isinstance(resources, list) else []
+
+    def _get_stage_compute_backend(self, stage):
+        """Return the compute backend resource dict for a Yadage stage.
+
+        When a stage declares ``compute_backend`` more than once, the last
+        declaration wins, matching how reana-workflow-engine-yadage builds its
+        job request (``_get_resources`` in ``externalbackend.py`` iterates all
+        resources and overwrites), so a stage is classified against the backend
+        it actually runs on.
+        """
+        return next(
+            filter(
+                lambda r: isinstance(r, dict) and "compute_backend" in r.keys(),
+                reversed(self._get_stage_resources(stage)),
+            ),
+            {},
+        )
+
+    @staticmethod
+    def _get_nested_stages(stage):
+        """Return the nested stages of a Yadage stage (empty if none)."""
+        return stage.get("scheduler", {}).get("workflow", {}).get("stages", [])
 
     def _parse_steps(self, stages, initial_step):
         """Parse and filter out Yadage workflow tree."""
@@ -165,19 +230,8 @@ class YadageComplexityEstimator(ComplexityEstimatorBase):
             return False
 
         def _get_stage_complexity(stage):
-            resources = (
-                stage.get("scheduler", {})
-                .get("step", {})
-                .get("environment", {})
-                .get("resources", [])
-            )
-            compute_backend = next(
-                filter(
-                    lambda r: isinstance(r, dict) and "compute_backend" in r.keys(),
-                    resources,
-                ),
-                {},
-            )
+            resources = self._get_stage_resources(stage)
+            compute_backend = self._get_stage_compute_backend(stage)
             k8s_memory_limit = next(
                 filter(
                     lambda r: isinstance(r, dict)
@@ -275,6 +329,26 @@ class YadageComplexityEstimator(ComplexityEstimatorBase):
 
         return _parse_stages(stages)
 
+    def compute_backends(self) -> set:
+        """Return the set of compute backends used across the workflow."""
+
+        def _collect_stages(stages):
+            backends = set()
+            for stage in stages:
+                nested = self._get_nested_stages(stage)
+                # A wrapper stage delegates its complexity to its nested stages
+                # (see ``_populate_complexity``), so its own backend is only
+                # relevant when there are no nested stages.
+                if nested:
+                    backends |= _collect_stages(nested)
+                else:
+                    compute_backend = self._get_stage_compute_backend(stage)
+                    backends.add(self._get_step_backend(compute_backend))
+            return backends
+
+        stages = self.specification.get("stages", [])
+        return _collect_stages(stages) if stages else {"kubernetes"}
+
     def parse_specification(self, initial_step):
         """Parse Yadage workflow specification tree."""
         steps = self._parse_steps(self.specification["stages"], initial_step)
@@ -286,6 +360,28 @@ class YadageComplexityEstimator(ComplexityEstimatorBase):
 class CWLComplexityEstimator(ComplexityEstimatorBase):
     """REANA CWL workflow complexity estimation."""
 
+    @staticmethod
+    def _get_step_hints(step):
+        """Return the effective hints of a CWL step, or an empty dict if none.
+
+        All hints are scanned and, for any given key, the first hint declaring
+        it wins. This mirrors how reana-workflow-engine-cwl resolves hints at
+        execution time (``ReanaPipeline._get_hint`` in ``cwl_reana.py``), so a
+        step is classified against the backend it actually runs on. Taking only
+        the last hint would misclassify the canonical shape, where a
+        ``class: reana`` hint carrying ``compute_backend`` is followed by, say,
+        a ``ResourceRequirement`` hint.
+
+        Robust to ``hints`` being absent, ``None`` or an empty list.
+        """
+        effective = {}
+        for hint in step.get("hints") or []:
+            if not isinstance(hint, dict):
+                continue
+            for key, value in hint.items():
+                effective.setdefault(key, value)
+        return effective
+
     def _parse_steps(self, workflow):
         """Parse CWL workflow specification tree."""
         tree = {}
@@ -294,7 +390,7 @@ class CWLComplexityEstimator(ComplexityEstimatorBase):
         for step in steps:
             name = step.get("id")
             run = step.get("run")
-            hints = step.get("hints", [{}]).pop()
+            hints = self._get_step_hints(step)
             # Parse scatter params
             scatter = step.get("scatter")
             scatter_params = None
@@ -395,6 +491,28 @@ class CWLComplexityEstimator(ComplexityEstimatorBase):
 
         return tree
 
+    def compute_backends(self) -> set:
+        """Return the set of compute backends used across the workflow."""
+
+        def _collect_steps(steps):
+            backends = set()
+            for step in steps:
+                hints = self._get_step_hints(step)
+                backends.add(self._get_step_backend(hints))
+                run = step.get("run")
+                if isinstance(run, dict):
+                    nested = run.get("steps", [])
+                    if nested:
+                        backends |= _collect_steps(nested)
+            return backends
+
+        workflow = self.specification.get("$graph", self.specification)
+        workflows = [workflow] if isinstance(workflow, dict) else (workflow or [])
+        backends = set()
+        for wf in workflows:
+            backends |= _collect_steps(wf.get("steps", []))
+        return backends if backends else {"kubernetes"}
+
     def parse_specification(self, initial_step):
         """Parse and filter out CWL workflow specification tree."""
         workflow = self.specification.get("$graph", self.specification)
@@ -411,14 +529,22 @@ class SnakemakeComplexityEstimator(ComplexityEstimatorBase):
     def _calculate_complexity(
         self, job_dependencies: Dict[str, List[str]]
     ) -> List[Tuple[int, float]]:
-        """Calculate complexity of an array of job dependencies."""
+        """Calculate complexity of an array of job dependencies.
+
+        Steps that run on an external backend (e.g. HTCondor) contribute 0 jobs
+        and are excluded from the Kubernetes memory average, so external-only
+        groups yield ``(0, 0)`` and do not trigger the Kubernetes memory check.
+        """
         spec_steps = self.specification.get("steps", [])
-        jobs_count = len(job_dependencies)
+        jobs_count = 0
         memory_limit = 0
         for dep in job_dependencies:
             step = next(filter(lambda step: step["name"] == dep, spec_steps))
-            memory_limit += self._get_memory_limit(step)
-        memory_limit = memory_limit / jobs_count
+            jobs = self._get_number_of_jobs(step)
+            jobs_count += jobs
+            if jobs:
+                memory_limit += self._get_memory_limit(step)
+        memory_limit = memory_limit / jobs_count if jobs_count else 0
         return [(jobs_count, memory_limit)]
 
     def _get_max_complexity(
@@ -440,6 +566,13 @@ class SnakemakeComplexityEstimator(ComplexityEstimatorBase):
                 for subjob_dep in job_dependencies[job_dep]
             )
         return filtered_job_deps
+
+    def compute_backends(self) -> set:
+        """Return the set of compute backends used across the workflow."""
+        steps = self.specification.get("steps", [])
+        if not steps:
+            return {"kubernetes"}
+        return {self._get_step_backend(step) for step in steps}
 
     def estimate_complexity(self) -> List[Tuple[int, float]]:
         """Estimate complexity array in parsed Snakemake workflow tree."""

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -218,7 +218,8 @@ REANA_WORKFLOW_SCHEDULING_READINESS_CHECK_LEVEL_VALUE_MAP = {
 }
 """REANA workflow scheduling readiness check level value map:
 - 0 = no readiness check; schedule new workflow as soon as they arrive;
-- 1 = check for maximum number of concurrently running workflows; schedule new workflows if not exceeded;
+- 1 = check concurrent-workflow limits; schedule a new workflow only if it is
+  below the cap of every resource it consumes.
 - 2 = check for available cluster memory size; schedule new workflow only if it fits;
 - 9 = perform all checks; satisfy all previous criteria.
 """

--- a/reana_server/rest/status.py
+++ b/reana_server/rest/status.py
@@ -75,6 +75,23 @@ def status(**kwargs):  # noqa
                 properties:
                   available:
                     type: number
+                  backends:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      properties:
+                        available:
+                          type: number
+                        health:
+                          type: string
+                        percentage:
+                          type: number
+                        total:
+                          type: number
+                        used:
+                          type: number
+                  bottleneck:
+                    type: string
                   running:
                     type: number
                   queued:
@@ -88,6 +105,8 @@ def status(**kwargs):  # noqa
                   sort:
                     type: number
                   total:
+                    type: number
+                  used:
                     type: number
               session:
                 type: object
@@ -121,8 +140,33 @@ def status(**kwargs):  # noqa
                     "sort": 3
                 },
                 "workflow": {
-                    "total": 30,
-                    "available": 24,
+                    "backends": {
+                        "dask": {
+                            "available": 4,
+                            "health": "healthy",
+                            "percentage": 80,
+                            "total": 5,
+                            "used": 1
+                        },
+                        "htcondorcern": {
+                            "available": 197,
+                            "health": "healthy",
+                            "percentage": 99,
+                            "total": 200,
+                            "used": 3
+                        },
+                        "kubernetes": {
+                            "available": 24,
+                            "health": "healthy",
+                            "percentage": 80,
+                            "total": 30,
+                            "used": 6
+                        }
+                    },
+                    "bottleneck": "dask",
+                    "total": 5,
+                    "used": 1,
+                    "available": 4,
                     "queued": 2,
                     "running": 4,
                     "pending": 2,

--- a/reana_server/scheduler.py
+++ b/reana_server/scheduler.py
@@ -12,13 +12,12 @@ import json
 import logging
 from functools import partial
 from time import sleep
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from bravado.exception import HTTPBadGateway, HTTPNotFound, HTTPConflict, HTTPBadRequest
-from sqlalchemy import func, or_
 from sqlalchemy.exc import SQLAlchemyError
 
-from reana_commons.config import REANA_MAX_CONCURRENT_BATCH_WORKFLOWS
+from reana_commons.config import get_concurrent_workflows_cap
 from reana_commons.consumer import BaseConsumer
 from reana_commons.publisher import WorkflowStatusPublisher
 from reana_db.database import Session
@@ -61,44 +60,72 @@ def check_memory_availability(
     return error
 
 
-def check_concurrent_workflows_limit() -> Optional[str]:
-    """Check upper limit on running REANA batch workflows."""
-    error = None
+def check_concurrent_workflows_limit(
+    compute_backends: Optional[List[str]] = None, uses_dask: bool = False
+) -> Optional[str]:
+    """Check the per-resource upper limits on concurrent REANA batch workflows.
+
+    Concurrency is capped independently per compute backend and per Dask cluster.
+    A workflow is admitted only if it is below the cap of *every* resource it consumes.
+    So a hybrid Kubernetes+HTCondor workflow is checked against both backend caps,
+    and a Dask-on-HTCondor workflow against the HTCondor cap and the Dask cap.
+
+    :param compute_backends: compute backends the workflow's steps use, as stored
+        in ``Workflow.compute_backends`` (e.g. ``["htcondorcern"]``); defaults to
+        ``["kubernetes"]``.
+    :param uses_dask: whether the workflow requests a Dask cluster.
+    :return: an error string if any applicable cap is reached, else ``None``.
+    """
+    if compute_backends is None:
+        compute_backends = ["kubernetes"]
+
     try:
-        running_workflows = (
-            Session.query(func.count())
-            .filter(
-                or_(
-                    Workflow.status == RunStatus.pending,
-                    Workflow.status == RunStatus.running,
-                )
-            )
-            .scalar()
-        )
-        if running_workflows >= REANA_MAX_CONCURRENT_BATCH_WORKFLOWS:
-            error = (
-                f"there are already {running_workflows} running workflows "
-                f"whilst the allowed maximum is {REANA_MAX_CONCURRENT_BATCH_WORKFLOWS}."
-            )
+        running_counts = Workflow.count_active_per_backend()
     except SQLAlchemyError as e:
         error = "Something went wrong while querying for number of running workflows."
         logging.error(error)
         logging.error(e)
+        Session.commit()
+        return error
+
+    # Every backend the workflow uses is capped (plus the Dask cap if applicable).
+    resources = list(compute_backends)
+    if uses_dask:
+        resources.append("dask")
+
+    error = None
+    for resource in resources:
+        max_concurrent = get_concurrent_workflows_cap(resource)
+        num_running = running_counts.get(resource, 0)
+        if num_running >= max_concurrent:
+            error = (
+                f"there are already {num_running} running workflows using "
+                f"'{resource}' whilst the allowed maximum is {max_concurrent}."
+            )
+            break
+
     Session.commit()
     return error
 
 
-def reana_ready(workflow_min_job_memory: Optional[float]) -> Optional[str]:
+def reana_ready(
+    workflow_min_job_memory: Optional[float],
+    compute_backends: Optional[List[str]] = None,
+    uses_dask: bool = False,
+) -> Optional[str]:
     """Check if REANA can start new workflows."""
     check_memory = partial(check_memory_availability, workflow_min_job_memory)
+    check_concurrent = partial(
+        check_concurrent_workflows_limit, compute_backends, uses_dask
+    )
 
     conditions_map = {
         "no_checks": [],
-        "concurrent": [check_concurrent_workflows_limit],
+        "concurrent": [check_concurrent],
         "memory": [check_memory],
-        "all_checks": [check_concurrent_workflows_limit, check_memory],
+        "all_checks": [check_concurrent, check_memory],
     }
-    conditions = conditions_map.get(REANA_WORKFLOW_SCHEDULING_READINESS_CHECK_VALUE)
+    conditions = conditions_map[REANA_WORKFLOW_SCHEDULING_READINESS_CHECK_VALUE]
 
     for check_condition in conditions:
         error = check_condition()
@@ -170,6 +197,8 @@ class WorkflowExecutionScheduler(BaseConsumer):
                 parameters=workflow_submission["parameters"],
                 priority=workflow_submission["priority"],
                 min_job_memory=workflow_submission["min_job_memory"],
+                compute_backends=workflow_submission.get("compute_backends"),
+                uses_dask=workflow_submission.get("uses_dask", False),
                 retry_count=retry_count + 1,
             )
 
@@ -182,11 +211,13 @@ class WorkflowExecutionScheduler(BaseConsumer):
 
         workflow_id = workflow_submission["workflow_id_or_name"]
         workflow_min_job_memory = workflow_submission.pop("min_job_memory", 0)
+        compute_backends = workflow_submission.pop("compute_backends", None)
+        uses_dask = workflow_submission.pop("uses_dask", False)
 
         workflow_submission.pop("priority", None)
         workflow_submission.pop("retry_count", None)
 
-        error = reana_ready(workflow_min_job_memory)
+        error = reana_ready(workflow_min_job_memory, compute_backends, uses_dask)
         if not error:
             logging.info(f"Starting queued workflow: {workflow_id}")
             workflow_submission["status"] = "start"

--- a/reana_server/status.py
+++ b/reana_server/status.py
@@ -17,11 +17,11 @@ from invenio_accounts.models import SessionActivity
 from kubernetes.client.rest import ApiException
 from marshmallow import Schema, fields
 from reana_commons.config import (
+    get_concurrent_workflows_cap,
     REANA_COMPONENT_PREFIX,
     REANA_COMPUTE_BACKENDS,
     REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE,
     REANA_RUNTIME_KUBERNETES_NAMESPACE,
-    REANA_MAX_CONCURRENT_BATCH_WORKFLOWS,
     SHARED_VOLUME_PATH,
 )
 from reana_commons.job_utils import kubernetes_memory_to_bytes
@@ -44,7 +44,11 @@ from reana_db.models import (
 )
 from sqlalchemy import desc
 
-from reana_server.config import REANA_KUBERNETES_JOBS_MEMORY_LIMIT_IN_BYTES
+from reana_server.config import (
+    DASK_ENABLED,
+    REANA_KUBERNETES_JOBS_MEMORY_LIMIT_IN_BYTES,
+    SUPPORTED_COMPUTE_BACKENDS,
+)
 
 
 class REANAStatus:
@@ -653,25 +657,71 @@ class ClusterHealth:
         }
 
     def get_workflow_health(self):
-        """Get cluster workflows health information."""
+        """Get cluster workflows health information.
+
+        Concurrency is capped independently per compute backend and per Dask
+        cluster (see ``check_concurrent_workflows_limit``), so the dashboard
+        reports one tile per capped resource under ``backends`` and surfaces the
+        most-constrained one at the top level. This keeps the dashboard's notion
+        of "cluster full" aligned with the scheduler's admission decision instead
+        of a single global counter.
+        """
         wf_status_obj = WorkflowsStatus()
 
         running = wf_status_obj.get_workflows_by_status(RunStatus.running)
         queued = wf_status_obj.get_workflows_by_status(RunStatus.queued)
         pending = wf_status_obj.get_workflows_by_status(RunStatus.pending)
-        total = REANA_MAX_CONCURRENT_BATCH_WORKFLOWS
-        used = running + pending
-        available = ClusterHealth.get_available(used, total)
-        percentage = ClusterHealth.get_percentage(used, total)
 
+        active_counts = Workflow.count_active_per_backend()
+
+        # One tile per configured compute backend (so operators see headroom even
+        # at zero usage), plus any backend currently in use, plus the Dask cap.
+        resources = (
+            set(SUPPORTED_COMPUTE_BACKENDS) | {"kubernetes"} | set(active_counts)
+        )
+        resources.discard("dask")
+        resources = sorted(resources)
+        # Dask capacity only exists where Dask is enabled, so reporting an idle
+        # tile on a cluster that rejects Dask workflows at validation would
+        # advertise capacity that cannot be used. Workflows still running from
+        # before Dask was disabled are real usage and stay visible.
+        if DASK_ENABLED or active_counts.get("dask", 0):
+            resources.append("dask")
+
+        backends = {}
+        bottleneck = None
+        for resource in resources:
+            total = get_concurrent_workflows_cap(resource)
+            used = active_counts.get(resource, 0)
+            # A cap of zero means the resource is closed, so no headroom is
+            # available. ``get_percentage`` treats a zero total as "unknown"
+            # and would report 100% available, contradicting the scheduler,
+            # which admits nothing at all for such a resource.
+            percentage = 0 if total == 0 else ClusterHealth.get_percentage(used, total)
+            backends[resource] = {
+                "used": used,
+                "total": total,
+                "available": ClusterHealth.get_available(used, total),
+                "percentage": percentage,
+                "health": ClusterHealth.get_health_status(percentage),
+            }
+            # The most-constrained resource is the one with the least available
+            # headroom (``percentage`` reports availability, see get_percentage).
+            if bottleneck is None or percentage < backends[bottleneck]["percentage"]:
+                bottleneck = resource
+
+        binding = backends[bottleneck]
         return {
             "running": running,
             "queued": queued,
             "pending": pending,
-            "available": available,
-            "total": total,
-            "percentage": percentage,
-            "health": ClusterHealth.get_health_status(percentage),
+            "backends": backends,
+            "bottleneck": bottleneck,
+            "used": binding["used"],
+            "available": binding["available"],
+            "total": binding["total"],
+            "percentage": binding["percentage"],
+            "health": binding["health"],
             "sort": 2,
         }
 

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -71,6 +71,7 @@ from reana_server.complexity import (
     get_workflow_min_job_memory,
     estimate_complexity,
     validate_job_memory_limits,
+    workflow_compute_backends,
 )
 from reana_server.config import (
     ADMIN_USER_ID,
@@ -399,6 +400,15 @@ def publish_workflow_submission(workflow, user_id, parameters):
             'Workflow scheduling policy "{0}" is not valid.'.format(scheduling_policy)
         )
 
+    # Record the compute backends the workflow uses so that the scheduler can
+    # apply the per-backend concurrency caps
+    workflow.compute_backends = workflow_compute_backends(
+        workflow.type_, workflow.reana_specification
+    )
+    Session.commit()
+
+    uses_dask = workflow_uses_dask(workflow.reana_specification)
+
     # No need to estimate the complexity for "fifo" strategy
     if scheduling_policy == "fifo":
         workflow_priority = 0
@@ -409,12 +419,15 @@ def publish_workflow_submission(workflow, user_id, parameters):
         workflow_priority = workflow.get_priority(total_cluster_memory)
         workflow_min_job_memory = get_workflow_min_job_memory(complexity)
         validate_job_memory_limits(complexity)
+
     current_workflow_submission_publisher.publish_workflow_submission(
         user_id=str(user_id),
         workflow_id_or_name=str(workflow.id_),
         parameters=parameters,
         priority=workflow_priority,
         min_job_memory=workflow_min_job_memory,
+        compute_backends=workflow.compute_backends,
+        uses_dask=uses_dask,
     )
 
 

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -12,9 +12,13 @@ import mock
 import pytest
 from mock import patch
 
+from reana_commons.errors import REANAKubernetesMemoryLimitExceeded
+
 from reana_server.complexity import (
     get_workflow_min_job_memory,
     estimate_complexity,
+    validate_job_memory_limits,
+    workflow_compute_backends,
 )
 
 
@@ -25,6 +29,10 @@ from reana_server.complexity import (
         ([(1, 8589934592.0), (2, 4294967296.0)], 4294967296.0),
         ([(2, 10)], 10),
         ([], 0),
+        # External backend steps have jobs=0 and should not influence the result
+        ([(0, 268435456)], 0),
+        ([(0, 268435456), (0, 1073741824)], 0),
+        ([(0, 268435456), (1, 536870912)], 536870912),
     ],
 )
 def test_get_workflow_min_job_memory(complexity, min_job_memory):
@@ -86,3 +94,426 @@ def test_estimate_complexity_snakemake(
     assert estimate_complexity("snakemake", snakemake_workflow_spec_loaded) == [
         complexity
     ]
+
+
+@mock.patch("reana_server.complexity.REANA_KUBERNETES_JOBS_MEMORY_LIMIT", "4Gi")
+@pytest.mark.parametrize(
+    "backends,expected_complexity,expected_min_memory",
+    [
+        # All steps on an external backend: no Kubernetes jobs and no memory
+        # requirement, so the Kubernetes memory check is skipped.
+        (
+            {"scatterA": "htcondor", "scatterB": "htcondor", "gather": "htcondor"},
+            [(0, 0)],
+            0,
+        ),
+        # Mixed: scatters run externally, gather runs on Kubernetes. Only the
+        # Kubernetes step contributes to jobs and memory.
+        (
+            {"scatterA": "htcondor", "scatterB": "htcondor", "gather": "kubernetes"},
+            [(1, 4294967296.0)],
+            4294967296.0,
+        ),
+    ],
+)
+def test_estimate_complexity_snakemake_external_backend(
+    snakemake_workflow_spec_loaded,
+    backends,
+    expected_complexity,
+    expected_min_memory,
+):
+    """Test that external-backend Snakemake steps contribute 0 jobs."""
+    wf_steps = snakemake_workflow_spec_loaded["workflow"]["specification"]["steps"]
+    for step in wf_steps:
+        step["compute_backend"] = backends[step["name"]]
+    complexity = estimate_complexity("snakemake", snakemake_workflow_spec_loaded)
+    assert complexity == expected_complexity
+    assert get_workflow_min_job_memory(complexity) == expected_min_memory
+
+
+@pytest.mark.parametrize(
+    "complexity,should_raise",
+    [
+        # k8s step exceeds limit — raises
+        ([(1, 2000)], True),
+        # external-only step with high "memory" — no raise (not a k8s limit)
+        ([(0, 2000)], False),
+        # mix: external over-limit + k8s under-limit — no raise
+        ([(0, 2000), (1, 500)], False),
+        # mix: external under-limit + k8s over-limit — raises
+        ([(0, 500), (1, 2000)], True),
+        # empty — no raise
+        ([], False),
+    ],
+)
+@mock.patch(
+    "reana_server.complexity.REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT_IN_BYTES", 1000
+)
+@mock.patch(
+    "reana_server.complexity.REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT", "1Ki"
+)
+def test_validate_job_memory_limits(complexity, should_raise):
+    """Test that validate_job_memory_limits ignores external-backend steps."""
+    if should_raise:
+        with pytest.raises(REANAKubernetesMemoryLimitExceeded):
+            validate_job_memory_limits(complexity)
+    else:
+        validate_job_memory_limits(complexity)
+
+
+def _serial_spec(steps):
+    return {"workflow": {"specification": {"steps": steps}}}
+
+
+def _yadage_spec(stages):
+    return {"workflow": {"specification": {"stages": stages}}}
+
+
+def _cwl_spec(steps):
+    return {"workflow": {"specification": {"steps": steps}}}
+
+
+def _snakemake_spec(steps):
+    return {"workflow": {"specification": {"steps": steps}}}
+
+
+def _yadage_stage(name, compute_backend=None, nested_stages=None):
+    resources = [{"compute_backend": compute_backend}] if compute_backend else []
+    stage = {
+        "name": name,
+        "scheduler": {
+            "step": {"environment": {"resources": resources}},
+        },
+    }
+    if nested_stages is not None:
+        stage["scheduler"]["workflow"] = {"stages": nested_stages}
+    return stage
+
+
+@pytest.mark.parametrize(
+    "workflow_type,spec,expected",
+    [
+        # --- serial ---
+        # default backend (no compute_backend key) → kubernetes
+        ("serial", _serial_spec([{"commands": ["echo hi"]}]), True),
+        # explicit kubernetes
+        (
+            "serial",
+            _serial_spec([{"commands": ["echo"], "compute_backend": "kubernetes"}]),
+            True,
+        ),
+        # external backend only
+        (
+            "serial",
+            _serial_spec([{"commands": ["echo"], "compute_backend": "htcondor"}]),
+            False,
+        ),
+        # mixed: one external + one k8s
+        (
+            "serial",
+            _serial_spec(
+                [
+                    {"commands": ["echo"], "compute_backend": "htcondor"},
+                    {"commands": ["echo"]},
+                ]
+            ),
+            True,
+        ),
+        # empty steps → conservative True
+        ("serial", _serial_spec([]), True),
+        # --- yadage ---
+        # default backend (no resources) → kubernetes
+        ("yadage", _yadage_spec([_yadage_stage("step1")]), True),
+        # external backend
+        (
+            "yadage",
+            _yadage_spec([_yadage_stage("step1", compute_backend="htcondor")]),
+            False,
+        ),
+        # external top-level, kubernetes nested stage
+        (
+            "yadage",
+            _yadage_spec(
+                [
+                    _yadage_stage(
+                        "step1",
+                        compute_backend="htcondor",
+                        nested_stages=[_yadage_stage("nested")],
+                    )
+                ]
+            ),
+            True,
+        ),
+        # all external including nested
+        (
+            "yadage",
+            _yadage_spec(
+                [
+                    _yadage_stage(
+                        "step1",
+                        compute_backend="htcondor",
+                        nested_stages=[
+                            _yadage_stage("nested", compute_backend="htcondor")
+                        ],
+                    )
+                ]
+            ),
+            False,
+        ),
+        # wrapper stage with default (k8s) backend but all-external nested stages:
+        # the wrapper delegates its complexity to its children, so this counts as
+        # external-only
+        (
+            "yadage",
+            _yadage_spec(
+                [
+                    _yadage_stage(
+                        "wrapper",
+                        nested_stages=[
+                            _yadage_stage("nested", compute_backend="htcondor")
+                        ],
+                    )
+                ]
+            ),
+            False,
+        ),
+        # empty stages → conservative True
+        ("yadage", _yadage_spec([]), True),
+        # --- snakemake ---
+        # default backend → kubernetes
+        ("snakemake", _snakemake_spec([{"name": "step1"}]), True),
+        # external backend
+        (
+            "snakemake",
+            _snakemake_spec([{"name": "step1", "compute_backend": "htcondor"}]),
+            False,
+        ),
+        # mixed
+        (
+            "snakemake",
+            _snakemake_spec(
+                [
+                    {"name": "step1", "compute_backend": "htcondor"},
+                    {"name": "step2"},
+                ]
+            ),
+            True,
+        ),
+        # empty → conservative True
+        ("snakemake", _snakemake_spec([]), True),
+        # --- cwl ---
+        # default backend (no hints) → kubernetes
+        ("cwl", _cwl_spec([{"id": "step1", "hints": []}]), True),
+        # external backend via hints
+        (
+            "cwl",
+            _cwl_spec([{"id": "step1", "hints": [{"compute_backend": "htcondor"}]}]),
+            False,
+        ),
+        # external top-level, kubernetes step in nested sub-workflow
+        (
+            "cwl",
+            _cwl_spec(
+                [
+                    {
+                        "id": "step1",
+                        "hints": [{"compute_backend": "htcondor"}],
+                        "run": {"steps": [{"id": "nested", "hints": []}]},
+                    }
+                ]
+            ),
+            True,
+        ),
+        # all external, including nested
+        (
+            "cwl",
+            _cwl_spec(
+                [
+                    {
+                        "id": "step1",
+                        "hints": [{"compute_backend": "htcondor"}],
+                        "run": {
+                            "steps": [
+                                {
+                                    "id": "nested",
+                                    "hints": [{"compute_backend": "htcondor"}],
+                                }
+                            ]
+                        },
+                    }
+                ]
+            ),
+            False,
+        ),
+        # empty steps → conservative True
+        ("cwl", _cwl_spec([]), True),
+    ],
+)
+def test_workflow_uses_kubernetes(workflow_type, spec, expected):
+    """Test Kubernetes detection for all workflow types and backend combinations."""
+    assert ("kubernetes" in workflow_compute_backends(workflow_type, spec)) == expected
+
+
+@pytest.mark.parametrize(
+    "workflow_type,spec,expected",
+    [
+        # single external backend is reported as such
+        (
+            "serial",
+            _serial_spec([{"commands": ["echo"], "compute_backend": "htcondor"}]),
+            ["htcondor"],
+        ),
+        # hybrid workflow reports every backend it uses, sorted
+        (
+            "serial",
+            _serial_spec(
+                [
+                    {"commands": ["echo"], "compute_backend": "htcondor"},
+                    {"commands": ["echo"]},
+                    {"commands": ["echo"], "compute_backend": "slurm"},
+                ]
+            ),
+            ["htcondor", "kubernetes", "slurm"],
+        ),
+        # default backend → kubernetes
+        ("serial", _serial_spec([{"commands": ["echo"]}]), ["kubernetes"]),
+        # empty → conservative kubernetes
+        ("serial", _serial_spec([]), ["kubernetes"]),
+        # snakemake mixed
+        (
+            "snakemake",
+            _snakemake_spec(
+                [
+                    {"name": "a", "compute_backend": "htcondor"},
+                    {"name": "b"},
+                ]
+            ),
+            ["htcondor", "kubernetes"],
+        ),
+    ],
+)
+def test_workflow_compute_backends(workflow_type, spec, expected):
+    """The classifier returns the sorted set of step-level compute backends."""
+    assert workflow_compute_backends(workflow_type, spec) == expected
+
+
+@pytest.mark.parametrize(
+    "workflow_type,spec,expected",
+    [
+        # CWL: the canonical ``class: reana`` hint carries the backend and is
+        # followed by another hint. Reading only the last hint would miss it and
+        # misclassify the step as Kubernetes.
+        (
+            "cwl",
+            _cwl_spec(
+                [
+                    {
+                        "id": "step1",
+                        "hints": [
+                            {"class": "reana", "compute_backend": "htcondorcern"},
+                            {"class": "ResourceRequirement", "ramMin": 4096},
+                        ],
+                    }
+                ]
+            ),
+            ["htcondorcern"],
+        ),
+        # CWL: the engine's ``_get_hint`` returns the first hint carrying the
+        # key, so a later duplicate declaration must not win.
+        (
+            "cwl",
+            _cwl_spec(
+                [
+                    {
+                        "id": "step1",
+                        "hints": [
+                            {"class": "reana", "compute_backend": "htcondorcern"},
+                            {"compute_backend": "slurmcern"},
+                        ],
+                    }
+                ]
+            ),
+            ["htcondorcern"],
+        ),
+        # CWL: a hint list with no backend at all still defaults to Kubernetes.
+        (
+            "cwl",
+            _cwl_spec([{"id": "step1", "hints": [{"class": "ResourceRequirement"}]}]),
+            ["kubernetes"],
+        ),
+        # Yadage: the engine's ``_get_resources`` iterates all resources with
+        # overwrite, so the last declaration is the one that runs.
+        (
+            "yadage",
+            _yadage_spec(
+                [
+                    {
+                        "name": "step1",
+                        "scheduler": {
+                            "step": {
+                                "environment": {
+                                    "resources": [
+                                        {"compute_backend": "htcondorcern"},
+                                        {"compute_backend": "kubernetes"},
+                                    ]
+                                }
+                            }
+                        },
+                    }
+                ]
+            ),
+            ["kubernetes"],
+        ),
+        # Yadage: mirror case, an external backend declared last wins.
+        (
+            "yadage",
+            _yadage_spec(
+                [
+                    {
+                        "name": "step1",
+                        "scheduler": {
+                            "step": {
+                                "environment": {
+                                    "resources": [
+                                        {"compute_backend": "kubernetes"},
+                                        {"compute_backend": "htcondorcern"},
+                                    ]
+                                }
+                            }
+                        },
+                    }
+                ]
+            ),
+            ["htcondorcern"],
+        ),
+        # Yadage: non-dict resources are ignored, as the engine ignores them.
+        (
+            "yadage",
+            _yadage_spec(
+                [
+                    {
+                        "name": "step1",
+                        "scheduler": {
+                            "step": {
+                                "environment": {
+                                    "resources": [
+                                        {"compute_backend": "htcondorcern"},
+                                        "kerberos",
+                                    ]
+                                }
+                            }
+                        },
+                    }
+                ]
+            ),
+            ["htcondorcern"],
+        ),
+    ],
+)
+def test_workflow_compute_backends_matches_execution(workflow_type, spec, expected):
+    """The classifier agrees with the backend the workflow engines resolve.
+
+    See ``ReanaPipeline._get_hint`` in reana-workflow-engine-cwl and
+    ``_get_resources`` in reana-workflow-engine-yadage.
+    """
+    assert workflow_compute_backends(workflow_type, spec) == expected

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -10,13 +10,36 @@
 
 import base64
 import json
+from uuid import uuid4
 
 import pytest
 from bravado.exception import HTTPBadGateway, HTTPNotFound, HTTPConflict
 from mock import DEFAULT, Mock, patch
 
+from reana_db.models import RunStatus, Service, ServiceStatus, ServiceType, Workflow
+
 from reana_server.api_client import WorkflowSubmissionPublisher
-from reana_server.scheduler import WorkflowExecutionScheduler
+from reana_server.scheduler import (
+    WorkflowExecutionScheduler,
+    check_concurrent_workflows_limit,
+)
+
+
+def _patch_caps(per_backend=None, k8s=30, external=200, dask_cap=5):
+    """Patch the concurrency caps resolved by ``get_concurrent_workflows_cap``.
+
+    :param per_backend: JSON-style override map of backend identifier -> cap.
+    :param k8s: default Kubernetes cap.
+    :param external: default cap for external backends without an override.
+    :param dask_cap: Dask-cluster cap.
+    """
+    return patch.multiple(
+        "reana_commons.config",
+        REANA_MAX_CONCURRENT_BATCH_WORKFLOWS_PER_BACKEND=per_backend or {},
+        REANA_MAX_CONCURRENT_K8S_BATCH_WORKFLOWS=k8s,
+        REANA_MAX_CONCURRENT_EXTERNAL_BATCH_WORKFLOWS=external,
+        REANA_MAX_CONCURRENT_DASK_WORKFLOWS=dask_cap,
+    )
 
 
 def test_scheduler_starts_workflows(
@@ -158,3 +181,226 @@ def test_scheduler_fail_after_too_many_retries(
             in_memory_queue_connection.channel().queues["workflow-submission"].empty()
         )
         assert not in_memory_queue_connection.channel().queues["jobs-status"].empty()
+
+
+def _add_workflow(
+    session,
+    owner_id,
+    backend="kubernetes",
+    status=RunStatus.running,
+    uses_dask=False,
+    compute_backends=None,
+):
+    """Persist a workflow with the given status, backends and Dask service."""
+    workflow = Workflow(
+        id_=uuid4(),
+        name="test_workflow",
+        owner_id=owner_id,
+        reana_specification={},
+        type_="serial",
+        status=status,
+        compute_backends=compute_backends or [backend],
+    )
+    if uses_dask:
+        workflow.services.append(
+            Service(
+                name=f"dask-{workflow.id_}",
+                uri=f"/{workflow.id_}/dashboard",
+                type_=ServiceType.dask,
+                status=ServiceStatus.created,
+            )
+        )
+    session.add(workflow)
+    session.commit()
+    return workflow
+
+
+def test_kubernetes_workflows_are_capped(session, user0):
+    """Pending and running Kubernetes workflows count towards the k8s cap."""
+    _add_workflow(session, user0.id_, "kubernetes", RunStatus.running)
+    _add_workflow(session, user0.id_, "kubernetes", RunStatus.pending)
+
+    with _patch_caps(k8s=2):
+        assert check_concurrent_workflows_limit(["kubernetes"]) is not None
+    with _patch_caps(k8s=3):
+        assert check_concurrent_workflows_limit(["kubernetes"]) is None
+
+
+def test_external_workflows_are_capped(session, user0):
+    """External-only workflows now consume their own backend's cap (RWC663-02).
+
+    Previously external workflows neither checked nor counted towards any cap, so
+    a flood of HTCondor workflows could spawn unlimited orchestration pods. The
+    cap applies even with no explicit override, via the external-backend default.
+    """
+    for _ in range(5):
+        _add_workflow(session, user0.id_, "htcondorcern", RunStatus.running)
+
+    # External-backend default cap.
+    with _patch_caps(external=5):
+        assert check_concurrent_workflows_limit(["htcondorcern"]) is not None
+    with _patch_caps(external=6):
+        assert check_concurrent_workflows_limit(["htcondorcern"]) is None
+    # Per-backend override takes precedence over the default.
+    with _patch_caps(per_backend={"htcondorcern": 5}, external=999):
+        assert check_concurrent_workflows_limit(["htcondorcern"]) is not None
+
+
+def test_unknown_backend_is_still_capped(session, user0):
+    """A backend with no override falls back to the external default (no bypass)."""
+    for _ in range(5):
+        _add_workflow(session, user0.id_, "compute4punch", RunStatus.running)
+
+    with _patch_caps(external=5):
+        assert check_concurrent_workflows_limit(["compute4punch"]) is not None
+
+
+def test_backend_caps_are_independent(session, user0):
+    """A saturated external backend does not block other backends."""
+    for _ in range(5):
+        _add_workflow(session, user0.id_, "htcondorcern", RunStatus.running)
+
+    # HTCondor is full, but a Kubernetes-only submission is unaffected.
+    with _patch_caps(per_backend={"htcondorcern": 5}):
+        assert check_concurrent_workflows_limit(["kubernetes"]) is None
+        # A hybrid workflow that also uses HTCondor is blocked by the full cap.
+        assert (
+            check_concurrent_workflows_limit(["kubernetes", "htcondorcern"]) is not None
+        )
+
+
+def test_dask_workflows_are_capped(session, user0):
+    """Dask workflows are bounded by the Dask cap regardless of step backend.
+
+    A Dask-on-HTCondor workflow escapes the step-backend caps cheaply but still
+    materialises a heavy Kubernetes Dask cluster, so the orthogonal Dask cap must
+    apply (RWC663-01).
+    """
+    for _ in range(5):
+        _add_workflow(
+            session, user0.id_, "htcondorcern", RunStatus.running, uses_dask=True
+        )
+
+    # HTCondor cap is generous, but the Dask cap (5) is reached.
+    with _patch_caps(external=200, dask_cap=5):
+        assert (
+            check_concurrent_workflows_limit(["htcondorcern"], uses_dask=True)
+            is not None
+        )
+    with _patch_caps(external=200, dask_cap=6):
+        assert (
+            check_concurrent_workflows_limit(["htcondorcern"], uses_dask=True) is None
+        )
+        # A non-Dask submission on the same backend is not affected by the Dask cap.
+        assert (
+            check_concurrent_workflows_limit(["htcondorcern"], uses_dask=False) is None
+        )
+
+
+def test_only_active_workflows_are_counted(session, user0):
+    """Finished/failed workflows do not count towards any cap."""
+    for _ in range(5):
+        _add_workflow(session, user0.id_, "kubernetes", RunStatus.finished)
+
+    with _patch_caps(k8s=1):
+        assert check_concurrent_workflows_limit(["kubernetes"]) is None
+
+
+@patch("reana_server.utils.current_workflow_submission_publisher")
+def test_hybrid_workflow_submission_classifies_all_backends(
+    mock_publisher, session, user0
+):
+    """A hybrid workflow is classified with every backend it uses.
+
+    Its initial steps run on HTCondor and later steps on Kubernetes, so the
+    submission must record both backends and consume a slot in each cap.
+    """
+    from reana_server.utils import publish_workflow_submission
+
+    workflow = Workflow(
+        id_=uuid4(),
+        name="hybrid_workflow",
+        owner_id=user0.id_,
+        reana_specification={
+            "workflow": {
+                "specification": {
+                    "steps": [
+                        {
+                            "commands": ["echo external"],
+                            "compute_backend": "htcondorcern",
+                        },
+                        {"commands": ["echo kubernetes"]},
+                    ]
+                }
+            }
+        },
+        type_="serial",
+        status=RunStatus.created,
+    )
+    session.add(workflow)
+    session.commit()
+
+    publish_workflow_submission(workflow, user0.id_, {})
+
+    # The classification is persisted and sent along in the submission message.
+    assert sorted(workflow.compute_backends) == ["htcondorcern", "kubernetes"]
+    _, kwargs = mock_publisher.publish_workflow_submission.call_args
+    assert sorted(kwargs["compute_backends"]) == ["htcondorcern", "kubernetes"]
+    assert kwargs["uses_dask"] is False
+
+    # Once pending/running, it consumes a slot in both backend caps.
+    Workflow.update_workflow_status(session, workflow.id_, RunStatus.running)
+    with _patch_caps(k8s=1):
+        assert check_concurrent_workflows_limit(["kubernetes"]) is not None
+    with _patch_caps(per_backend={"htcondorcern": 1}):
+        assert check_concurrent_workflows_limit(["htcondorcern"]) is not None
+
+
+@patch("reana_server.utils.current_workflow_submission_publisher")
+def test_dask_on_external_workflow_submission_is_flagged(
+    mock_publisher, session, user0
+):
+    """A Dask cluster on external steps must be flagged for the Dask cap (RWC663-01).
+
+    The steps run on HTCondor (so ``compute_backends == ["htcondorcern"]``), but
+    the workflow still requests a heavy Kubernetes Dask cluster, so ``uses_dask``
+    must be reported so the scheduler applies the Dask cap.
+    """
+    from reana_server.utils import publish_workflow_submission
+
+    workflow = Workflow(
+        id_=uuid4(),
+        name="dask_on_htcondor",
+        owner_id=user0.id_,
+        reana_specification={
+            "workflow": {
+                "type": "serial",
+                "resources": {
+                    "dask": {
+                        "image": "daskdev/dask:latest",
+                        "number_of_workers": 20,
+                        "single_worker_memory": "800Mi",
+                    }
+                },
+                "specification": {
+                    "steps": [
+                        {
+                            "commands": ["echo external"],
+                            "compute_backend": "htcondorcern",
+                        },
+                    ]
+                },
+            }
+        },
+        type_="serial",
+        status=RunStatus.created,
+    )
+    session.add(workflow)
+    session.commit()
+
+    publish_workflow_submission(workflow, user0.id_, {})
+
+    assert workflow.compute_backends == ["htcondorcern"]
+    _, kwargs = mock_publisher.publish_workflow_submission.call_args
+    assert kwargs["compute_backends"] == ["htcondorcern"]
+    assert kwargs["uses_dask"] is True

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA-Server cluster status tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+from reana_server.status import ClusterHealth
+
+
+@pytest.fixture
+def workflow_health():
+    """Return a factory rendering the workflow health tiles for given caps."""
+
+    def _render(caps, active_counts, dask_enabled=True):
+        with patch("reana_server.status.WorkflowsStatus") as workflows_status, patch(
+            "reana_server.status.Workflow.count_active_per_backend",
+            return_value=active_counts,
+        ), patch(
+            "reana_server.status.get_concurrent_workflows_cap",
+            side_effect=lambda resource: caps[resource],
+        ), patch(
+            "reana_server.status.SUPPORTED_COMPUTE_BACKENDS",
+            [key for key in caps if key != "dask"],
+        ), patch(
+            "reana_server.status.DASK_ENABLED", dask_enabled
+        ):
+            workflows_status.return_value.get_workflows_by_status.return_value = 0
+            # ``ClusterHealth.__init__`` gathers node, job and session health as
+            # well, which needs a live Kubernetes cluster, so build a bare
+            # instance and exercise the workflow tiles on their own.
+            cluster_health = ClusterHealth.__new__(ClusterHealth)
+            return cluster_health.get_workflow_health()
+
+    return _render
+
+
+def test_workflow_health_reports_headroom(workflow_health):
+    """Backends below their cap report the free headroom as availability."""
+    health = workflow_health(
+        {"kubernetes": 30, "htcondorcern": 200, "dask": 5},
+        {"kubernetes": 15, "htcondorcern": 10},
+    )
+
+    assert health["backends"]["kubernetes"]["percentage"] == 50
+    assert health["backends"]["kubernetes"]["available"] == 15
+    assert health["backends"]["htcondorcern"]["percentage"] == 95
+    # The most-constrained resource is surfaced at the top level.
+    assert health["bottleneck"] == "kubernetes"
+    assert health["percentage"] == 50
+    assert health["health"] == "warning"
+
+
+def test_workflow_health_reports_closed_backend_as_unavailable(workflow_health):
+    """A cap of zero closes the backend, so no headroom is reported.
+
+    ``get_percentage`` treats a zero total as an unknown total and would
+    otherwise report 100% available, contradicting the scheduler, which admits
+    nothing at all for such a backend, as well as the per-backend tooltip in
+    reana-ui, which computes 0%.
+    """
+    health = workflow_health(
+        {"kubernetes": 30, "htcondorcern": 0, "dask": 5},
+        {"kubernetes": 1},
+    )
+
+    closed = health["backends"]["htcondorcern"]
+    assert closed["total"] == 0
+    assert closed["used"] == 0
+    assert closed["available"] == 0
+    assert closed["percentage"] == 0
+    assert closed["health"] == "critical"
+    # A closed backend is the cluster's bottleneck.
+    assert health["bottleneck"] == "htcondorcern"
+    assert health["percentage"] == 0
+
+
+def test_workflow_health_bottleneck_is_the_saturated_backend(workflow_health):
+    """A saturated external backend becomes the bottleneck over a roomy cap."""
+    health = workflow_health(
+        {"kubernetes": 30, "htcondorcern": 5, "dask": 5},
+        {"kubernetes": 2, "htcondorcern": 5},
+    )
+
+    assert health["backends"]["kubernetes"]["percentage"] == 93
+    assert health["backends"]["htcondorcern"]["percentage"] == 0
+    assert health["bottleneck"] == "htcondorcern"
+    # The top-level tile mirrors the bottleneck, so the dashboard reports the
+    # same "cluster full" verdict the scheduler would reach.
+    assert health["used"] == 5
+    assert health["total"] == 5
+    assert health["available"] == 0
+    assert health["percentage"] == 0
+    assert health["health"] == "critical"
+
+
+def test_workflow_health_hides_dask_when_disabled(workflow_health):
+    """No idle Dask tile is advertised on a cluster that rejects Dask workflows."""
+    health = workflow_health(
+        {"kubernetes": 30, "dask": 5}, {"kubernetes": 1}, dask_enabled=False
+    )
+
+    assert "dask" not in health["backends"]
+    assert health["bottleneck"] == "kubernetes"
+
+
+def test_workflow_health_shows_dask_usage_after_disabling(workflow_health):
+    """Workflows still running from before Dask was disabled stay visible."""
+    health = workflow_health(
+        {"kubernetes": 30, "dask": 5},
+        {"kubernetes": 1, "dask": 2},
+        dask_enabled=False,
+    )
+
+    assert health["backends"]["dask"]["used"] == 2
+
+
+def test_workflow_health_shows_dask_when_enabled(workflow_health):
+    """An enabled but idle Dask cap is reported so operators see the headroom."""
+    health = workflow_health({"kubernetes": 30, "dask": 5}, {"kubernetes": 1})
+
+    assert health["backends"]["dask"] == {
+        "used": 0,
+        "total": 5,
+        "available": 5,
+        "percentage": 100,
+        "health": "healthy",
+    }


### PR DESCRIPTION
Workflows whose steps run on external backends (HTCondor, Slurm) consume fewer Kubernetes resources, but the scheduler does not take this into account. Even fully external workflows are still subject to the concurrency limit.

This PR introduces more generous concurrency limits for external workflows rather than subjecting them to a coarse global limit.

Closes https://github.com/reanahub/reana-workflow-controller/issues/663