### PR TITLE
fix(auth): close email enumeration on /api/login in SSO mode 

### DIFF
--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -391,10 +391,21 @@ RATELIMIT_AUTHENTICATED_USER = _get_rate_limit(
     "REANA_RATELIMIT_AUTHENTICATED_USER", "20 per second"
 )
 REANA_RATELIMIT_SLOW = _get_rate_limit("REANA_RATELIMIT_SLOW", "1/5 second")
+REANA_RATELIMIT_SLOWER = _get_rate_limit("REANA_RATELIMIT_SLOWER", "30 per minute")
+REANA_RATELIMIT_SLOWEST = _get_rate_limit("REANA_RATELIMIT_SLOWEST", "5 per hour")
 
 RATELIMIT_PER_ENDPOINT = {
     "launch.launch": REANA_RATELIMIT_SLOW,
+    "users.request_token": REANA_RATELIMIT_SLOWEST,
 }
+
+# Invenio-accounts rate limits — only effective in deployments where local
+# accounts are allowed (i.e. ``REANA_SSO_ENABLED`` is false). Setting them
+# unconditionally is harmless: SSO-mode clusters have no local /signin POST
+# or local registration flow to throttle.
+ACCOUNTS_LOGIN_RATELIMIT = REANA_RATELIMIT_SLOWER
+ACCOUNTS_SEND_CONFIRMATION_RATELIMIT = REANA_RATELIMIT_SLOWEST
+ACCOUNTS_FORGOT_PASSWORD_EMAIL_RATELIMIT = REANA_RATELIMIT_SLOWEST
 
 # Flask-Breadcrumbs needs this variable set
 # =========================================

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -46,8 +46,8 @@ REANA_HOSTNAME = os.getenv("REANA_HOSTNAME", "localhost")
 REANA_HOSTPORT = os.getenv("REANA_HOSTPORT", "30443")
 REANA_URL = compose_reana_url(REANA_HOSTNAME, REANA_HOSTPORT)
 
-REANA_SSO_CERN_CONSUMER_KEY = os.getenv("CERN_CONSUMER_KEY", "CHANGE_ME")
-REANA_SSO_CERN_CONSUMER_SECRET = os.getenv("CERN_CONSUMER_SECRET", "CHANGE_ME")
+REANA_SSO_CERN_CONSUMER_KEY = os.getenv("CERN_CONSUMER_KEY", "")
+REANA_SSO_CERN_CONSUMER_SECRET = os.getenv("CERN_CONSUMER_SECRET", "")
 REANA_SSO_CERN_BASE_URL = os.getenv(
     "CERN_BASE_URL", "https://auth.cern.ch/auth/realms/cern"
 )
@@ -64,8 +64,8 @@ REANA_SSO_CERN_USERINFO_URL = os.getenv(
     "https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/userinfo",
 )
 
-REANA_SSO_EOSC_CONSUMER_KEY = os.getenv("EOSC_CONSUMER_KEY", "CHANGE_ME")
-REANA_SSO_EOSC_CONSUMER_SECRET = os.getenv("EOSC_CONSUMER_SECRET", "CHANGE_ME")
+REANA_SSO_EOSC_CONSUMER_KEY = os.getenv("EOSC_CONSUMER_KEY", "")
+REANA_SSO_EOSC_CONSUMER_SECRET = os.getenv("EOSC_CONSUMER_SECRET", "")
 REANA_SSO_EOSC_BASE_URL = os.getenv(
     "EOSC_BASE_URL", "https://proxy.testing.eosc-federation.eu"
 )
@@ -88,6 +88,18 @@ REANA_SSO_EOSC_USERINFO_URL = os.getenv(
 REANA_SSO_LOGIN_PROVIDERS = json.loads(os.getenv("LOGIN_PROVIDERS_CONFIGS", "[]"))
 REANA_SSO_LOGIN_PROVIDERS_SECRETS = json.loads(
     os.getenv("LOGIN_PROVIDERS_SECRETS", "{}")
+)
+
+#: Whether the deployment uses an external SSO provider (CERN, EOSC, or
+#: generic Keycloak). Derived from the presence of provider credentials: the
+#: REANA Helm chart only sets the corresponding env vars when real secrets
+#: are configured, so truthiness is a reliable signal. When enabled, local
+#: account registration and login are disabled: local accounts and external
+#: SSO are mutually exclusive.
+REANA_SSO_ENABLED = bool(
+    REANA_SSO_LOGIN_PROVIDERS
+    or REANA_SSO_CERN_CONSUMER_KEY
+    or REANA_SSO_EOSC_CONSUMER_KEY
 )
 
 DASK_ENABLED = strtobool(os.getenv("DASK_ENABLED", "true"))
@@ -273,6 +285,13 @@ if REANA_USER_EMAIL_CONFIRMATION:
 SECURITY_LOGIN_URL = "/signin"
 #: Disable password change by users.
 SECURITY_CHANGEABLE = False
+if REANA_SSO_ENABLED:
+    #: Disable local account registration when an external SSO provider is
+    #: configured. Local accounts and SSO are mutually exclusive.
+    SECURITY_REGISTERABLE = False
+    #: Disable local username/password login when an external SSO provider is
+    #: configured. Users must authenticate via the SSO flow.
+    ACCOUNTS_LOCAL_LOGIN_ENABLED = False
 #: Modify sign in validaiton error to avoid leaking extra information.
 failed_signin_msg = ("Signin failed. Invalid user or password.", "error")
 SECURITY_MSG_USER_DOES_NOT_EXIST = failed_signin_msg

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -643,3 +643,7 @@ if ACCESS_TOKEN_ISSUANCE_POLICY not in _ACCESS_TOKEN_ISSUANCE_POLICIES:
         sorted(_ACCESS_TOKEN_ISSUANCE_POLICIES),
     )
     ACCESS_TOKEN_ISSUANCE_POLICY = "manual"
+# The unsafe ``auto`` + no-SSO combination is refused at Flask app
+# initialization time (``REANA.init_app``) rather than here, so importers
+# that only read a few constants (e.g. the scheduler container) are not
+# forced to receive the SSO secrets just to satisfy a module-level check.

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -313,7 +313,7 @@ CORS_SUPPORTS_CREDENTIALS = False
 
 #: Secret key - each installation (dev, production, ...) needs a separate key.
 #: It should be changed before deploying.
-SECRET_KEY = os.getenv("REANA_SECRET_KEY", "CHANGE_ME")
+SECRET_KEY = os.getenv("REANA_SECRET_KEY", "")
 """Secret key used for the application user sessions."""
 
 #: Maximum lifetime of a user web session, in hours. Flask-KVSession uses this
@@ -512,10 +512,10 @@ SECURITY_SEND_REGISTER_EMAIL = False
 
 # Gitlab Application configuration
 # ================================
-REANA_GITLAB_OAUTH_APP_ID = os.getenv("REANA_GITLAB_OAUTH_APP_ID", "CHANGE_ME")
-REANA_GITLAB_OAUTH_APP_SECRET = os.getenv("REANA_GITLAB_OAUTH_APP_SECRET", "CHANGE_ME")
-REANA_GITLAB_HOST = os.getenv("REANA_GITLAB_HOST", None)
-REANA_GITLAB_URL = "https://{}".format((REANA_GITLAB_HOST or "CHANGE ME"))
+REANA_GITLAB_OAUTH_APP_ID = os.getenv("REANA_GITLAB_OAUTH_APP_ID", "")
+REANA_GITLAB_OAUTH_APP_SECRET = os.getenv("REANA_GITLAB_OAUTH_APP_SECRET", "")
+REANA_GITLAB_HOST = os.getenv("REANA_GITLAB_HOST", "")
+REANA_GITLAB_URL = "https://{}".format(REANA_GITLAB_HOST) if REANA_GITLAB_HOST else ""
 
 # Workflow scheduler
 # ==================

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -252,8 +252,10 @@ MAIL_SUPPRESS_SEND = True
 # Accounts
 # ========
 #: Redis URL
+REANA_CACHE_USER = os.getenv("REANA_CACHE_USER", "")
 REANA_CACHE_PASSWORD = os.getenv("REANA_CACHE_PASSWORD", "")
-ACCOUNTS_SESSION_REDIS_URL = "redis://:{password}@{host}:6379/1".format(
+ACCOUNTS_SESSION_REDIS_URL = "redis://{user}:{password}@{host}:6379/1".format(
+    user=REANA_CACHE_USER,
     password=REANA_CACHE_PASSWORD,
     host=REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES["cache"],
 )

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -15,6 +15,7 @@ import os
 import re
 from datetime import timedelta
 from typing import Optional
+from urllib.parse import quote as _urlquote
 
 from distutils.util import strtobool
 from limits.util import parse
@@ -254,9 +255,11 @@ MAIL_SUPPRESS_SEND = True
 #: Redis URL
 REANA_CACHE_USER = os.getenv("REANA_CACHE_USER", "")
 REANA_CACHE_PASSWORD = os.getenv("REANA_CACHE_PASSWORD", "")
+# Percent-encode credentials so any of @, :, /, ?, #, %, [, ], etc. in
+# operator-supplied passwords do not break URI parsing.
 ACCOUNTS_SESSION_REDIS_URL = "redis://{user}:{password}@{host}:6379/1".format(
-    user=REANA_CACHE_USER,
-    password=REANA_CACHE_PASSWORD,
+    user=_urlquote(REANA_CACHE_USER, safe=""),
+    password=_urlquote(REANA_CACHE_PASSWORD, safe=""),
     host=REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES["cache"],
 )
 #: Email address used as sender of account registration emails.

--- a/reana_server/ext.py
+++ b/reana_server/ext.py
@@ -10,7 +10,7 @@
 
 import logging
 
-from flask import jsonify
+from flask import jsonify, request
 from flask_limiter.errors import RateLimitExceeded
 from marshmallow.exceptions import ValidationError
 from reana_commons.config import REANA_LOG_FORMAT, REANA_LOG_LEVEL
@@ -72,6 +72,44 @@ def handle_invalid_padding_error(error: InvalidPaddingError):
     ) from error
 
 
+def _block_local_login_in_sso_mode(app):
+    """Mask ``POST /api/login`` behind a generic credential error in SSO mode.
+
+    ``ACCOUNTS_LOCAL_LOGIN_ENABLED = False`` does block local login, but the
+    "Local login is disabled." message fires only after the user lookup
+    succeeds, leaking which emails correspond to registered REANA users.
+    Intercept the request earlier and return the same generic body that an
+    unknown email otherwise produces, so known and unknown emails are
+    indistinguishable.
+    """
+    if not app.config.get("REANA_SSO_ENABLED"):
+        return
+
+    generic_body = {
+        "status": 400,
+        "message": "Validation error.",
+        "errors": [
+            {
+                "field": "email",
+                "message": "Signin failed. Invalid user or password.",
+            }
+        ],
+    }
+
+    @app.before_request
+    def _reject_local_login():
+        if request.method != "POST":
+            return
+        # The API app is mounted at ``/api`` by ``invenio-app``, so requests
+        # to ``/api/login`` arrive here with ``request.path == "/login"``
+        # (the prefix is stripped by the WSGI dispatcher). Match both the
+        # mounted and unmounted forms so the hook works on the API app and
+        # also defends the UI app, where the prefix is not stripped.
+        path = request.path.rstrip("/")
+        if path in ("/login", "/api/login"):
+            return jsonify(generic_body), 400
+
+
 class REANA(object):
     """REANA Invenio app.
 
@@ -95,6 +133,7 @@ class REANA(object):
         self.init_config(app)
         self.init_error_handlers(app)
         self._validate_security_config(app)
+        _block_local_login_in_sso_mode(app)
 
         account_info_received.connect(_create_and_associate_oauth_user)
         user_registered.connect(_create_and_associate_local_user)

--- a/reana_server/ext.py
+++ b/reana_server/ext.py
@@ -124,6 +124,14 @@ class REANA(object):
     @staticmethod
     def _validate_security_config(app):
         """Refuse unsafe combinations of security-related config."""
+        if not app.config.get("SECRET_KEY"):
+            raise ValueError(
+                "SECRET_KEY is unset. Provide a strong random value via "
+                "secrets.reana.REANA_SECRET_KEY in your Helm values, e.g. "
+                "`--set secrets.reana.REANA_SECRET_KEY=$(openssl rand -hex 32)`. "
+                "For existing clusters that need to rotate, see: "
+                "https://blog.reana.io/posts/2024/reana-0.9.4/"
+            )
         if app.config.get(
             "ACCESS_TOKEN_ISSUANCE_POLICY"
         ) == "auto" and not app.config.get("REANA_SSO_ENABLED"):

--- a/reana_server/ext.py
+++ b/reana_server/ext.py
@@ -94,6 +94,7 @@ class REANA(object):
         """Flask application initialization."""
         self.init_config(app)
         self.init_error_handlers(app)
+        self._validate_security_config(app)
 
         account_info_received.connect(_create_and_associate_oauth_user)
         user_registered.connect(_create_and_associate_local_user)
@@ -119,3 +120,15 @@ class REANA(object):
         app.register_error_handler(RateLimitExceeded, handle_rate_limit_error)
         app.register_error_handler(UnprocessableEntity, handle_args_validation_error)
         app.register_error_handler(InvalidPaddingError, handle_invalid_padding_error)
+
+    @staticmethod
+    def _validate_security_config(app):
+        """Refuse unsafe combinations of security-related config."""
+        if app.config.get(
+            "ACCESS_TOKEN_ISSUANCE_POLICY"
+        ) == "auto" and not app.config.get("REANA_SSO_ENABLED"):
+            raise ValueError(
+                "REANA_ACCESS_TOKEN_ISSUANCE_POLICY='auto' is unsafe without SSO. "
+                "Either configure an SSO provider (CERN, EOSC, or Keycloak) "
+                "or set REANA_ACCESS_TOKEN_ISSUANCE_POLICY=manual."
+            )


### PR DESCRIPTION
The earlier `disable local accounts when SSO is configured` change
on this branch sets `ACCOUNTS_LOCAL_LOGIN_ENABLED=False` when SSO is
configured, which does refuse local credentials at /api/login. But
invenio-accounts only emits the "Local login is disabled." response
after the user lookup succeeds: unknown emails get the generic
"Signin failed. Invalid user or password." message, while known
emails get the disabled-login message. That lets an unauthenticated
client distinguish registered from unregistered REANA users
(typically created via prior SSO logins, since invenio-accounts
materialises a local User row for every SSO-authenticated identity).

Add a before_request hook on the API app that, when REANA_SSO_ENABLED
is true, intercepts POST login requests and returns the same generic
body that an unknown email would otherwise produce. The hook runs
before the invenio-accounts view, so user lookup never happens and
the response is byte-identical for any input.

Match both /login and /api/login: invenio-app mounts the API app at
/api and strips that prefix before requests reach Flask, so on the
production API app request.path is /login. Matching both forms keeps
the hook effective regardless of how the app is mounted.

The `ACCOUNTS_LOCAL_LOGIN_ENABLED=False` setting from that earlier
commit is kept as defence-in-depth: it still blocks the HTML /signin
form.