### PR TITLE
test(validation): require Snakemake default in allowlist

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,12 @@
 #
 adage==0.11.0             # via reana-commons, reana-server (setup.py), yadage
 aiohappyeyeballs==2.6.2   # via aiohttp
-aiohttp==3.14.0           # via kubernetes
+aiohttp==3.14.1           # via kubernetes
 aiosignal==1.4.0          # via aiohttp
 alembic==1.18.4           # via flask-alembic, invenio-db, reana-db
 amqp==5.3.1               # via kombu
-appdirs==1.4.4            # via fs, snakemake
+annotated-types==0.7.0    # via pydantic
+appdirs==1.4.4            # via fs
 argcomplete==3.6.3        # via cwltool
 argparse-dataclass==2.0.0  # via snakemake-interface-common, snakemake-interface-executor-plugins, yte
 arrow==1.4.0              # via marshmallow-utils
@@ -41,26 +42,26 @@ commonmark==0.9.2         # via rich
 conda-inject==1.3.2       # via snakemake
 configargparse==1.7.5     # via snakemake, snakemake-interface-common
 connection-pool==0.0.3    # via snakemake
-cryptography==48.0.0      # via invenio-accounts, pyjwt, sqlalchemy-utils
+cryptography==48.0.1      # via invenio-accounts, pyjwt, sqlalchemy-utils
 cwltool==3.1.20210628163208  # via reana-commons
 decorator==5.3.1          # via ipython, jsonpath-rw
 deprecated==1.3.1         # via limits
 dnspython==2.8.0          # via email-validator
-docutils==0.23            # via snakemake
+docutils==0.22.4          # via snakemake
 dpath==2.2.0              # via snakemake, yte
 durationpy==0.10          # via kubernetes
 edtf==5.0.1               # via babel-edtf, marshmallow-utils
 email-validator==2.3.0    # via flask-security-invenio
 executing==2.2.1          # via stack-data
 fastjsonschema==2.21.2    # via nbformat
-filelock==3.29.1          # via cachecontrol
+filelock==3.29.3          # via cachecontrol
 flask==3.1.3              # via flask-alembic, flask-babel, flask-caching, flask-celeryext, flask-collect-invenio, flask-cors, flask-kvsession-invenio, flask-limiter, flask-login, flask-mail, flask-menu, flask-oauthlib-invenio, flask-principal, flask-security-invenio, flask-shell-ipython, flask-sqlalchemy, flask-webpackext, flask-wtf, invenio-app, invenio-base, invenio-config, invenio-mail, reana-server (setup.py)
 flask-alembic==3.1.1      # via invenio-db
 flask-babel==4.0.0        # via flask-security-invenio, invenio-i18n
 flask-caching==2.4.0      # via invenio-cache
 flask-celeryext==0.5.0    # via invenio-celery
 flask-collect-invenio==1.4.0  # via invenio-assets
-flask-cors==6.0.3         # via invenio-rest
+flask-cors==6.0.5         # via invenio-rest
 flask-kvsession-invenio==1.0.0  # via invenio-accounts
 flask-limiter==2.9.2      # via invenio-app, reana-server (setup.py)
 flask-login==0.6.3        # via flask-security-invenio
@@ -79,7 +80,7 @@ fs==2.4.16                # via reana-commons
 ftfy==6.3.1               # via marshmallow-utils
 future==1.0.0             # via invenio-oauth2server
 geojson==3.3.0            # via marshmallow-utils
-gherkin-official==39.1.0  # via reana-commons
+gherkin-official==40.0.0  # via reana-commons
 gitdb==4.0.12             # via gitpython
 github3-py==4.0.1         # via invenio-oauthclient
 gitpython==3.1.50         # via reana-server (setup.py), snakemake
@@ -103,7 +104,7 @@ invenio-celery==2.2.0     # via invenio-accounts, invenio-app, invenio-logging
 invenio-config==1.1.0     # via invenio-app, reana-server (setup.py)
 invenio-db[postgresql]==2.5.1  # via invenio-logging, reana-server (setup.py)
 invenio-i18n==3.5.0       # via invenio-access, invenio-accounts, invenio-oauth2server, invenio-oauthclient, invenio-theme, invenio-userprofiles, reana-server (setup.py)
-invenio-logging==4.1.1    # via invenio-rest, reana-server (setup.py)
+invenio-logging==4.2.0    # via invenio-rest, reana-server (setup.py)
 invenio-mail==2.3.0       # via invenio-accounts, invenio-oauthclient, reana-server (setup.py)
 invenio-oauth2server==4.0.0  # via reana-server (setup.py)
 invenio-oauthclient==7.0.1  # via reana-server (setup.py)
@@ -140,7 +141,7 @@ maxminddb-geolite2==2018.703  # via invenio-accounts
 mistune==3.2.1            # via schema-salad
 mock==3.0.5               # via packtivity, reana-commons
 monotonic==1.6            # via bravado
-msgpack==1.1.2            # via bravado-core, cachecontrol, invenio-celery
+msgpack==1.2.0            # via bravado-core, cachecontrol, invenio-celery
 msgpack-python==0.5.6     # via bravado
 multidict==6.7.1          # via aiohttp, yarl
 mypy-extensions==1.1.0    # via cwltool, schema-salad
@@ -153,7 +154,7 @@ packtivity==0.16.2        # via reana-server (setup.py), yadage
 parse==1.22.1             # via reana-commons
 parso==0.8.7              # via jedi
 pexpect==4.9.0            # via ipython
-platformdirs==4.10.0      # via jupyter-core
+platformdirs==4.10.0      # via jupyter-core, snakemake
 ply==3.11                 # via jsonpath-rw
 polib==1.2.0              # via invenio-i18n
 prompt-toolkit==3.0.52    # via click-repl, ipython
@@ -166,6 +167,8 @@ pulp==3.3.2               # via snakemake
 pure-eval==0.2.3          # via stack-data
 pycountry==26.2.16        # via marshmallow-utils
 pycparser==3.0            # via cffi
+pydantic==2.13.4          # via sqlmodel
+pydantic-core==2.46.4     # via pydantic
 pydot==4.0.1              # via cwltool
 pygments==2.20.0          # via ipython, ipython-pygments-lexers, rich
 pyjwt[crypto]==2.13.0     # via github3-py, invenio-accounts, invenio-oauth2server
@@ -177,13 +180,12 @@ pytz==2024.1              # via bravado-core, flask-babel, invenio-i18n
 pywebpack==2.2.1          # via flask-webpackext
 pyyaml==6.0.3             # via bravado, bravado-core, conda-inject, kubernetes, packtivity, reana-commons, snakemake, swagger-spec-validator, yadage, yadage-schemas, yte
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons[cwl,kubernetes,snakemake,yadage]==0.95.0a20  # via reana-db, reana-server (setup.py)
+reana-commons[cwl,kubernetes,snakemake,yadage]==0.95.0a21  # via reana-db, reana-server (setup.py)
 reana-db==0.95.0a10       # via reana-server (setup.py)
 redis==8.0.0              # via invenio-celery
 referencing==0.37.0       # via snakemake
 requests[security]==2.34.2  # via bravado, bravado-core, cachecontrol, cwltool, github3-py, kubernetes, packtivity, reana-server (setup.py), requests-oauthlib, schema-salad, snakemake, yadage, yadage-schemas
 requests-oauthlib==2.0.0  # via flask-oauthlib-invenio, invenio-oauth2server, invenio-oauthclient, kubernetes
-reretry==0.11.8           # via snakemake
 rfc3987==1.3.8            # via jsonschema
 rich==12.6.0              # via flask-limiter, rich-argparse, rich-click
 rich-argparse==1.8.0      # via schema-salad
@@ -197,7 +199,7 @@ simplekv==0.14.1          # via flask-kvsession-invenio, invenio-accounts
 six==1.17.0               # via bravado, bravado-core, flask-talisman, fs, jsonpath-rw, jsonschema, kubernetes, mock, prov, python-dateutil, rdflib, reana-server (setup.py)
 smart-open==7.6.1         # via snakemake
 smmap==5.0.3              # via gitdb
-snakemake==9.16.3         # via reana-commons
+snakemake==9.22.0         # via reana-commons
 snakemake-interface-common==1.23.0  # via snakemake, snakemake-interface-executor-plugins, snakemake-interface-logger-plugins, snakemake-interface-report-plugins, snakemake-interface-scheduler-plugins, snakemake-interface-storage-plugins
 snakemake-interface-executor-plugins==9.4.0  # via snakemake
 snakemake-interface-logger-plugins==2.1.0  # via snakemake
@@ -205,19 +207,21 @@ snakemake-interface-report-plugins==1.3.0  # via snakemake
 snakemake-interface-scheduler-plugins==2.0.2  # via snakemake
 snakemake-interface-storage-plugins==4.4.1  # via snakemake
 speaklater==1.3           # via flask-security-invenio
-sqlalchemy[asyncio]==2.0.50  # via alembic, flask-alembic, flask-sqlalchemy, invenio-db, reana-db, sqlalchemy-continuum, sqlalchemy-utils, wtforms-alchemy
+sqlalchemy[asyncio]==2.0.50  # via alembic, flask-alembic, flask-sqlalchemy, invenio-db, reana-db, sqlalchemy-continuum, sqlalchemy-utils, sqlmodel, wtforms-alchemy
 sqlalchemy-continuum==1.5.2  # via invenio-db
 sqlalchemy-utils[encrypted]==0.41.2  # via invenio-db, reana-db, sqlalchemy-utils, wtforms-alchemy
+sqlmodel==0.0.37          # via snakemake
 stack-data==0.6.3         # via ipython
 strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==3.0.4  # via bravado-core
 tablib==3.9.0             # via reana-server (setup.py)
 tabulate==0.10.0          # via snakemake
-tenacity==9.1.4           # via snakemake-interface-storage-plugins
+tenacity==9.1.4           # via snakemake, snakemake-interface-storage-plugins
 throttler==1.2.3          # via snakemake, snakemake-interface-executor-plugins, snakemake-interface-storage-plugins
 tinycss2==1.5.1           # via bleach
 traitlets==5.15.1         # via ipython, jupyter-core, matplotlib-inline, nbformat
-typing-extensions==4.15.0  # via aiohttp, aiosignal, alembic, bravado, cwltool, flask-limiter, gherkin-official, limits, referencing, sqlalchemy, swagger-spec-validator
+typing-extensions==4.15.0  # via aiohttp, aiosignal, alembic, bravado, cwltool, flask-limiter, gherkin-official, limits, pydantic, pydantic-core, referencing, sqlalchemy, swagger-spec-validator, typing-inspection
+typing-inspection==0.4.2  # via pydantic
 tzdata==2026.2            # via arrow, celery, kombu
 ua-parser==1.0.2          # via invenio-accounts
 ua-parser-builtins==202606  # via ua-parser
@@ -231,7 +235,7 @@ validators==0.35.0        # via wtforms-components
 vine==5.1.0               # via amqp, celery, kombu
 watchdog==6.0.0           # via invenio-base
 wcmatch==8.4.1            # via reana-commons
-wcwidth==0.8.0            # via ftfy, prompt-toolkit
+wcwidth==0.8.1            # via ftfy, prompt-toolkit
 webargs==8.7.1            # via invenio-rest
 webcolors==25.10.0        # via jsonschema
 webencodings==0.5.1       # via bleach, tinycss2

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extras_require = {
     "tests": [
         "apispec[yaml]>=3.0",
         "apispec-webframeworks",
-        "reana-commons[kubernetes,yadage,snakemake,cwl,tests]>=0.95.0a20,<0.96.0",
+        "reana-commons[kubernetes,yadage,snakemake,cwl,tests]>=0.95.0a21,<0.96.0",
         "reana-db[tests]>=0.95.0a10,<0.96.0",
     ],
 }
@@ -51,7 +51,7 @@ install_requires = [
     "Flask>=3.0.0,<4.0.0",
     "gitpython>=3.1",
     "marshmallow>=3.5.0,<4.0.0",
-    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.95.0a20,<0.96.0",
+    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.95.0a21,<0.96.0",
     "reana-db>=0.95.0a10,<0.96.0",
     "requests>=2.25.0",
     "tablib>=0.12.1",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,6 +10,7 @@ import pytest
 from unittest.mock import patch
 from contextlib import nullcontext as does_not_raise
 
+from reana_commons.config import REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE
 from reana_commons.errors import REANAValidationError
 
 from reana_server.validation import (
@@ -97,16 +98,30 @@ def snakemake_workflow(*images):
             pytest.raises(REANAValidationError, match="not allowed"),
             id="snakemake-explicit-container-disallowed",
         ),
-        # Snakemake: rule without container directive produces "" from the loader;
-        # the runtime uses the admin-controlled default image, so it is not vetted.
+        # Snakemake: the runtime default must be explicitly allowlisted.
         pytest.param(
             {"enabled": True, "allowlist": []},
             snakemake_workflow(""),
-            does_not_raise(),
-            id="snakemake-no-container-uses-admin-default",
+            pytest.raises(REANAValidationError, match="not allowed"),
+            id="snakemake-no-container-empty-allowlist-rejected",
         ),
         pytest.param(
-            ALLOWLIST,
+            {
+                "enabled": True,
+                "allowlist": [REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE],
+            },
+            snakemake_workflow(""),
+            does_not_raise(),
+            id="snakemake-no-container-default-allowlisted",
+        ),
+        pytest.param(
+            {
+                "enabled": True,
+                "allowlist": [
+                    ALLOWED_IMAGE,
+                    REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE,
+                ],
+            },
             snakemake_workflow(ALLOWED_IMAGE, ""),
             does_not_raise(),
             id="snakemake-mixed-with-and-without-container",


### PR DESCRIPTION
Update server validation coverage for the strict policy requiring the
configured Snakemake default image to be explicitly allowlisted.

Closes reanahub/reana-workflow-engine-snakemake#129

