### PR TITLE
feat(rest): support scoped user secret names

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4067,6 +4067,13 @@
                 "image": {
                   "description": "Replaces the default Docker image of an interactive session.",
                   "type": "string"
+                },
+                "secret_names": {
+                  "description": "Optional. Explicit allowlist of user secret names to expose to the interactive session. If omitted, the interactive session inherits workflow.resources.secret_names when present; otherwise, all user secrets remain available.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 }
               },
               "type": "object"

--- a/reana_server/rest/secrets.py
+++ b/reana_server/rest/secrets.py
@@ -23,24 +23,31 @@ from marshmallow import Schema, validate
 from reana_server.decorators import signin_required
 
 blueprint = Blueprint("secrets", __name__)
+_RESERVED_USER_SECRET_NAMES = {"REANA_USER_SECRETS_TYPES"}
+
+
+def _validate_user_secret_name(secret_name: str):
+    """Reject reserved secret names used by REANA control variables."""
+    if secret_name in _RESERVED_USER_SECRET_NAMES:
+        raise marshmallow.ValidationError(
+            f"Secret name {secret_name} is reserved for internal use."
+        )
 
 
 class AddSecretsBodySchema(Schema):
     """Schema for add_secrets endpoint body."""
 
-    body = (
-        fields.Dict(
-            keys=fields.Str(),
-            values=fields.Nested(
-                {
-                    "value": fields.Str(required=True),
-                    "type": fields.Str(
-                        validate=validate.OneOf(Secret.types), required=True
-                    ),
-                }
-            ),
-            required=True,
+    body = fields.Dict(
+        keys=fields.Str(validate=_validate_user_secret_name),
+        values=fields.Nested(
+            {
+                "value": fields.Str(required=True),
+                "type": fields.Str(
+                    validate=validate.OneOf(Secret.types), required=True
+                ),
+            }
         ),
+        required=True,
     )
 
 
@@ -153,7 +160,9 @@ def add_secrets(user, overwrite=False):
               }
     """
     json_body = request.json
-    AddSecretsBodySchema().validate({"body": json_body})
+    validation_errors = AddSecretsBodySchema().validate({"body": json_body})
+    if validation_errors:
+        return jsonify({"message": validation_errors}), 400
 
     try:
         secrets = [

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -4102,6 +4102,15 @@ def open_interactive_session(
                 type: string
                 description: >-
                   Replaces the default Docker image of an interactive session.
+              secret_names:
+                type: array
+                items:
+                  type: string
+                description: >-
+                  Optional. Explicit allowlist of user secret names to expose
+                  to the interactive session. If omitted, the interactive
+                  session inherits workflow.resources.secret_names when
+                  present; otherwise, all user secrets remain available.
       responses:
         200:
           description: >-

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2795,6 +2795,24 @@ def test_open_interactive_session(
             assert res.status_code == expected_status_code
 
 
+def test_add_secrets_rejects_reserved_secret_name(app, user0):
+    """Reserved internal secret names should be rejected before storing secrets."""
+    reserved_secret = {
+        "REANA_USER_SECRETS_TYPES": {"value": "dXNlci1zZWNyZXQ=", "type": "env"}
+    }
+
+    with app.test_client() as client:
+        res = client.post(
+            "/api/secrets/",
+            query_string={"access_token": user0.access_token},
+            content_type="application/json",
+            data=json.dumps(reserved_secret),
+        )
+
+    assert res.status_code == 400
+    assert "reserved for internal use" in json.dumps(res.json["message"])
+
+
 @pytest.mark.parametrize(("expected_status_code"), [200])
 def test_close_interactive_session(
     app,


### PR DESCRIPTION
Document interactive-session secret precedence, reserve the internal sidecar manifest name, and validate uploaded secret names before they reach runtime secret reconstruction.

Closes reanahub/reana#978