### PR TITLE
feat(validation): validate workflow specifications on server

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,4 +1,54 @@
 {
+  "definitions": {
+    "ErrorResponse": {
+      "properties": {
+        "message": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "WorkflowSubmissionResponse": {
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "run_number": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "validation_warnings": {
+          "items": {
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "workflow_id": {
+          "type": "string"
+        },
+        "workflow_name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
   "info": {
     "description": "Submit workflows to be run on REANA Cloud",
     "title": "REANA Server",
@@ -1140,6 +1190,26 @@
               "type": "object"
             }
           },
+          "409": {
+            "description": "Another workflow-family mutation is in progress.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "429": {
+            "description": "Request rate limit exceeded.",
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "message"
+              ],
+              "type": "object"
+            }
+          },
           "500": {
             "description": "Request failed. Internal server error.",
             "examples": {
@@ -1155,6 +1225,12 @@
               },
               "type": "object"
             }
+          },
+          "503": {
+            "description": "Workspace mutation or controller service is unavailable.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           }
         },
         "summary": "Launch workflow from a remote REANA specification file."
@@ -1162,7 +1238,7 @@
     },
     "/api/ping": {
       "get": {
-        "description": "Ping the server.",
+        "description": "Ping the server.\n\nThis endpoint is deliberately unauthenticated: it also carries the protocol bootstrap signal that a client needs *before* it authenticates or builds a request body. ``api_capabilities`` advertises the client-facing protocols the server implements; a released server omits the field, which identifies it as legacy.",
         "operationId": "ping",
         "produces": [
           "application/json"
@@ -1172,13 +1248,27 @@
             "description": "Ping succeeded. Service is running and accessible.",
             "examples": {
               "application/json": {
+                "api_capabilities": [
+                  "workflow-specification-bundles-v1"
+                ],
                 "message": "OK",
+                "reana_server_version": "0.95.0a6",
                 "status": 200
               }
             },
             "schema": {
               "properties": {
+                "api_capabilities": {
+                  "description": "Client-facing protocols implemented by this server. Absent on released servers that predate protocol negotiation.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
                 "message": {
+                  "type": "string"
+                },
+                "reana_server_version": {
                   "type": "string"
                 },
                 "status": {
@@ -2271,6 +2361,20 @@
               "type": "object"
             }
           },
+          "429": {
+            "description": "Request rate limit exceeded.",
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "message"
+              ],
+              "type": "object"
+            }
+          },
           "500": {
             "description": "Request failed. Internal server error.",
             "examples": {
@@ -2859,9 +2963,9 @@
       },
       "post": {
         "consumes": [
-          "application/json"
+          "multipart/form-data"
         ],
-        "description": "This resource is expecting a REANA specification in JSON format with all the necessary information to instantiate a workflow.",
+        "description": "Creates a workflow from one uncompressed ZIP validation snapshot in the multipart ``bundle`` field. The archive contains canonical ``reana.yaml`` plus explicitly declared workflow/parameter files. The server loads and validates the specification authoritatively (sandboxed for Snakemake/CWL/Yadage).",
         "operationId": "create_workflow",
         "parameters": [
           {
@@ -2872,20 +2976,11 @@
             "type": "string"
           },
           {
-            "description": "Remote repository which contains a valid REANA specification.",
-            "in": "query",
-            "name": "spec",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "description": "REANA specification with necessary data to instantiate a workflow.",
-            "in": "body",
-            "name": "reana_specification",
-            "required": false,
-            "schema": {
-              "type": "object"
-            }
+            "description": "Uncompressed ZIP validation snapshot containing canonical reana.yaml plus explicitly declared workflow sources.",
+            "in": "formData",
+            "name": "bundle",
+            "required": true,
+            "type": "file"
           },
           {
             "description": "The API access_token of workflow owner.",
@@ -2912,6 +3007,23 @@
               "properties": {
                 "message": {
                   "type": "string"
+                },
+                "validation_warnings": {
+                  "items": {
+                    "properties": {
+                      "code": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
                 },
                 "workflow_id": {
                   "type": "string"
@@ -2971,11 +3083,45 @@
               "type": "object"
             }
           },
+          "409": {
+            "description": "Another workflow-family mutation is in progress.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "413": {
+            "description": "The uploaded request exceeds the bounded bundle limit.",
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "message"
+              ],
+              "type": "object"
+            }
+          },
+          "429": {
+            "description": "Request rate limit exceeded.",
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "message"
+              ],
+              "type": "object"
+            }
+          },
           "500": {
             "description": "Request failed. Internal controller error.",
             "examples": {
               "application/json": {
-                "message": "Internal controller error."
+                "message": "An internal server error occurred."
               }
             },
             "schema": {
@@ -2989,6 +3135,12 @@
           },
           "501": {
             "description": "Request failed. Not implemented."
+          },
+          "503": {
+            "description": "Workspace mutation or controller service is unavailable.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           }
         },
         "summary": "Creates a new workflow based on a REANA specification file."
@@ -3138,9 +3290,170 @@
               },
               "type": "object"
             }
+          },
+          "503": {
+            "description": "Workspace mutation serialization is unavailable.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           }
         },
         "summary": "Move files within workspace."
+      }
+    },
+    "/api/workflows/validate": {
+      "post": {
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "description": "Accepts one uncompressed ZIP validation snapshot in the multipart ``bundle`` field. The archive contains canonical ``reana.yaml`` plus its explicitly declared workflow/configuration files. Serial specs are loaded and validated in-process; Snakemake/CWL/Yadage specs -- whose loading executes user code -- are validated inside a sandboxed job spawned by reana-workflow-controller. Returns a structured validation report.",
+        "operationId": "validate_workflow_specification",
+        "parameters": [
+          {
+            "description": "Uncompressed ZIP validation snapshot containing canonical reana.yaml plus explicitly declared workflow sources.",
+            "in": "formData",
+            "name": "bundle",
+            "required": true,
+            "type": "file"
+          },
+          {
+            "in": "query",
+            "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "If true, run offline reproducibility checks on runtime environment image references and return the loaded image and effective runtime UID/GID combinations so the client can optionally pull and inspect them locally.",
+            "in": "query",
+            "name": "environments",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Validation ran; a structured report is returned.",
+            "schema": {
+              "properties": {
+                "environments": {
+                  "description": "Distinct runtime image and effective UID/GID combinations of the loaded spec (only when environments is requested), for client-side checks.",
+                  "items": {
+                    "properties": {
+                      "image": {
+                        "type": "string"
+                      },
+                      "runtime_gid": {
+                        "type": "integer"
+                      },
+                      "runtime_uid": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "runtime_uid",
+                      "runtime_gid"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "environments_truncated": {
+                  "description": "Whether one or more requested environment identities were omitted from the bounded response.",
+                  "type": "boolean"
+                },
+                "errors": {
+                  "items": {
+                    "properties": {
+                      "code": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "valid": {
+                  "type": "boolean"
+                },
+                "warnings": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "The bundle was missing or malformed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "Request malformed or missing access token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "403": {
+            "description": "Request access forbidden.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "413": {
+            "description": "The uploaded request exceeds the bounded bundle limit.",
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "message"
+              ],
+              "type": "object"
+            }
+          },
+          "429": {
+            "description": "Request rate limit exceeded.",
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "message"
+              ],
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Internal error while validating the specification.",
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Validate a raw workflow specification bundle."
       }
     },
     "/api/workflows/{workflow_id_or_name_a}/diff/{workflow_id_or_name_b}": {
@@ -4084,6 +4397,12 @@
               "type": "object"
             }
           },
+          "409": {
+            "description": "The workspace is currently being mutated.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "Request failed. Internal controller error.",
             "examples": {
@@ -4099,9 +4418,118 @@
               },
               "type": "object"
             }
+          },
+          "503": {
+            "description": "Workspace mutation serialization is unavailable.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           }
         },
         "summary": "Prune the workspace's files."
+      }
+    },
+    "/api/workflows/{workflow_id_or_name}/restart": {
+      "post": {
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "description": "Atomically validates and applies one raw replacement REANA specification. Workflow source files are reused from the existing workspace.",
+        "operationId": "restart_workflow",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "access_token",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Raw replacement REANA specification.",
+            "in": "formData",
+            "name": "replacement",
+            "required": true,
+            "type": "file"
+          },
+          {
+            "description": "JSON object containing optional input_parameters and operational_options objects.",
+            "in": "formData",
+            "name": "parameters",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Workflow restart was submitted.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowSubmissionResponse"
+            }
+          },
+          "400": {
+            "description": "Replacement or parameters are malformed or invalid.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "Request malformed or missing access token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "403": {
+            "description": "Restart is not permitted.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Workflow does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "409": {
+            "description": "The workspace is currently being mutated.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "413": {
+            "description": "Replacement exceeds the configured request limit.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "429": {
+            "description": "Request rate limit exceeded.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "503": {
+            "description": "Workspace mutation serialization is unavailable.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "summary": "Restart a workflow with a replacement specification."
       }
     },
     "/api/workflows/{workflow_id_or_name}/retention_rules": {
@@ -4752,7 +5180,7 @@
         "consumes": [
           "application/json"
         ],
-        "description": "This resource starts the workflow execution process. Resource is expecting a workflow UUID.",
+        "description": "This resource starts the workflow execution process. Resource is expecting a workflow UUID.\n\nThe workspace is the authoritative copy of the specification: before the workflow is queued, the server re-loads and re-validates the specification *from the current workspace* (in a sandbox for Snakemake/CWL/Yadage, in-process for serial) and refreshes the stored specification from it. A workspace that no longer loads or fails policy is rejected with a 400 and the workflow keeps its current status. Any non-blocking validation findings are returned in ``validation_warnings``.",
         "operationId": "start_workflow",
         "parameters": [
           {
@@ -4784,10 +5212,6 @@
                   "description": "Optional. Additional operational options for workflow execution.",
                   "type": "object"
                 },
-                "reana_specification": {
-                  "description": "Optional. Replace the original workflow specification with the given one. Only considered when restarting a workflow.",
-                  "type": "object"
-                },
                 "restart": {
                   "description": "Optional. If true, restart the given workflow.",
                   "type": "boolean"
@@ -4805,32 +5229,16 @@
             "description": "Request succeeded. Info about a workflow, including the execution status is returned.",
             "examples": {
               "application/json": {
-                "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
-                "message": "Workflow submitted",
+                "message": "Workflow submitted.",
+                "run_number": "1",
                 "status": "queued",
                 "user": "00000000-0000-0000-0000-000000000000",
-                "workflow_name": "mytest.1"
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest"
               }
             },
             "schema": {
-              "properties": {
-                "message": {
-                  "type": "string"
-                },
-                "status": {
-                  "type": "string"
-                },
-                "user": {
-                  "type": "string"
-                },
-                "workflow_id": {
-                  "type": "string"
-                },
-                "workflow_name": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
+              "$ref": "#/definitions/WorkflowSubmissionResponse"
             }
           },
           "400": {
@@ -4897,11 +5305,25 @@
               "type": "object"
             }
           },
+          "429": {
+            "description": "Request rate limit exceeded.",
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "message"
+              ],
+              "type": "object"
+            }
+          },
           "500": {
             "description": "Request failed. Internal controller error.",
             "examples": {
               "application/json": {
-                "message": "Internal controller error."
+                "message": "An internal server error occurred."
               }
             },
             "schema": {
@@ -4927,6 +5349,12 @@
                 }
               },
               "type": "object"
+            }
+          },
+          "503": {
+            "description": "Workspace mutation serialization is unavailable.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
             }
           }
         },
@@ -5177,7 +5605,7 @@
             "type": "string"
           },
           {
-            "description": "Required. New workflow status.",
+            "description": "Required. New workflow status. The `start` value is retained for compatibility; new clients should use POST /api/workflows/<workflow_id_or_name>/start.",
             "enum": [
               "start",
               "stop",
@@ -5215,7 +5643,7 @@
                   "type": "object"
                 },
                 "restart": {
-                  "description": "Optional. If true, the workflow is a restart of an earlier workflow execution. Only allowed when status is `start`.",
+                  "description": "Optional. If true, restart the given workflow. Only allowed when status is `start`.",
                   "type": "boolean"
                 },
                 "workspace": {
@@ -5235,32 +5663,15 @@
             "description": "Request succeeded. Info about a workflow, including the status is returned.",
             "examples": {
               "application/json": {
-                "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
                 "message": "Workflow successfully launched",
                 "status": "created",
                 "user": "00000000-0000-0000-0000-000000000000",
-                "workflow_name": "mytest.1"
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest"
               }
             },
             "schema": {
-              "properties": {
-                "message": {
-                  "type": "string"
-                },
-                "status": {
-                  "type": "string"
-                },
-                "user": {
-                  "type": "string"
-                },
-                "workflow_id": {
-                  "type": "string"
-                },
-                "workflow_name": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
+              "$ref": "#/definitions/WorkflowSubmissionResponse"
             }
           },
           "400": {
@@ -5327,6 +5738,20 @@
               "type": "object"
             }
           },
+          "429": {
+            "description": "Request rate limit exceeded.",
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "message"
+              ],
+              "type": "object"
+            }
+          },
           "500": {
             "description": "Request failed. Internal controller error.",
             "examples": {
@@ -5357,6 +5782,12 @@
                 }
               },
               "type": "object"
+            }
+          },
+          "503": {
+            "description": "Workspace mutation serialization is unavailable.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
             }
           }
         },
@@ -5765,6 +6196,18 @@
               "type": "object"
             }
           },
+          "409": {
+            "description": "The workspace is currently being mutated.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "411": {
+            "description": "A Content-Length header is required for streaming uploads.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "Request failed. Internal server error.",
             "examples": {
@@ -5779,6 +6222,12 @@
                 }
               },
               "type": "object"
+            }
+          },
+          "503": {
+            "description": "Workspace mutation or controller service is unavailable.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
             }
           }
         },
@@ -5878,6 +6327,12 @@
               "type": "object"
             }
           },
+          "409": {
+            "description": "The workspace is currently being mutated.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "Request failed. Internal server error.",
             "examples": {
@@ -5892,6 +6347,12 @@
                 }
               },
               "type": "object"
+            }
+          },
+          "503": {
+            "description": "Workspace mutation serialization is unavailable.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
             }
           }
         },

--- a/reana_server/config.py
+++ b/reana_server/config.py
@@ -18,11 +18,16 @@ from typing import Optional
 from urllib.parse import quote as _urlquote
 
 from distutils.util import strtobool
+from flask import request
 from limits.util import parse
 from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
+from invenio_app.limiter import set_rate_limit
 from invenio_oauthclient.contrib import cern_openid, eosc_aai
 from invenio_oauthclient.contrib.keycloak import KeycloakSettingsHelper
-from reana_commons.config import REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES
+from reana_commons.config import (
+    REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES,
+    WORKFLOW_SPECIFICATION_BUNDLES_CAPABILITY,
+)
 from reana_commons.job_utils import kubernetes_memory_to_bytes
 
 # This database URI import is necessary for Invenio-DB
@@ -42,6 +47,59 @@ def compose_reana_url(hostname: str, hostport: str | int) -> str:
 ADMIN_USER_ID = "00000000-0000-0000-0000-000000000000"
 
 SHARED_VOLUME_PATH = os.getenv("SHARED_VOLUME_PATH", "/var/reana")
+
+REANA_API_CAPABILITIES = [WORKFLOW_SPECIFICATION_BUNDLES_CAPABILITY]
+"""Protocol capabilities advertised by the unauthenticated ``/api/ping``.
+
+Capabilities, not version comparisons, decide whether a client operation is
+supported. The list is additive: new protocols append a new string and released
+clients keep ignoring the field."""
+
+REANA_SPEC_BUNDLE_MAX_FILES = int(os.getenv("REANA_SPEC_BUNDLE_MAX_FILES", "1000"))
+"""Maximum number of files accepted in an uploaded specification bundle.
+
+Bounds the staging of an untrusted multipart upload so a client cannot exhaust
+the shared volume with a huge bundle."""
+
+REANA_SPEC_BUNDLE_MAX_BYTES = int(
+    os.getenv("REANA_SPEC_BUNDLE_MAX_BYTES", str(100 * 1024 * 1024))
+)
+"""Maximum cumulative extracted file bytes in a specification bundle."""
+
+REANA_SPEC_BUNDLE_MAX_PATH_BYTES = int(
+    os.getenv("REANA_SPEC_BUNDLE_MAX_PATH_BYTES", "4096")
+)
+"""Maximum UTF-8 byte length of one specification-bundle member path."""
+
+REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES = int(
+    os.getenv(
+        "REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES",
+        str(
+            REANA_SPEC_BUNDLE_MAX_BYTES
+            + REANA_SPEC_BUNDLE_MAX_FILES * (2 * REANA_SPEC_BUNDLE_MAX_PATH_BYTES + 128)
+            + 64 * 1024
+        ),
+    )
+)
+"""Maximum multipart request bytes for a specification bundle.
+
+This is deliberately larger than the extracted-content limit: an uncompressed
+ZIP stores every member name in both its local and central-directory records,
+and multipart framing adds a small fixed overhead. Member-count and path-length
+limits keep this allowance bounded.
+"""
+
+REANA_SPEC_VALIDATION_TIMEOUT = int(os.getenv("REANA_SPEC_VALIDATION_TIMEOUT", "60"))
+"""Wall-clock budget (seconds) used to size the server's read timeout for a
+sandboxed spec validation call.
+
+Read from the same ``REANA_SPEC_VALIDATION_TIMEOUT`` environment variable as
+reana-workflow-controller, which owns the actual sandbox Job
+``activeDeadlineSeconds``; the default matches the controller's so the two agree
+when the variable is unset. This value is *not* the deadline itself -- the
+server derives a longer read timeout from it (``+120s``, above the controller's
+``timeout + 60`` wait) so it never gives up before the controller's sandbox
+deadline elapses."""
 
 REANA_HOSTNAME = os.getenv("REANA_HOSTNAME", "localhost")
 REANA_HOSTPORT = os.getenv("REANA_HOSTPORT", "30443")
@@ -424,8 +482,31 @@ REANA_RATELIMIT_SLOWEST = _get_rate_limit("REANA_RATELIMIT_SLOWEST", "5 per hour
 
 RATELIMIT_PER_ENDPOINT = {
     "launch.launch": REANA_RATELIMIT_SLOW,
+    # Both endpoints can spawn a sandboxed validation Job per call (for
+    # non-serial specs), so throttle them like ``launch`` to bound the rate at
+    # which an authenticated user can drive validator Jobs against the cluster.
+    "workflows.validate_workflow_specification": REANA_RATELIMIT_SLOW,
+    "workflows.create_workflow": REANA_RATELIMIT_SLOW,
+    "workflows.start_workflow": REANA_RATELIMIT_SLOW,
+    # A restart re-loads and re-validates the workspace, which can spawn a
+    # sandboxed validation Job for non-serial specs, so throttle it like start.
+    "workflows.restart_workflow": REANA_RATELIMIT_SLOW,
     "users.request_token": REANA_RATELIMIT_SLOWEST,
 }
+
+
+def set_reana_rate_limit():
+    """Return a slow limit only for the expensive PUT status=start branch."""
+    if (
+        request.endpoint == "workflows.set_workflow_status"
+        and request.args.get("status") == "start"
+    ):
+        return REANA_RATELIMIT_SLOW
+    return set_rate_limit()
+
+
+RATELIMIT_APPLICATION = set_reana_rate_limit
+"""Global rate selector with conditional protection for workflow starts."""
 
 # Invenio-accounts rate limits — only effective in deployments where local
 # accounts are allowed (i.e. ``REANA_SSO_ENABLED`` is false). Setting them
@@ -576,8 +657,26 @@ WORKFLOW_SPEC_EXTENSIONS = [".yaml", ".yml"]
 REGEX_CHARS_TO_REPLACE = re.compile("[^a-zA-Z0-9_]+")
 """Regex matching groups of characters that need to be replaced in workflow names."""
 
-FETCHER_MAXIMUM_FILE_SIZE = 1024**3  # 1 GB
+FETCHER_MAXIMUM_FILE_SIZE = int(
+    os.getenv("REANA_FETCHER_MAXIMUM_FILE_SIZE", str(1024**3))
+)
 """Maximum file size allowed when fetching workflow specifications."""
+
+FETCHER_MAXIMUM_EXTRACTED_SIZE = int(
+    os.getenv("REANA_FETCHER_MAXIMUM_EXTRACTED_SIZE", str(1024**3))
+)
+"""Maximum cumulative regular-file bytes extracted from a remote archive."""
+
+FETCHER_MAXIMUM_FILES = int(os.getenv("REANA_FETCHER_MAXIMUM_FILES", "10000"))
+"""Maximum number of regular files accepted from a remote source snapshot."""
+
+FETCHER_MAXIMUM_CLONE_SIZE = int(
+    os.getenv(
+        "REANA_FETCHER_MAXIMUM_CLONE_SIZE",
+        str(FETCHER_MAXIMUM_FILE_SIZE + FETCHER_MAXIMUM_EXTRACTED_SIZE),
+    )
+)
+"""Maximum temporary bytes used by the generic Git fallback clone."""
 
 FETCHER_ALLOWED_SCHEMES = ["https", "http"]
 """Schemes allowed when fetching workflow specifications."""
@@ -585,18 +684,18 @@ FETCHER_ALLOWED_SCHEMES = ["https", "http"]
 FETCHER_REQUEST_TIMEOUT = 60
 """Timeout used when fetching workflow specifications."""
 
+RWC_MUTATION_CONNECT_TIMEOUT = float(
+    os.getenv("REANA_RWC_MUTATION_CONNECT_TIMEOUT", "10")
+)
+"""Connection timeout for controller calls made under workspace locks."""
+
+RWC_MUTATION_READ_TIMEOUT = float(os.getenv("REANA_RWC_MUTATION_READ_TIMEOUT", "300"))
+"""Read timeout for controller calls made under workspace locks."""
+
 FETCHER_ALLOWED_GITLAB_HOSTNAMES = {"gitlab.com", "gitlab.cern.ch"}
 if REANA_GITLAB_HOST:
     FETCHER_ALLOWED_GITLAB_HOSTNAMES.add(REANA_GITLAB_HOST)
 """GitLab instances allowed when fetching workflow specifications."""
-
-LAUNCHER_ALLOWED_SNAKEMAKE_URLS = [
-    "https://github.com/reanahub/reana-demo-cms-h4l",
-    "https://github.com/reanahub/reana-demo-helloworld",
-    "https://github.com/reanahub/reana-demo-root6-roofit",
-    "https://github.com/reanahub/reana-demo-worldpopulation",
-]
-"""Allowed URLs when launching a Snakemake workflow."""
 
 # Workspace retention rules
 # ==================

--- a/reana_server/ext.py
+++ b/reana_server/ext.py
@@ -42,22 +42,66 @@ def handle_rate_limit_error(error: RateLimitExceeded):
     return jsonify({"message": error_message}), 429
 
 
+ARGUMENT_LOCATIONS = frozenset(
+    {
+        "cookies",
+        "files",
+        "form",
+        "headers",
+        "json",
+        "json_or_form",
+        "match_info",
+        "path",
+        "query",
+        "querystring",
+        "view_args",
+    }
+)
+"""Request locations webargs namespaces its validation messages under."""
+
+
+def _flatten_validation_messages(messages, path=()):
+    """Yield ``(field path, messages)`` leaves of a marshmallow error tree."""
+    if isinstance(messages, dict):
+        for key, value in messages.items():
+            yield from _flatten_validation_messages(value, path + (str(key),))
+    elif isinstance(messages, (list, tuple)):
+        yield path, [str(message) for message in messages]
+    else:
+        yield path, [str(messages)]
+
+
 def handle_args_validation_error(error: UnprocessableEntity):
     """Error handler for werkzeug exception ``UnprocessableEntity``.
 
     This error handler is needed to display useful error messages, instead of the
     generic default one, when marshmallow argument validation fails.
+
+    ``normalized_messages()`` nests the field errors under the request location
+    webargs parsed (and once more per nested schema or collection), so the tree
+    is flattened to leaves. Joining its top-level values directly would render
+    the nested dictionary's *keys* and drop every actual complaint.
+
+    Note that ``/api`` requests are served by Invenio's separate API
+    application, where ``invenio_rest.views.api_errorhandler`` owns 422; this
+    handler therefore only shapes argument errors raised outside that
+    application.
     """
     error_message = error.description or str(error)
 
     exception = getattr(error, "exc", None)
     if isinstance(exception, ValidationError):
         validation_messages = []
-        for field, messages in exception.normalized_messages().items():
+        for path, messages in _flatten_validation_messages(
+            exception.normalized_messages()
+        ):
+            if len(path) > 1 and path[0] in ARGUMENT_LOCATIONS:
+                path = path[1:]
             validation_messages.append(
-                "Field '{}': {}".format(field, ", ".join(messages))
+                "Field '{}': {}".format(".".join(path), ", ".join(messages))
             )
-        error_message = ". ".join(validation_messages)
+        if validation_messages:
+            error_message = ". ".join(validation_messages)
 
     return jsonify({"message": error_message}), 400
 

--- a/reana_server/fetcher.py
+++ b/reana_server/fetcher.py
@@ -10,26 +10,42 @@
 
 from abc import ABC, abstractmethod
 import os
+import posixpath
+import resource
 import shutil
+import stat
+import subprocess
+import time
 from typing import Any, List, Mapping, Optional, Sequence
-from urllib.parse import urlparse
+from urllib.parse import quote, quote_plus, urlparse
 import zipfile
 
-from git import Repo
 import requests
 from requests.exceptions import HTTPError, Timeout, RequestException
 import werkzeug.exceptions
 import werkzeug.routing
 
+from reana_commons.specification_paths import (
+    SPECIFICATION_BUNDLE_MAX_DEPTH,
+    SPECIFICATION_BUNDLE_MAX_PATH_BYTES,
+)
+
 from reana_server.config import (
     FETCHER_ALLOWED_GITLAB_HOSTNAMES,
     FETCHER_ALLOWED_SCHEMES,
+    FETCHER_MAXIMUM_CLONE_SIZE,
+    FETCHER_MAXIMUM_EXTRACTED_SIZE,
     FETCHER_MAXIMUM_FILE_SIZE,
+    FETCHER_MAXIMUM_FILES,
     FETCHER_REQUEST_TIMEOUT,
     REGEX_CHARS_TO_REPLACE,
     WORKFLOW_SPEC_EXTENSIONS,
     WORKFLOW_SPEC_FILENAMES,
 )
+from reana_server.specification_bundles import preflight_zip_metadata
+
+_GIT_CLONE_POLL_INTERVAL = 0.5
+_FETCHER_MAXIMUM_DIRECTORIES = FETCHER_MAXIMUM_FILES * 2 + 1024
 
 
 class REANAFetcherError(Exception):
@@ -232,30 +248,176 @@ class WorkflowFetcherGit(WorkflowFetcherBase):
 
     def fetch(self) -> None:
         """Fetch workflow specification from a Git repository."""
-        try:
-            repository = Repo.clone_from(
-                self._parsed_url.original_url,
-                self._output_dir,
-                depth=1,
-                no_single_branch=True,
-                env={"GIT_TERMINAL_PROMPT": "0"},
-            )
-        except Exception:
+        clone_command = [
+            "git",
+            "clone",
+            "--depth=1",
+            "--no-single-branch",
+            self._parsed_url.original_url,
+            self._output_dir,
+        ]
+        if not self._run_bounded_git(clone_command):
             raise REANAFetcherError(
                 "Cannot clone the given Git repository. Please check that the provided "
                 "URL is correct and that the repository is publicly accessible."
             )
 
         if self._git_ref:
-            try:
-                repository.remote().fetch(self._git_ref, depth=1)
-                repository.git.checkout(self._git_ref)
-            except Exception:
+            fetch_command = [
+                "git",
+                "-C",
+                self._output_dir,
+                "fetch",
+                "--depth=1",
+                "origin",
+                self._git_ref,
+            ]
+            checkout_command = [
+                "git",
+                "-C",
+                self._output_dir,
+                "checkout",
+                "--detach",
+                "FETCH_HEAD",
+            ]
+            if not self._run_bounded_git(fetch_command) or not self._run_bounded_git(
+                checkout_command
+            ):
                 raise REANAFetcherError(
                     f'Cannot checkout the given Git reference "{self._git_ref}"'
                 )
 
         shutil.rmtree(os.path.join(self._output_dir, ".git"))
+        file_count = 0
+        total_size = 0
+        for root, directories, files in os.walk(
+            self._output_dir, topdown=True, followlinks=False
+        ):
+            for directory in directories:
+                path = os.path.join(root, directory)
+                if os.path.islink(path):
+                    raise REANAFetcherError(
+                        "Remote source repositories may not contain symbolic links"
+                    )
+            for filename in files:
+                path = os.path.join(root, filename)
+                mode = os.lstat(path).st_mode
+                if not stat.S_ISREG(mode):
+                    raise REANAFetcherError(
+                        "Remote source repositories may contain only regular files"
+                    )
+                file_count += 1
+                total_size += os.lstat(path).st_size
+                if file_count > FETCHER_MAXIMUM_FILES:
+                    raise REANAFetcherError("Remote source contains too many files")
+                if total_size > FETCHER_MAXIMUM_EXTRACTED_SIZE:
+                    raise REANAFetcherError("Remote source extracted size exceeded")
+
+    def _run_bounded_git(self, command: Sequence[str]) -> bool:
+        """Run Git while bounding its temporary clone tree."""
+        environment = dict(os.environ)
+        environment["GIT_TERMINAL_PROMPT"] = "0"
+
+        def kill_and_reap(process) -> None:
+            if process.poll() is None:
+                process.kill()
+            process.wait()
+
+        try:
+            process = subprocess.Popen(
+                command,
+                env=environment,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            resource.prlimit(
+                process.pid,
+                resource.RLIMIT_FSIZE,
+                (FETCHER_MAXIMUM_CLONE_SIZE, FETCHER_MAXIMUM_CLONE_SIZE),
+            )
+        except (OSError, ValueError):
+            if "process" in locals():
+                kill_and_reap(process)
+            return False
+
+        clone_file_limit = FETCHER_MAXIMUM_FILES * 2 + 1024
+        deadline = time.monotonic() + FETCHER_REQUEST_TIMEOUT
+        try:
+            while process.poll() is None:
+                if self._clone_tree_exceeds_limits(clone_file_limit, strict=False):
+                    raise REANAFetcherError(
+                        "Remote Git clone exceeded its temporary storage limit"
+                    )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise REANAFetcherError("Remote Git clone timed out")
+                try:
+                    process.wait(timeout=min(_GIT_CLONE_POLL_INTERVAL, remaining))
+                except subprocess.TimeoutExpired:
+                    pass
+        except Exception:
+            kill_and_reap(process)
+            raise
+        # A fast clone can finish between polling intervals. Check its final
+        # on-disk state before the caller removes the temporary ``.git`` tree.
+        if self._clone_tree_exceeds_limits(clone_file_limit, strict=True):
+            raise REANAFetcherError(
+                "Remote Git clone exceeded its temporary storage limit"
+            )
+        return process.returncode == 0
+
+    def _clone_tree_exceeds_limits(self, file_limit: int, strict: bool) -> bool:
+        """Return whether the current temporary Git tree exceeds its bounds."""
+        file_count = 0
+        directory_count = 0
+        total_size = 0
+        pending = [(self._output_dir, "")]
+        while pending:
+            root, relative_root = pending.pop()
+            try:
+                entries = os.scandir(root)
+            except OSError as error:
+                if strict:
+                    raise REANAFetcherError(
+                        "Could not inspect the completed remote Git clone"
+                    ) from error
+                continue
+            with entries:
+                for entry in entries:
+                    relative_path = posixpath.join(relative_root, entry.name)
+                    if (
+                        len(relative_path.encode("utf-8"))
+                        > SPECIFICATION_BUNDLE_MAX_PATH_BYTES
+                        or len(relative_path.split("/"))
+                        > SPECIFICATION_BUNDLE_MAX_DEPTH
+                    ):
+                        return True
+                    try:
+                        metadata = os.lstat(entry.path)
+                    except OSError as error:
+                        if strict:
+                            raise REANAFetcherError(
+                                "Could not inspect the completed remote Git clone"
+                            ) from error
+                        continue
+                    if stat.S_ISDIR(metadata.st_mode):
+                        directory_count += 1
+                        if directory_count > _FETCHER_MAXIMUM_DIRECTORIES:
+                            return True
+                        pending.append((entry.path, relative_path))
+                        continue
+                    if not stat.S_ISREG(metadata.st_mode):
+                        if strict:
+                            return True
+                        continue
+                    file_count += 1
+                    total_size += metadata.st_size
+                    if (
+                        file_count > file_limit
+                        or total_size > FETCHER_MAXIMUM_CLONE_SIZE
+                    ):
+                        return True
+        return False
 
     def generate_workflow_name(self) -> str:
         """Generate a workflow name from the given repository URL.
@@ -338,13 +500,146 @@ class WorkflowFetcherZip(WorkflowFetcherBase):
         """Fetch workflow specification from a zip archive."""
         archive_path = os.path.join(self._output_dir, self._archive_name)
         self._download_file(self._parsed_url.original_url, archive_path)
-        try:
-            with zipfile.ZipFile(archive_path, "r") as zip_file:
-                zip_file.extractall(path=self._output_dir)
-        except zipfile.BadZipfile:
-            raise REANAFetcherError("The provided zip file is not valid")
+        self.extract_archive(archive_path)
 
-        os.remove(archive_path)
+    @staticmethod
+    def _validate_archive_entries(entries) -> None:
+        """Validate remote ZIP metadata before creating any output files."""
+        if len(entries) > FETCHER_MAXIMUM_FILES:
+            raise REANAFetcherError(
+                "Remote source contains too many archive entries "
+                f"(maximum is {FETCHER_MAXIMUM_FILES})"
+            )
+        declared_size = 0
+        names = set()
+        file_names = set()
+        directories = set()
+        for entry in entries:
+            name = entry.filename
+            normalized = posixpath.normpath(name)
+            if (
+                not name
+                or "\x00" in name
+                or "\\" in name
+                or name.startswith("/")
+                or (len(name) >= 2 and name[1] == ":")
+                or normalized in (".", "..")
+                or normalized != name.rstrip("/")
+                or any(part in ("", ".", "..") for part in normalized.split("/"))
+            ):
+                raise REANAFetcherError(
+                    f"Remote source contains an unsafe path: {name}"
+                )
+            components = normalized.split("/")
+            if (
+                len(name.encode("utf-8")) > SPECIFICATION_BUNDLE_MAX_PATH_BYTES
+                or len(components) > SPECIFICATION_BUNDLE_MAX_DEPTH
+            ):
+                raise REANAFetcherError(
+                    f"Remote source path exceeds its metadata limits: {name}"
+                )
+            for index in range(1, len(components)):
+                directories.add("/".join(components[:index]))
+                if len(directories) > _FETCHER_MAXIMUM_DIRECTORIES:
+                    raise REANAFetcherError(
+                        "Remote source contains too many directories"
+                    )
+            if normalized in names:
+                raise REANAFetcherError(
+                    f"Remote source contains a duplicate path: {normalized}"
+                )
+            names.add(normalized)
+            mode = (entry.external_attr >> 16) & 0xFFFF
+            file_type = stat.S_IFMT(mode)
+            if entry.is_dir():
+                if file_type not in (0, stat.S_IFDIR):
+                    raise REANAFetcherError(
+                        f"Remote source contains a non-directory entry: {name}"
+                    )
+                continue
+            if entry.flag_bits & 0x1:
+                raise REANAFetcherError(
+                    "Encrypted remote source archives are not supported"
+                )
+            if file_type not in (0, stat.S_IFREG):
+                raise REANAFetcherError(
+                    f"Remote source contains a non-regular file: {name}"
+                )
+            file_names.add(normalized)
+            declared_size += entry.file_size
+            if declared_size > FETCHER_MAXIMUM_EXTRACTED_SIZE:
+                raise REANAFetcherError("Remote source extracted size exceeded")
+        for name in names:
+            components = name.split("/")
+            for index in range(1, len(components)):
+                parent = "/".join(components[:index])
+                if parent in file_names:
+                    raise REANAFetcherError(
+                        f"Remote source path is nested below a regular file: {parent}"
+                    )
+
+    def _extract_archive_entries(self, zip_file, entries) -> None:
+        """Extract validated remote ZIP members using exclusive regular files."""
+        extracted_size = 0
+        for entry in entries:
+            destination = os.path.join(
+                self._output_dir, *entry.filename.rstrip("/").split("/")
+            )
+            try:
+                if entry.is_dir():
+                    os.makedirs(destination, mode=0o700, exist_ok=True)
+                    continue
+                os.makedirs(os.path.dirname(destination), mode=0o700, exist_ok=True)
+                flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                if hasattr(os, "O_NOFOLLOW"):
+                    flags |= os.O_NOFOLLOW
+                descriptor = os.open(destination, flags, 0o600)
+                with zip_file.open(entry, "r") as source, os.fdopen(
+                    descriptor, "wb"
+                ) as output:
+                    while True:
+                        chunk = source.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        extracted_size += len(chunk)
+                        if extracted_size > FETCHER_MAXIMUM_EXTRACTED_SIZE:
+                            raise REANAFetcherError(
+                                "Remote source extracted size exceeded"
+                            )
+                        output.write(chunk)
+            except REANAFetcherError:
+                if not entry.is_dir():
+                    try:
+                        os.unlink(destination)
+                    except OSError:
+                        pass
+                raise
+            except (OSError, EOFError, RuntimeError, zipfile.BadZipFile) as exc:
+                if not entry.is_dir():
+                    try:
+                        os.unlink(destination)
+                    except OSError:
+                        pass
+                raise REANAFetcherError(
+                    f"Could not extract remote source entry {entry.filename}: {exc}"
+                )
+
+    def extract_archive(self, archive_path: str) -> None:
+        """Safely extract an already downloaded archive into the output tree."""
+        try:
+            with open(archive_path, "rb") as archive_stream:
+                preflight_zip_metadata(archive_stream, FETCHER_MAXIMUM_FILES)
+                with zipfile.ZipFile(archive_stream, "r") as zip_file:
+                    entries = zip_file.infolist()
+                    self._validate_archive_entries(entries)
+                    self._extract_archive_entries(zip_file, entries)
+        except (OSError, ValueError, zipfile.BadZipFile) as exc:
+            raise REANAFetcherError(f"The provided zip file is not valid: {exc}")
+        finally:
+            try:
+                os.remove(archive_path)
+            except OSError:
+                pass
 
         if not self._discover_workflow_specs():
             top_level_entries = [
@@ -369,6 +664,43 @@ class WorkflowFetcherZip(WorkflowFetcherBase):
         :returns: Generated workflow name.
         """
         return self._workflow_name
+
+
+def extract_streamed_zip_response(
+    response,
+    output_dir: str,
+    spec: Optional[str] = None,
+    workflow_name: str = "workflow",
+) -> WorkflowFetcherZip:
+    """Bound and safely extract a streamed provider ZIP response."""
+    archive_path = os.path.join(output_dir, ".reana-source-archive.zip")
+    downloaded = 0
+    try:
+        with open(archive_path, "xb") as archive:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if not chunk:
+                    continue
+                downloaded += len(chunk)
+                if downloaded > FETCHER_MAXIMUM_FILE_SIZE:
+                    raise REANAFetcherError("Maximum file size exceeded")
+                archive.write(chunk)
+        fetcher = WorkflowFetcherZip(
+            ParsedUrl("https://invalid.example/source.zip"),
+            output_dir,
+            spec=spec,
+            workflow_name=workflow_name,
+        )
+        fetcher.extract_archive(archive_path)
+        return fetcher
+    finally:
+        try:
+            response.close()
+        except Exception:
+            pass
+        try:
+            os.remove(archive_path)
+        except OSError:
+            pass
 
 
 def _match_url(parsed_url: ParsedUrl, rules: Sequence[str]) -> Mapping[str, Any]:
@@ -426,8 +758,12 @@ def _get_github_fetcher(
         workflow_name = f"{repository}-{git_ref}"
         return WorkflowFetcherZip(parsed_url, output_dir, spec, workflow_name)
     else:
-        repository_url = ParsedUrl(f"https://github.com/{username}/{repository}.git")
-        return WorkflowFetcherGit(repository_url, output_dir, git_ref, spec)
+        archive_ref = quote(git_ref or "HEAD", safe="/")
+        archive_url = ParsedUrl(
+            f"https://github.com/{username}/{repository}/archive/{archive_ref}.zip"
+        )
+        workflow_name = repository if not git_ref else f"{repository}-{git_ref}"
+        return WorkflowFetcherZip(archive_url, output_dir, spec, workflow_name)
 
 
 def _get_gitlab_fetcher(
@@ -467,10 +803,14 @@ def _get_gitlab_fetcher(
         workflow_name = parsed_url.basename_without_extension
         return WorkflowFetcherZip(parsed_url, output_dir, spec, workflow_name)
     else:
-        repository_url = ParsedUrl(
-            f"https://{parsed_url.hostname}/{username}/{repository}.git"
+        project = quote_plus(f"{username}/{repository}")
+        archive_ref = quote(git_ref or "HEAD", safe="")
+        archive_url = ParsedUrl(
+            f"https://{parsed_url.hostname}/api/v4/projects/{project}/"
+            f"repository/archive.zip?sha={archive_ref}"
         )
-        return WorkflowFetcherGit(repository_url, output_dir, git_ref, spec)
+        workflow_name = repository if not git_ref else f"{repository}-{git_ref}"
+        return WorkflowFetcherZip(archive_url, output_dir, spec, workflow_name)
 
 
 def get_fetcher(

--- a/reana_server/gitlab_client.py
+++ b/reana_server/gitlab_client.py
@@ -12,7 +12,7 @@ import yaml
 
 from reana_commons.k8s.secrets import UserSecretsStore
 
-from reana_server.config import REANA_GITLAB_HOST
+from reana_server.config import FETCHER_REQUEST_TIMEOUT, REANA_GITLAB_HOST
 
 
 class GitLabClientException(Exception):
@@ -91,8 +91,12 @@ class GitLabClient:
         quoted = {k: quote_plus(v) for k, v in kwargs.items()}
         return f"https://{self.host}/api/v4/{path.lstrip('/').format(**quoted)}"
 
-    def _request(self, verb: str, url: str, params=None, data=None):
-        res = self._http_request(verb, url, params=params, data=data)
+    def _request(self, verb: str, url: str, params=None, data=None, stream=False):
+        request_kwargs = {"params": params, "data": data}
+        if stream:
+            request_kwargs["stream"] = True
+            request_kwargs["timeout"] = FETCHER_REQUEST_TIMEOUT
+        res = self._http_request(verb, url, **request_kwargs)
         if res.status_code == 401:
             raise GitLabClientInvalidToken
         elif res.status_code >= 400:
@@ -156,6 +160,16 @@ class GitLabClient:
             "ref": ref,
         }
         return self._get(url, params)
+
+    def get_repository_archive(
+        self, project: Union[int, str], ref: str
+    ) -> requests.Response:
+        """Stream a ZIP snapshot for one exact repository reference."""
+        url = self._make_url(
+            "projects/{project}/repository/archive.zip", project=str(project)
+        )
+        params = {"access_token": self.access_token, "sha": ref}
+        return self._request("GET", url, params=params, stream=True)
 
     def get_projects(self, page: int = 1, per_page: Optional[int] = None, **kwargs):
         """Get a list of projects the user has access to.

--- a/reana_server/reana_admin/cli.py
+++ b/reana_server/reana_admin/cli.py
@@ -43,7 +43,6 @@ from reana_db.models import (
     WorkspaceRetentionRule,
     WorkspaceRetentionRuleStatus,
 )
-from reana_db.utils import update_workspace_retention_rules
 
 from reana_server.api_client import current_rwc_api_client
 from reana_server.config import ADMIN_USER_ID, REANA_HOSTNAME
@@ -55,6 +54,11 @@ from reana_server.reana_admin.options import (
 )
 from reana_server.reana_admin.retention_rule_deleter import RetentionRuleDeleter
 from reana_server.status import STATUS_OBJECT_TYPES
+from reana_server.workspace_mutations import (
+    WorkspaceMutationConflict,
+    WorkspaceMutationUnavailable,
+    workspace_mutation_lock,
+)
 from reana_server.utils import (
     _get_admin_user_or_raise,
     _create_user,
@@ -790,7 +794,7 @@ def queue_consume(
 @add_user_options
 @add_workflow_option()
 @admin_access_token_option
-def retention_rules_apply(
+def retention_rules_apply(  # noqa: C901
     dry_run: bool,
     force_date: Optional[datetime.datetime],
     yes_i_am_sure: bool,
@@ -834,53 +838,95 @@ def retention_rules_apply(
             Workflow.owner_id == user.id_
         )
 
-    click.echo("Setting the status of all the rules that will be applied to `pending`")
     active_rules = candidate_rules.filter(
         WorkspaceRetentionRule.status == WorkspaceRetentionRuleStatus.active,
         WorkspaceRetentionRule.apply_on < current_time,
     )
-    if not dry_run:
-        update_workspace_retention_rules(
-            active_rules, WorkspaceRetentionRuleStatus.pending
-        )
-
     click.echo("Fetching all the pending rules")
     pending_rules = candidate_rules.filter(
         WorkspaceRetentionRule.status == WorkspaceRetentionRuleStatus.pending
     )
-    if not dry_run:
-        pending_rules = pending_rules.all()
-    else:
-        pending_rules = pending_rules.union(active_rules).all()
+    rules_to_apply = pending_rules.union(active_rules).all()
 
-    if not pending_rules:
+    if not rules_to_apply:
         click.echo("No rules to be applied!")
 
-    for rule in pending_rules:
-        if not Path(rule.workflow.workspace_path).exists():
-            # workspace was deleted, set rule as if it was already applied
+    rules_by_workspace = {}
+    for rule in rules_to_apply:
+        rules_by_workspace.setdefault(rule.workflow.workspace_path, []).append(rule.id_)
+
+    for workspace_path, rule_ids in rules_by_workspace.items():
+        try:
+            with workspace_mutation_lock(workspace_path):
+                # Refresh decisions while holding the same lock used by API
+                # workspace mutations. This closes the restart/delete
+                # check-then-act window and lets stale pending rules retry.
+                rules = (
+                    Session.query(WorkspaceRetentionRule)
+                    .filter(
+                        WorkspaceRetentionRule.id_.in_(rule_ids),
+                        (
+                            WorkspaceRetentionRule.status
+                            == WorkspaceRetentionRuleStatus.pending
+                        )
+                        | (
+                            (
+                                WorkspaceRetentionRule.status
+                                == WorkspaceRetentionRuleStatus.active
+                            )
+                            & (WorkspaceRetentionRule.apply_on < current_time)
+                        ),
+                    )
+                    .all()
+                )
+                if not dry_run:
+                    for rule in rules:
+                        if rule.status == WorkspaceRetentionRuleStatus.active:
+                            rule.status = WorkspaceRetentionRuleStatus.pending
+                    Session.commit()
+
+                for rule in rules:
+                    if not Path(workspace_path).exists():
+                        click.secho(
+                            f"Workspace {workspace_path} of rule {rule.id_} does not "
+                            "exist, setting the status to `applied`",
+                            fg="red",
+                        )
+                        if not dry_run:
+                            rule.status = WorkspaceRetentionRuleStatus.applied
+                        continue
+
+                    next_status = WorkspaceRetentionRuleStatus.active
+                    try:
+                        RetentionRuleDeleter(rule).apply_rule(dry_run)
+                        next_status = WorkspaceRetentionRuleStatus.applied
+                    except Exception as error:
+                        click.secho(
+                            f"Error while applying rule {rule.id_}: {error}", fg="red"
+                        )
+                        logging.debug(error, exc_info=True)
+                    if not dry_run:
+                        click.echo(
+                            f"Setting the status of rule {rule.id_} to "
+                            f"`{next_status.name}`"
+                        )
+                        rule.status = next_status
+                if not dry_run:
+                    Session.commit()
+        except WorkspaceMutationConflict:
+            Session.rollback()
+            click.echo(
+                f"Workspace {workspace_path} is currently being modified; "
+                "retention rules will be retried later."
+            )
+        except WorkspaceMutationUnavailable:
+            Session.rollback()
             click.secho(
-                f"Workspace {rule.workflow.workspace_path} of rule {rule.id_} does not exist, "
-                "setting the status to `applied`",
+                f"Could not serialize retention rules for workspace {workspace_path}; "
+                "they will be retried later.",
                 fg="red",
             )
-            update_workspace_retention_rules(
-                [rule], WorkspaceRetentionRuleStatus.applied
-            )
-            continue
-        # if there are errors, the status of the rule will be reset to `active`
-        # so that the rule will be applied again at the next execution of the cronjob
-        next_status = WorkspaceRetentionRuleStatus.active
-        try:
-            RetentionRuleDeleter(rule).apply_rule(dry_run)
-            next_status = WorkspaceRetentionRuleStatus.applied
-        except Exception as e:
-            click.secho(f"Error while applying rule {rule.id_}: {e}", fg="red")
-            logging.debug(e, exc_info=True)
-
-        if not dry_run:
-            click.echo(f"Setting the status of rule {rule.id_} to `{next_status.name}`")
-            update_workspace_retention_rules([rule], next_status)
+            logging.exception("Workspace mutation locking is unavailable.")
 
 
 @reana_admin.command()

--- a/reana_server/rest/launch.py
+++ b/reana_server/rest/launch.py
@@ -10,46 +10,87 @@ import json
 import logging
 import os
 import shutil
-import threading
 import traceback
+import uuid
 
-from bravado.exception import HTTPError
+from bravado.exception import BravadoTimeoutError, HTTPError
 from flask import Blueprint, jsonify
 from jsonschema import ValidationError
 import marshmallow
 from marshmallow import Schema
 from webargs import fields
 from webargs.flaskparser import use_kwargs
-import yaml
 
+from reana_commons.config import SHARED_VOLUME_PATH
 from reana_commons.errors import REANAValidationError, REANAQuotaExceededError
-from reana_commons.specification import load_reana_spec
 from reana_commons.validation.utils import validate_workflow_name
+from reana_db.database import Session
+from reana_db.models import RunStatus
 from reana_db.utils import (
     _get_workflow_with_uuid_or_name,
-    get_disk_usage_or_zero,
+    build_workspace_path,
     store_workflow_disk_quota,
     update_users_disk_quota,
 )
 
 from reana_server.api_client import current_rwc_api_client
-from reana_server.config import FETCHER_ALLOWED_SCHEMES, LAUNCHER_ALLOWED_SNAKEMAKE_URLS
+from reana_server.config import (
+    FETCHER_ALLOWED_SCHEMES,
+    RWC_MUTATION_CONNECT_TIMEOUT,
+    RWC_MUTATION_READ_TIMEOUT,
+)
 from reana_server.decorators import check_quota, signin_required
 from reana_server.fetcher import REANAFetcherError, get_fetcher
+from reana_server.specification_bundles import (
+    seed_workspace,
+    stage_validation_snapshot,
+    workspace_seed_members,
+)
 from reana_server.utils import (
     get_fetched_workflows_dir,
-    mv_workflow_files,
     prevent_disk_quota_excess,
     publish_workflow_submission,
-    filter_input_files,
     get_workspace_retention_rules,
 )
-from reana_server.validation import validate_workflow
+from reana_server.validation import (
+    SpecValidationServiceError,
+    load_and_validate_spec,
+    validate_input_parameters,
+)
+from reana_server.workspace_mutations import (
+    WorkspaceMutationConflict,
+    WorkspaceMutationUnavailable,
+    workflow_creation_mutation_lock,
+)
+from reana_server.workflow_creation import create_workflow_on_controller
 
 blueprint = Blueprint("launch", __name__)
 
-load_reana_spec_lock = threading.Lock()
-"""Lock used to make sure only one specification is loaded at a time."""
+
+def _resolve_created_workflow(response, expected_workflow_uuid, user_id):
+    """Resolve the reserved workflow and remove any controller-created orphan."""
+    returned_workflow_uuid = response.get("workflow_id")
+    if returned_workflow_uuid == expected_workflow_uuid:
+        return _get_workflow_with_uuid_or_name(expected_workflow_uuid, user_id)
+    if returned_workflow_uuid:
+        try:
+            unexpected_workflow = _get_workflow_with_uuid_or_name(
+                returned_workflow_uuid, user_id
+            )
+        except ValueError:
+            pass
+        else:
+            unexpected_workflow.status = RunStatus.deleted
+            Session.commit()
+            shutil.rmtree(unexpected_workflow.workspace_path, ignore_errors=True)
+    raise RuntimeError("Controller returned an unexpected workflow id.")
+
+
+def _compensate_failed_creation(workflow):
+    """Remove a controller-created workflow after an ambiguous failure."""
+    workflow.status = RunStatus.deleted
+    Session.commit()
+    shutil.rmtree(workflow.workspace_path, ignore_errors=True)
 
 
 @blueprint.route("/launch", methods=["POST"])
@@ -147,6 +188,23 @@ def launch(user, url, name="", parameters="{}", specification=None):
               {
                 "message": "Malformed request."
               }
+        429:
+          description: Request rate limit exceeded.
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+        409:
+          description: Another workflow-family mutation is in progress.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        503:
+          description: Workspace mutation or controller service is unavailable.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         500:
           description: >-
             Request failed. Internal server error.
@@ -161,6 +219,8 @@ def launch(user, url, name="", parameters="{}", specification=None):
                 "message": "Internal server error."
               }
     """
+    tmpdir = None
+    validation_directory = None
     try:
         user_id = str(user.id_)
         tmpdir = get_fetched_workflows_dir(user_id)
@@ -168,41 +228,34 @@ def launch(user, url, name="", parameters="{}", specification=None):
         # Fetch the workflow spec
         fetcher = get_fetcher(url, tmpdir, specification)
         fetcher.fetch()
+        specification_path = fetcher.workflow_spec_path()
 
         # Generate the workflow name
         workflow_name = name.replace(" ", "") or fetcher.generate_workflow_name()
         validate_workflow_name(workflow_name)
 
-        # Load and validate the workflow spec
-        spec_path = fetcher.workflow_spec_path()
-
-        # When launching a snakemake workflow, check if the url is allowed
-        # FIXME: This will not be needed when using a sandbox
-        with open(spec_path) as spec_fd:
-            reana_yaml = yaml.safe_load(spec_fd.read())
-            workflow_type = reana_yaml["workflow"]["type"]
-            if (
-                workflow_type == "snakemake"
-                and url not in LAUNCHER_ALLOWED_SNAKEMAKE_URLS
-            ):
-                raise ValidationError(
-                    "Unfortunately, it is not possible to launch generic Snakemake "
-                    "workflows at the moment. Please contact the REANA admins for "
-                    "more information."
-                )
-
-        # FIXME: locking will not be needed when the loading and validation of
-        # specifications will be done inside an external sandbox
-        with load_reana_spec_lock:
-            reana_yaml = load_reana_spec(spec_path, workspace_path=tmpdir)
+        # Load + validate the spec authoritatively. Loading runs in-process for
+        # serial workflows and inside the sandboxed validator Job for
+        # Snakemake/CWL/Yadage, so the API process never executes untrusted
+        # workflow code. This sandboxing is what makes it safe to launch generic
+        # Snakemake/CWL/Yadage workflows from any URL -- the untrusted spec
+        # loading is confined to the disposable validator Job, not the API
+        # server -- so no per-type URL allowlist is needed. Invalid specs are
+        # rejected here (fail early).
+        (
+            validation_directory,
+            _validation_relative_path,
+            _validation_bytes,
+            _legacy_parameters,
+        ) = stage_validation_snapshot(specification_path, SHARED_VOLUME_PATH)
+        reana_yaml, validation_warnings = load_and_validate_spec(validation_directory)
         input_parameters = json.loads(parameters)
-        validation_warnings = validate_workflow(reana_yaml, input_parameters)
+        original_parameters = reana_yaml.get("inputs", {}).get("parameters", {})
+        validate_input_parameters(input_parameters, original_parameters)
 
-        # Keep only files and directories listed as workflow's inputs
-        filter_input_files(tmpdir, reana_yaml)
-
-        # Check the user's disk quota
-        disk_usage = get_disk_usage_or_zero(tmpdir)
+        # Build the same declared workspace seed a local client would produce:
+        # workflow definition first, datasets/tests only after validation.
+        seed_members, disk_usage = workspace_seed_members(specification_path)
         prevent_disk_quota_excess(
             user, disk_usage, action=f"Launching the workflow {workflow_name}"
         )
@@ -212,28 +265,57 @@ def launch(user, url, name="", parameters="{}", specification=None):
         retention_rules = get_workspace_retention_rules(retention_days)
 
         # Create workflow
+        workflow_uuid = str(uuid.uuid4())
+        workspace_path = build_workspace_path(user_id, workflow_uuid)
         workflow_dict = {
             "reana_specification": reana_yaml,
             "workflow_name": workflow_name,
+            "workflow_id": workflow_uuid,
             "operational_options": {},
             "launcher_url": url,
             "retention_rules": retention_rules,
         }
-        response, http_response = current_rwc_api_client.api.create_workflow(
-            workflow=workflow_dict,
-            user=user_id,
-        ).result()
+        with workflow_creation_mutation_lock(user.id_, workflow_name, workspace_path):
+            response, http_response = create_workflow_on_controller(
+                lambda: current_rwc_api_client.api.create_workflow(
+                    workflow=workflow_dict,
+                    user=user_id,
+                    _request_options={
+                        "connect_timeout": RWC_MUTATION_CONNECT_TIMEOUT,
+                        "timeout": RWC_MUTATION_READ_TIMEOUT,
+                    },
+                ).result(),
+                workflow_uuid,
+                user.id_,
+                workspace_path,
+                _compensate_failed_creation,
+            )
 
-        workflow = _get_workflow_with_uuid_or_name(response["workflow_id"], user_id)
-        mv_workflow_files(tmpdir, workflow.workspace_path)
+            workflow = _resolve_created_workflow(response, workflow_uuid, user_id)
+            if os.path.abspath(workflow.workspace_path) != os.path.abspath(
+                workspace_path
+            ):
+                workflow.status = RunStatus.deleted
+                Session.commit()
+                shutil.rmtree(workflow.workspace_path, ignore_errors=True)
+                raise RuntimeError("Controller created an unexpected workspace path.")
+            try:
+                copied_bytes = seed_workspace(seed_members, workflow.workspace_path)
+                if copied_bytes != disk_usage:
+                    raise REANAValidationError(
+                        "The fetched workflow changed while its workspace was seeded."
+                    )
+            except Exception:
+                workflow.status = RunStatus.deleted
+                Session.commit()
+                shutil.rmtree(workflow.workspace_path, ignore_errors=True)
+                raise
 
-        # Update the workflows's and user's disk usage
-        store_workflow_disk_quota(workflow, bytes_to_sum=disk_usage)
-        update_users_disk_quota(user, bytes_to_sum=disk_usage)
+            store_workflow_disk_quota(workflow, bytes_to_sum=disk_usage)
+            update_users_disk_quota(user, bytes_to_sum=disk_usage)
 
-        # Start the workflow
-        parameters = {"input_parameters": input_parameters}
-        publish_workflow_submission(workflow, user.id_, parameters)
+            parameters = {"input_parameters": input_parameters}
+            publish_workflow_submission(workflow, user.id_, parameters)
         response_data = {
             "workflow_id": workflow.id_,
             "workflow_name": workflow.name,
@@ -248,6 +330,12 @@ def launch(user, url, name="", parameters="{}", specification=None):
     except HTTPError as e:
         logging.error(traceback.format_exc())
         return jsonify(e.response.json()), e.response.status_code
+    except BravadoTimeoutError:
+        return jsonify({"message": "Workflow controller request timed out."}), 503
+    except WorkspaceMutationConflict:
+        return jsonify({"message": "The workflow family is currently changing."}), 409
+    except WorkspaceMutationUnavailable:
+        return jsonify({"message": "Workspace mutation serialization failed."}), 503
     except json.JSONDecodeError:
         logging.error(traceback.format_exc())
         return (
@@ -265,6 +353,11 @@ def launch(user, url, name="", parameters="{}", specification=None):
     ) as e:
         logging.error(traceback.format_exc())
         return jsonify({"message": str(e)}), 400
+    except SpecValidationServiceError as e:
+        # The validation service could not run (not an invalid specification):
+        # surface it as a server-side error, not a "fetching" failure.
+        logging.error(traceback.format_exc())
+        return jsonify({"message": str(e)}), 500
     except Exception:
         logging.error(traceback.format_exc())
         return (
@@ -272,18 +365,14 @@ def launch(user, url, name="", parameters="{}", specification=None):
             500,
         )
     finally:
-        # FIXME: `load_reana_spec` is not thread-safe and it changes the cwd, so for the
-        # time being we can only delete the files inside the directory where the
-        # workflow is fetched.  Deleting the directory would result in a
-        # `FileNotFoundError` when calling `os.getcwd()`, due to the cwd not existing
-        # anymore.
-        #
-        # remove_fetched_workflows_dir(tmpdir)
-        for entry in os.scandir(tmpdir):
-            if entry.is_file() or entry.is_symlink():
-                os.remove(entry)
-            else:
-                shutil.rmtree(entry)
+        # Specification loading now happens in the sandboxed validator (or
+        # in-process for serial, which does not change the cwd), so the previous
+        # cwd/thread-safety limitation no longer applies and we can remove the
+        # whole fetch directory.
+        if validation_directory:
+            shutil.rmtree(validation_directory, ignore_errors=True)
+        if tmpdir:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 class LaunchSchema(Schema):
@@ -292,4 +381,4 @@ class LaunchSchema(Schema):
     workflow_id = fields.UUID()
     workflow_name = fields.Str()
     message = fields.Str()
-    validation_warnings = fields.Dict()
+    validation_warnings = fields.Raw()

--- a/reana_server/rest/ping.py
+++ b/reana_server/rest/ping.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,6 +9,9 @@
 """Reana-Server Ping-functionality Flask-Blueprint."""
 
 from flask import Blueprint, jsonify
+
+from reana_server import __version__
+from reana_server.config import REANA_API_CAPABILITIES
 
 blueprint = Blueprint("ping", __name__)
 
@@ -22,6 +25,13 @@ def ping():  # noqa
       operationId: ping
       description: >-
         Ping the server.
+
+
+        This endpoint is deliberately unauthenticated: it also carries the
+        protocol bootstrap signal that a client needs *before* it authenticates
+        or builds a request body. ``api_capabilities`` advertises the
+        client-facing protocols the server implements; a released server omits
+        the field, which identifies it as legacy.
       produces:
        - application/json
       responses:
@@ -35,10 +45,29 @@ def ping():  # noqa
                 type: string
               status:
                 type: string
+              reana_server_version:
+                type: string
+              api_capabilities:
+                description: >-
+                  Client-facing protocols implemented by this server. Absent on
+                  released servers that predate protocol negotiation.
+                type: array
+                items:
+                  type: string
           examples:
             application/json:
               message: OK
               status: 200
+              reana_server_version: 0.95.0a6
+              api_capabilities: ["workflow-specification-bundles-v1"]
     """
 
-    return jsonify(message="OK", status="200"), 200
+    return (
+        jsonify(
+            message="OK",
+            status="200",
+            reana_server_version=__version__,
+            api_capabilities=REANA_API_CAPABILITIES,
+        ),
+        200,
+    )

--- a/reana_server/rest/users.py
+++ b/reana_server/rest/users.py
@@ -362,6 +362,15 @@ def request_token(user):
               {
                 "message": "Token is not valid."
               }
+        429:
+          description: Request rate limit exceeded.
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
         500:
           description: >-
             Request failed. Internal server error.

--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -9,51 +9,120 @@
 """Reana-Server workflow-functionality Flask-Blueprint."""
 
 import json
+import functools
 import logging
 import os
+import shutil
 import traceback
+import tempfile
+import uuid
 
 import requests
-from bravado.exception import HTTPError
+from bravado.exception import BravadoTimeoutError, HTTPError
 from flask import Blueprint, Response, jsonify, request, stream_with_context
 from jsonschema.exceptions import ValidationError
+from werkzeug.exceptions import RequestEntityTooLarge
 from reana_commons import workspace
-from reana_commons.config import REANA_WORKFLOW_ENGINES
-from reana_commons.errors import REANAQuotaExceededError, REANAValidationError
-from reana_commons.specification import load_reana_spec
+from reana_commons.config import (
+    REANA_WORKFLOW_ENGINES,
+    SHARED_VOLUME_PATH,
+    WORKFLOW_RUNTIME_USER_GID,
+    WORKFLOW_RUNTIME_USER_UID,
+)
+from reana_commons.errors import (
+    REANAQuotaExceededError,
+    REANASpecificationPathError,
+    REANAValidationError,
+)
+from reana_commons.specification_paths import (
+    SPECIFICATION_BUNDLE_MAX_PATH_BYTES,
+    open_regular_file_beneath,
+)
+from reana_commons.validation.environments import iter_environment_tag_warnings
+from reana_commons.validation.images import iter_image_environments
+from reana_commons.validation.report import (
+    MAX_VALIDATION_REPORT_ENTRIES,
+    REPORT_TRUNCATED_CODE,
+)
 from reana_commons.validation.operational_options import validate_operational_options
-from reana_commons.validation.utils import validate_workflow_name
+from reana_commons.validation.utils import (
+    MAX_LOAD_ERROR_MESSAGE_CHARS,
+    bound_error_message,
+    validate_workflow_name,
+)
 from reana_db.database import Session
-from reana_db.models import InteractiveSessionType, RunStatus
-from reana_db.utils import _get_workflow_with_uuid_or_name
+from reana_db.models import (
+    InteractiveSessionType,
+    RunStatus,
+    ResourceType,
+    Workflow,
+    WorkflowResource,
+    WorkspaceRetentionRule,
+    WorkspaceRetentionRuleStatus,
+)
+from reana_db.utils import (
+    _get_workflow_with_uuid_or_name,
+    build_workspace_path,
+    get_disk_usage_or_zero,
+    get_default_quota_resource,
+    store_workflow_disk_quota,
+    update_users_disk_quota,
+)
 from reana_server.api_client import current_rwc_api_client
-from reana_server.config import REANA_HOSTNAME
+from reana_server.config import (
+    REANA_HOSTNAME,
+    REANA_SPEC_BUNDLE_MAX_BYTES,
+    REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES,
+    RWC_MUTATION_CONNECT_TIMEOUT,
+    RWC_MUTATION_READ_TIMEOUT,
+)
 from reana_server.decorators import check_quota, signin_required
 from reana_server.deleter import Deleter, InOrOut
 from reana_server.gitlab_client import (
+    GitLabClient,
     GitLabClientRequestError,
     GitLabClientInvalidToken,
+)
+from reana_server.fetcher import extract_streamed_zip_response
+from reana_server.specification_bundles import (
+    extract_uploaded_bundle,
+    seed_workspace,
+    stage_validation_snapshot,
+    workspace_seed_members,
 )
 from reana_server.utils import (
     RequestStreamWithLen,
     _fail_gitlab_commit_build_status,
     _get_reana_yaml_from_gitlab,
-    _load_and_save_yadage_spec,
     clone_workflow,
     ensure_dask_service,
+    get_fetched_workflows_dir,
     get_quota_excess_message,
     get_workspace_retention_rules,
     is_uuid_v4,
+    mv_workflow_files,
     prevent_disk_quota_excess,
     publish_workflow_submission,
 )
 from reana_server.validation import (
-    validate_images,
-    validate_inputs,
-    validate_workflow,
-    validate_workspace_path,
-    validate_dask_limits,
+    REANA_SPEC_FILENAMES,
+    SpecValidationServiceError,
+    has_reana_spec_file,
+    load_and_validate_spec,
+    load_raw_spec_mapping,
+    validate_input_parameters,
+    validate_loaded_spec,
+    validate_spec_bundle,
 )
+from reana_server.workspace_mutations import (
+    WorkspaceMutationConflict,
+    WorkspaceMutationUnavailable,
+    workflow_creation_mutation_lock,
+    workflow_family_mutation_lock,
+    workspace_mutation_lock,
+    workspace_mutation_locks,
+)
+from reana_server.workflow_creation import create_workflow_on_controller
 import marshmallow
 from webargs import fields, validate
 from webargs.flaskparser import use_kwargs
@@ -64,6 +133,512 @@ except ImportError:
     from urlparse import urlparse
 
 blueprint = Blueprint("workflows", __name__)
+
+# Maximum bytes a single multipart part may buffer in RAM before Werkzeug spills
+# it to a temporary file. Kept small so an untrusted bundle upload cannot pin a
+# large amount of server memory during multipart parsing.
+_BUNDLE_MAX_FORM_MEMORY_SIZE = 1024 * 1024
+
+_INTERNAL_ERROR_MESSAGE = "An internal server error occurred."
+_FILE_COPY_CHUNK_SIZE = 1024 * 1024
+
+
+_RWC_MUTATION_REQUEST_OPTIONS = {
+    "connect_timeout": RWC_MUTATION_CONNECT_TIMEOUT,
+    "timeout": RWC_MUTATION_READ_TIMEOUT,
+}
+# Backward-compatible private alias for focused server tests and extensions.
+_workspace_mutation_lock = workspace_mutation_lock
+
+
+def _legacy_specification_message(replacement_hint):
+    """Explain that a released client is talking the retired JSON protocol.
+
+    A released client serializes the workflow specification itself and sends it
+    as a JSON ``reana_specification`` member. The server no longer accepts a
+    client-serialized specification -- it loads and validates the raw
+    specification bundle authoritatively -- so the pairing cannot work and must
+    fail with an upgrade instruction rather than an unknown-field complaint.
+    """
+    return (
+        "This server no longer accepts a client-serialized 'reana_specification'. "
+        "{} Please upgrade REANA client to a version that uploads the workflow "
+        "specification bundle, or connect to an older REANA cluster.".format(
+            replacement_hint
+        )
+    )
+
+
+def _serialize_workspace_mutation(view):
+    """Run a workspace-mutating API view under the shared workspace lock."""
+
+    @functools.wraps(view)
+    def wrapped(workflow_id_or_name, *args, **kwargs):
+        user = kwargs["user"]
+        try:
+            try:
+                workflow = _get_workflow_with_uuid_or_name(
+                    workflow_id_or_name, str(user.id_)
+                )
+                lock_key = workflow.workspace_path
+            except ValueError:
+                # Preserve the existing proxy contract: the controller remains
+                # authoritative for unknown identifiers. Real server workflows
+                # resolve to their shared workspace and therefore also collide
+                # across UUID/name aliases and restart run numbers.
+                lock_key = "workflow-id-or-name:{}".format(workflow_id_or_name)
+            with _workspace_mutation_lock(lock_key):
+                return view(workflow_id_or_name, *args, **kwargs)
+        except WorkspaceMutationConflict:
+            return (
+                jsonify(
+                    {"message": "The workflow workspace is currently being modified."}
+                ),
+                409,
+            )
+        except WorkspaceMutationUnavailable:
+            return (
+                jsonify(
+                    _internal_error_response(
+                        "Workspace mutation serialization is unavailable."
+                    )
+                ),
+                503,
+            )
+
+    return wrapped
+
+
+def _internal_error_response(context):
+    """Return an opaque 500 response while retaining diagnostic details in logs."""
+    logging.exception(context)
+    return {"message": _INTERNAL_ERROR_MESSAGE}
+
+
+def _compensate_failed_workflow_create(workflow, user):
+    """Clean up a partially completed post-create workflow operation.
+
+    Each cleanup action converges on the desired final state and is therefore
+    safe to retry: the row is marked deleted, the workspace is absent, workflow
+    disk usage is recalculated as zero, and user disk usage is recalculated from
+    all workflow resources. Failures in one cleanup action do not prevent the
+    remaining actions from being attempted.
+    """
+    # The failed quota operation may have left the scoped session in a failed
+    # transaction. Start compensation from a clean transaction boundary.
+    Session.rollback()
+
+    try:
+        workflow.status = RunStatus.deleted
+        Session.commit()
+    except Exception:
+        Session.rollback()
+        logging.exception(
+            "Could not mark partially created workflow %s as deleted.", workflow.id_
+        )
+
+    shutil.rmtree(workflow.workspace_path, ignore_errors=True)
+
+    try:
+        store_workflow_disk_quota(
+            workflow, bytes_to_sum=None, override_policy_checks=True
+        )
+    except Exception:
+        Session.rollback()
+        logging.exception(
+            "Could not reset disk quota for partially created workflow %s.",
+            workflow.id_,
+        )
+
+    try:
+        update_users_disk_quota(user, override_policy_checks=True)
+    except Exception:
+        Session.rollback()
+        logging.exception(
+            "Could not recalculate disk quota for user %s after workflow %s "
+            "creation failed.",
+            user.id_,
+            workflow.id_,
+        )
+
+
+def _is_truthy_arg(value):
+    """Interpret a query-string flag (``?environments=true``) as a boolean."""
+    return str(value).lower() in ("1", "true", "yes", "on")
+
+
+def _add_bounded_environments(report, reana_specification):
+    """Add environments and tag warnings within the global report budget."""
+    errors = list(report.get("errors", []))
+    warnings = []
+    truncated = False
+    environments_truncated = False
+    overlong_environment_omitted = False
+    for warning in report.get("warnings", []):
+        if warning.get("code") == REPORT_TRUNCATED_CODE:
+            truncated = True
+        else:
+            warnings.append(warning)
+    original_warning_count = len(warnings)
+    environments = []
+
+    def append(target, entry):
+        nonlocal truncated
+        if len(errors) + len(warnings) + len(environments) >= (
+            MAX_VALIDATION_REPORT_ENTRIES
+        ):
+            truncated = True
+            return False
+        target.append(entry)
+        return True
+
+    image_names = []
+    for environment in iter_image_environments(
+        reana_specification,
+        int(WORKFLOW_RUNTIME_USER_UID),
+        int(WORKFLOW_RUNTIME_USER_GID),
+    ):
+        environment = dict(environment)
+        if len(environment["image"]) > MAX_LOAD_ERROR_MESSAGE_CHARS:
+            truncated = True
+            environments_truncated = True
+            overlong_environment_omitted = True
+            continue
+        if not append(environments, environment):
+            environments_truncated = True
+            break
+        image_names.append(environment["image"])
+
+    if overlong_environment_omitted:
+        append(
+            warnings,
+            {
+                "code": "environment_identity_omitted",
+                "message": (
+                    "A runtime environment identity was omitted because its "
+                    "image reference is too long."
+                ),
+                "path": "",
+            },
+        )
+
+    for finding in iter_environment_tag_warnings(image_names):
+        warning = {
+            "code": bound_error_message(finding["code"]),
+            "message": bound_error_message(finding["message"]),
+            "path": bound_error_message(finding["image"]),
+        }
+        if not append(warnings, warning):
+            break
+
+    if truncated:
+        while (
+            len(errors) + len(warnings) + len(environments)
+            >= MAX_VALIDATION_REPORT_ENTRIES
+        ):
+            if len(warnings) > original_warning_count:
+                warnings.pop()
+            elif environments:
+                environments.pop()
+                environments_truncated = True
+            elif warnings:
+                warnings.pop()
+            else:
+                # Only pre-existing errors remain. Never drop a real validation
+                # error to make room for the marker: each error message is
+                # already bounded, so one extra marker entry cannot blow the
+                # response-size budget the entry count only approximates.
+                break
+        warnings.append(
+            {
+                "code": REPORT_TRUNCATED_CODE,
+                "message": "Additional validation findings were omitted.",
+                "path": "",
+            }
+        )
+    report["errors"] = errors
+    report["warnings"] = warnings
+    report["environments"] = environments
+    report["environments_truncated"] = environments_truncated
+
+
+def _validate_spec_bundle_request_size():
+    """Reject oversized bundle requests before multipart parsing starts.
+
+    Fast up-front check for the common case where a ``Content-Length`` header is
+    present. It does *not* cover chunked uploads (no ``Content-Length``); the
+    per-view request-level cap set by :func:`_cap_bundle_request_body` handles
+    those.
+    """
+    if (
+        request.content_length is not None
+        and request.content_length > REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES
+    ):
+        raise RequestEntityTooLarge(
+            description="Specification bundle request is too large "
+            "(maximum is {} bytes).".format(REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES)
+        )
+
+
+def _cap_bundle_request_body(max_form_parts=1):
+    """Bound the request body size *before* multipart parsing is triggered.
+
+    Setting ``request.max_content_length`` (reliable on Flask/Werkzeug >= 3.1)
+    makes Werkzeug abort parsing with ``RequestEntityTooLarge`` (413) as soon as
+    the body exceeds the cap -- including a **chunked** upload that carries no
+    ``Content-Length`` header (which slips past
+    :func:`_validate_spec_bundle_request_size`). Without this, accessing
+    ``request.files`` on a chunked upload spools the entire multipart body to
+    server-local temp before any per-member cap can run.
+
+    ``request.max_form_memory_size`` is kept small so no single part is fully
+    buffered in RAM before Werkzeug spills it to a temporary file.
+
+    This is a **per-view** cap (deliberately not a global ``MAX_CONTENT_LENGTH``,
+    which Werkzeug >= 3.1 would also enforce on ``request.stream`` and thereby
+    break the large streaming workspace uploads handled by ``upload_file``). It
+    must be called before ``request.files`` is accessed, otherwise the body has
+    already been parsed with the default (unbounded) limits.
+    """
+    request.max_content_length = REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES
+    request.max_form_memory_size = _BUNDLE_MAX_FORM_MEMORY_SIZE
+    request.max_form_parts = max_form_parts
+
+
+def _remaining_stream_size(stream):
+    """Return remaining bytes in a seekable multipart file stream.
+
+    Werkzeug fully parses file parts into seekable temporary streams. Their
+    position must be restored so the downstream controller receives exactly the
+    bytes whose length is returned here.
+    """
+    try:
+        position = stream.tell()
+        stream.seek(0, os.SEEK_END)
+        size = stream.tell() - position
+        stream.seek(position)
+    except (AttributeError, OSError, TypeError, ValueError) as exc:
+        raise REANAValidationError(
+            "Could not determine the uploaded file size."
+        ) from exc
+    if size < 0:
+        raise REANAValidationError("Could not determine the uploaded file size.")
+    return size
+
+
+def _stage_validation_bundle(files):
+    """Securely extract the single uploaded ZIP bundle."""
+    if set(files) != {"bundle"}:
+        raise REANAValidationError(
+            "Upload exactly one specification archive in the 'bundle' field."
+        )
+    bundles = (
+        files.getlist("bundle") if hasattr(files, "getlist") else [files["bundle"]]
+    )
+    if len(bundles) != 1:
+        raise REANAValidationError(
+            "Upload exactly one specification archive in the 'bundle' field."
+        )
+    return extract_uploaded_bundle(bundles[0], SHARED_VOLUME_PATH)
+
+
+@blueprint.route("/workflows/validate", methods=["POST"])
+@signin_required()
+def validate_workflow_specification(user):  # noqa
+    r"""Validate a raw REANA workflow specification bundle.
+
+    ---
+    post:
+      summary: Validate a raw workflow specification bundle.
+      description: >-
+        Accepts one uncompressed ZIP validation snapshot in the multipart
+        ``bundle`` field. The archive contains canonical ``reana.yaml`` plus its
+        explicitly declared workflow/configuration files. Serial specs are loaded
+        and validated in-process; Snakemake/CWL/Yadage specs -- whose loading
+        executes user code -- are validated inside a sandboxed job spawned by
+        reana-workflow-controller. Returns a structured validation report.
+      operationId: validate_workflow_specification
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: bundle
+          in: formData
+          description: Uncompressed ZIP validation snapshot containing canonical
+            reana.yaml plus explicitly declared workflow sources.
+          required: true
+          type: file
+        - name: access_token
+          in: query
+          required: false
+          type: string
+        - name: environments
+          in: query
+          description: If true, run offline reproducibility checks on runtime
+            environment image references and return the loaded image and
+            effective runtime UID/GID combinations so the client can optionally
+            pull and inspect them locally.
+          required: false
+          type: boolean
+      responses:
+        200:
+          description: Validation ran; a structured report is returned.
+          schema:
+            type: object
+            properties:
+              valid:
+                type: boolean
+              errors:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    code:
+                      type: string
+                    message:
+                      type: string
+                    path:
+                      type: string
+              warnings:
+                type: array
+                items:
+                  type: object
+              environments:
+                description: Distinct runtime image and effective UID/GID
+                  combinations of the loaded spec (only when environments is
+                  requested), for client-side checks.
+                type: array
+                items:
+                  type: object
+                  required:
+                    - image
+                    - runtime_uid
+                    - runtime_gid
+                  properties:
+                    image:
+                      type: string
+                    runtime_uid:
+                      type: integer
+                    runtime_gid:
+                      type: integer
+              environments_truncated:
+                description: Whether one or more requested environment
+                  identities were omitted from the bounded response.
+                type: boolean
+        400:
+          description: The bundle was missing or malformed.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        401:
+          description: Request malformed or missing access token.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        403:
+          description: Request access forbidden.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        413:
+          description: The uploaded request exceeds the bounded bundle limit.
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+        429:
+          description: Request rate limit exceeded.
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+        500:
+          description: Internal error while validating the specification.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+    """
+    abs_dir = None
+    try:
+        # Cap the request body *before* touching request.files, so a chunked
+        # upload (no Content-Length) cannot make Werkzeug spool the whole
+        # multipart body to server-local temp before any size check runs.
+        _cap_bundle_request_body()
+        _validate_spec_bundle_request_size()
+        if not request.files:
+            return (
+                jsonify({"message": "No specification bundle files were provided."}),
+                400,
+            )
+        abs_dir, rel_path, _bundle_bytes, _legacy_parameters = _stage_validation_bundle(
+            request.files
+        )
+        reana_yaml_path = next(
+            (
+                os.path.join(abs_dir, name)
+                for name in REANA_SPEC_FILENAMES
+                if os.path.isfile(os.path.join(abs_dir, name))
+            ),
+            None,
+        )
+        if not reana_yaml_path:
+            return (
+                jsonify({"message": "No reana.yaml found in the uploaded bundle."}),
+                400,
+            )
+        report = validate_spec_bundle(abs_dir, rel_path)
+        # Optional offline runtime-environment checks. The server never contacts
+        # registries; clients may explicitly pull and inspect returned identities.
+        if _is_truthy_arg(request.args.get("environments")) and report.get(
+            "reana_specification"
+        ):
+            _add_bounded_environments(
+                report,
+                report["reana_specification"],
+            )
+        # The expanded specification is an internal validation artifact. It can
+        # be as large as the uploaded snapshot and neither supported client uses
+        # it, so do not reflect it in the bounded control-plane response.
+        report.pop("reana_specification", None)
+        return jsonify(report), 200
+    except REANAValidationError as e:
+        # A genuinely invalid *specification* is a client error (400); note the
+        # unloadable-spec case is already reported as 200 ``valid:false`` above.
+        return jsonify({"message": str(e)}), 400
+    except SpecValidationServiceError:
+        # The validation *service* itself failed (controller unreachable / a
+        # non-OK controller response / the sandbox exited with the internal-error
+        # code). That is a server-side outage, not an invalid specification, so it
+        # must surface as 500 -- never as a 200 ``valid:false`` report that a
+        # client would render as "X is not a valid REANA specification".
+        return (
+            jsonify(
+                _internal_error_response(
+                    "Workflow specification validation service failure."
+                )
+            ),
+            500,
+        )
+    except RequestEntityTooLarge as e:
+        return jsonify({"message": e.description or str(e)}), 413
+    except Exception:
+        return (
+            jsonify(
+                _internal_error_response(
+                    "Unexpected error while validating a workflow specification."
+                )
+            ),
+            500,
+        )
+    finally:
+        if abs_dir:
+            shutil.rmtree(abs_dir, ignore_errors=True)
 
 
 @blueprint.route("/workflows", methods=["GET"])
@@ -408,11 +983,13 @@ def create_workflow(user):  # noqa
     post:
       summary: Creates a new workflow based on a REANA specification file.
       description: >-
-        This resource is expecting a REANA specification in JSON format with
-        all the necessary information to instantiate a workflow.
+        Creates a workflow from one uncompressed ZIP validation snapshot in the
+        multipart ``bundle`` field. The archive contains canonical ``reana.yaml``
+        plus explicitly declared workflow/parameter files. The server loads and validates the specification
+        authoritatively (sandboxed for Snakemake/CWL/Yadage).
       operationId: create_workflow
       consumes:
-        - application/json
+        - multipart/form-data
       produces:
         - application/json
       parameters:
@@ -422,20 +999,12 @@ def create_workflow(user):  # noqa
             name will be generated.
           required: true
           type: string
-        # probably need to rename this to something more specific
-        - name: spec
-          in: query
-          description: Remote repository which contains a valid REANA
-            specification.
-          required: false
-          type: string
-        - name: reana_specification
-          in: body
-          description: REANA specification with necessary data to instantiate
-            a workflow.
-          required: false
-          schema:
-            type: object
+        - name: bundle
+          in: formData
+          description: Uncompressed ZIP validation snapshot containing canonical
+            reana.yaml plus explicitly declared workflow sources.
+          required: true
+          type: file
         - name: access_token
           in: query
           description: The API access_token of workflow owner.
@@ -454,6 +1023,17 @@ def create_workflow(user):  # noqa
                 type: string
               workflow_name:
                 type: string
+              validation_warnings:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    code:
+                      type: string
+                    message:
+                      type: string
+                    path:
+                      type: string
           examples:
             application/json:
               {
@@ -503,6 +1083,32 @@ def create_workflow(user):  # noqa
                 "message": "User 00000000-0000-0000-0000-000000000000 does not
                             exist."
               }
+        413:
+          description: The uploaded request exceeds the bounded bundle limit.
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+        409:
+          description: Another workflow-family mutation is in progress.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        429:
+          description: Request rate limit exceeded.
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+        503:
+          description: Workspace mutation or controller service is unavailable.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         500:
           description: >-
             Request failed. Internal controller error.
@@ -514,22 +1120,45 @@ def create_workflow(user):  # noqa
           examples:
             application/json:
               {
-                "message": "Internal controller error."
+                "message": "An internal server error occurred."
               }
         501:
           description: >-
             Request failed. Not implemented.
     """
+    bundle_dir = None
+    fetched_dir = None
+    seed_members = None
+    seed_bytes = 0
     try:
         if request.args.get("spec"):
             return jsonify("Not implemented"), 501
 
-        if not request.is_json:
-            raise Exception(
-                "Either remote repository or REANA specification needs to be provided"
+        # Parse the JSON body at most once: a released client posts its whole
+        # serialized specification here, and this runs before the per-view body
+        # cap that only bounds the multipart bundle path.
+        json_payload = (request.json or {}) if request.is_json else {}
+        request_from_gitlab = "object_kind" in json_payload
+        # A released client sends the serialized specification as the *entire*
+        # JSON body: the OpenAPI 2.0 body parameter is named
+        # ``reana_specification``, but a Swagger body parameter's schema is the
+        # body itself, so that name never appears on the wire (the released
+        # server read it back as a bare ``request.json``). The only JSON this
+        # endpoint still accepts is a GitLab webhook, so any other JSON body is
+        # a client that predates the specification-bundle protocol.
+        if not request_from_gitlab and json_payload:
+            return (
+                jsonify(
+                    {
+                        "message": _legacy_specification_message(
+                            "Workflow creation now uploads an uncompressed ZIP "
+                            "specification bundle in the multipart 'bundle' field."
+                        )
+                    }
+                ),
+                400,
             )
-
-        request_from_gitlab = "object_kind" in request.json
+        validation_warnings = []
         if request_from_gitlab:
             (
                 reana_spec_file,
@@ -538,23 +1167,75 @@ def create_workflow(user):  # noqa
                 git_branch,
                 git_commit_sha,
             ) = _get_reana_yaml_from_gitlab(request.json, user.id_)
-            git_data = {
+            fetched_dir = get_fetched_workflows_dir(str(user.id_))
+            gitlab_client = GitLabClient.from_k8s_secret(user.id_)
+            archive_response = gitlab_client.get_repository_archive(
+                git_url, git_commit_sha
+            )
+            fetcher = extract_streamed_zip_response(
+                archive_response,
+                fetched_dir,
+                spec="reana.yaml",
+                workflow_name=workflow_name,
+            )
+            specification_path = fetcher.workflow_spec_path()
+            (
+                bundle_dir,
+                _bundle_rel,
+                _bundle_bytes,
+                _legacy_parameters,
+            ) = stage_validation_snapshot(specification_path, SHARED_VOLUME_PATH)
+            reana_spec_file, validation_warnings = load_and_validate_spec(bundle_dir)
+            seed_members, seed_bytes = workspace_seed_members(specification_path)
+            prevent_disk_quota_excess(
+                user,
+                seed_bytes,
+                action=f"Creating the workflow {workflow_name}",
+            )
+            git_metadata = {
                 "git_url": git_url,
                 "git_branch": git_branch,
                 "git_commit_sha": git_commit_sha,
             }
         else:
-            git_data = {}
-            reana_spec_file = request.json
+            # Raw-bundle create: the client uploads the specification bundle
+            # (reana.yaml + referenced workflow/parameter files) as multipart
+            # form data. The server loads and validates it authoritatively
+            # (in-process for serial, sandboxed for Snakemake/CWL/Yadage), so it
+            # never trusts a client-serialized specification.
+            git_metadata = {}
             workflow_name = request.args.get("workflow_name", "")
+            # Reject an over-quota user *before* any expensive work (staging the
+            # bundle on the shared volume and spawning a sandbox validation Job).
+            if user.has_exceeded_quota():
+                raise REANAQuotaExceededError(get_quota_excess_message(user))
+            # Cap the request body *before* touching request.files, so a chunked
+            # upload (no Content-Length) cannot make Werkzeug spool the whole
+            # multipart body to server-local temp before any size check runs.
+            _cap_bundle_request_body()
+            _validate_spec_bundle_request_size()
+            if not request.files:
+                raise REANAValidationError(
+                    "A workflow specification bundle must be uploaded."
+                )
+            # Stage the bundle and validate it (B3: create-time lint). Keep it
+            # afterwards so it can seed the workspace once the workflow exists
+            # (C1); it is removed in the outer ``finally``.
+            (
+                bundle_dir,
+                _bundle_rel,
+                bundle_bytes,
+                _legacy_parameters,
+            ) = _stage_validation_bundle(request.files)
+            reana_spec_file, validation_warnings = load_and_validate_spec(bundle_dir)
+            prevent_disk_quota_excess(
+                user, bundle_bytes, action=f"Creating the workflow {workflow_name}"
+            )
 
         if user.has_exceeded_quota() and request_from_gitlab:
             message = f"User quota exceeded. Please check {REANA_HOSTNAME}"
             _fail_gitlab_commit_build_status(user, git_url, git_commit_sha, message)
             return jsonify({"message": "Gitlab webhook was processed"}), 200
-        elif user.has_exceeded_quota():
-            message = get_quota_excess_message(user)
-            raise REANAQuotaExceededError(message)
 
         validate_workflow_name(workflow_name)
         if is_uuid_v4(workflow_name):
@@ -569,53 +1250,92 @@ def create_workflow(user):  # noqa
         )
 
         workspace_root_path = reana_spec_file.get("workspace", {}).get("root_path")
-        validate_workspace_path(reana_spec_file)
-
-        validate_inputs(reana_spec_file)
-
-        validate_images(reana_spec_file)
-
-        validate_dask_limits(reana_spec_file)
+        # Both raw and GitLab snapshots were fully validated before workflow
+        # creation; only the declared seed remains to be copied below.
 
         retention_days = reana_spec_file.get("workspace", {}).get("retention_days")
         retention_rules = get_workspace_retention_rules(retention_days)
 
+        canonical_workflow_name = workflow_name or "workflow"
+        workflow_uuid = str(uuid.uuid4())
+        workspace_path = build_workspace_path(
+            str(user.id_), workflow_uuid, workspace_root_path
+        )
         workflow_dict = {
             "reana_specification": reana_spec_file,
-            "workflow_name": workflow_name,
+            "workflow_name": canonical_workflow_name,
+            "workflow_id": workflow_uuid,
             "operational_options": operational_options,
             "retention_rules": retention_rules,
         }
-        if git_data:
-            workflow_dict["git_data"] = git_data
+        if git_metadata:
+            workflow_dict["git_metadata"] = git_metadata
 
-        response, http_response = current_rwc_api_client.api.create_workflow(
-            workflow=workflow_dict,
-            user=str(user.id_),
-            workspace_root_path=workspace_root_path,
-        ).result()
-
-        if git_data:
-            workflow = _get_workflow_with_uuid_or_name(
-                response["workflow_id"], str(user.id_)
+        with workflow_creation_mutation_lock(
+            user.id_, canonical_workflow_name, workspace_path
+        ):
+            response, http_response = create_workflow_on_controller(
+                lambda: current_rwc_api_client.api.create_workflow(
+                    workflow=workflow_dict,
+                    user=str(user.id_),
+                    workspace_root_path=workspace_root_path,
+                    _request_options=_RWC_MUTATION_REQUEST_OPTIONS,
+                ).result(),
+                workflow_uuid,
+                user.id_,
+                workspace_path,
+                lambda created_workflow: _compensate_failed_workflow_create(
+                    created_workflow, user
+                ),
             )
+            returned_workflow_uuid = response.get("workflow_id")
+            if returned_workflow_uuid != workflow_uuid:
+                if returned_workflow_uuid:
+                    try:
+                        unexpected_workflow = _get_workflow_with_uuid_or_name(
+                            returned_workflow_uuid, str(user.id_)
+                        )
+                    except ValueError:
+                        pass
+                    else:
+                        _compensate_failed_workflow_create(unexpected_workflow, user)
+                raise RuntimeError("Controller returned an unexpected workflow id.")
+            workflow = _get_workflow_with_uuid_or_name(workflow_uuid, str(user.id_))
+            if os.path.abspath(workflow.workspace_path) != os.path.abspath(
+                workspace_path
+            ):
+                _compensate_failed_workflow_create(workflow, user)
+                raise RuntimeError("Controller created an unexpected workspace path.")
 
-            # This is necessary for GitLab integration
-            if workflow.type_ == "yadage":
-                _load_and_save_yadage_spec(
-                    workflow, workflow_dict["operational_options"]
-                )
-            elif workflow.type_ in ["cwl", "snakemake"]:
-                reana_yaml_path = os.path.join(workflow.workspace_path, "reana.yaml")
-                workflow.reana_specification = load_reana_spec(
-                    reana_yaml_path, workflow.workspace_path
-                )
+            if validation_warnings:
+                response["validation_warnings"] = validation_warnings
+
+            if git_metadata:
+                try:
+                    copied_bytes = seed_workspace(seed_members, workflow.workspace_path)
+                    if copied_bytes != seed_bytes:
+                        raise REANAValidationError(
+                            "The GitLab source changed while its workspace was seeded."
+                        )
+                except Exception:
+                    _compensate_failed_workflow_create(workflow, user)
+                    raise
                 Session.commit()
+                store_workflow_disk_quota(workflow, bytes_to_sum=seed_bytes)
+                update_users_disk_quota(user, bytes_to_sum=seed_bytes)
 
-            validate_images(workflow.reana_specification)
-
-            parameters = request.json
-            publish_workflow_submission(workflow, user.id_, parameters)
+                parameters = request.json
+                publish_workflow_submission(workflow, user.id_, parameters)
+            elif bundle_dir:
+                # Seed the freshly created workspace from the exact validated
+                # snapshot while creation still owns its mutation boundary.
+                try:
+                    mv_workflow_files(bundle_dir, workflow.workspace_path)
+                    store_workflow_disk_quota(workflow, bytes_to_sum=bundle_bytes)
+                    update_users_disk_quota(user, bytes_to_sum=bundle_bytes)
+                except Exception:
+                    _compensate_failed_workflow_create(workflow, user)
+                    raise
         return jsonify(response), http_response.status_code
     except GitLabClientInvalidToken as e:
         return jsonify({"message": str(e)}), 401
@@ -626,19 +1346,53 @@ def create_workflow(user):  # noqa
             e.response.status_code,
         )
     except HTTPError as e:
+        if e.response.status_code >= 500:
+            return (
+                jsonify(
+                    _internal_error_response(
+                        "Controller error while creating a workflow."
+                    )
+                ),
+                e.response.status_code,
+            )
         logging.error(traceback.format_exc())
         return jsonify(e.response.json()), e.response.status_code
+    except BravadoTimeoutError:
+        return jsonify({"message": "Workflow controller request timed out."}), 503
+    except WorkspaceMutationConflict:
+        return jsonify({"message": "The workflow family is currently changing."}), 409
+    except WorkspaceMutationUnavailable:
+        return (
+            jsonify(
+                _internal_error_response(
+                    "Workspace mutation serialization is unavailable."
+                )
+            ),
+            503,
+        )
     except REANAQuotaExceededError as e:
+        if "git_url" in locals() and "git_commit_sha" in locals():
+            _fail_gitlab_commit_build_status(user, git_url, git_commit_sha, str(e))
+            return jsonify({"message": "Gitlab webhook was processed"}), 200
         return jsonify({"message": e.message}), 403
     except (KeyError, REANAValidationError) as e:
         logging.error(traceback.format_exc())
         return jsonify({"message": str(e)}), 400
+    except RequestEntityTooLarge as e:
+        return jsonify({"message": e.description or str(e)}), 413
     except ValueError as e:
         logging.error(traceback.format_exc())
         return jsonify({"message": str(e)}), 403
-    except Exception as e:
-        logging.error(traceback.format_exc())
-        return jsonify({"message": str(e)}), 500
+    except Exception:
+        return (
+            jsonify(_internal_error_response("Unexpected error creating a workflow.")),
+            500,
+        )
+    finally:
+        if bundle_dir:
+            shutil.rmtree(bundle_dir, ignore_errors=True)
+        if fetched_dir:
+            shutil.rmtree(fetched_dir, ignore_errors=True)
 
 
 @blueprint.route("/workflows/<workflow_id_or_name>/specification", methods=["GET"])
@@ -1184,26 +1938,383 @@ def get_workflow_status(workflow_id_or_name, user):  # noqa
         return jsonify({"message": str(e)}), 500
 
 
-def _start_workflow(workflow_id_or_name, user, **parameters):
-    """Start given workflow by publishing it to the submission queue.
+def _workspace_has_source_file(workspace_path, relative_path):
+    """Return whether ``relative_path`` is a file contained in ``workspace_path``.
 
-    This function is used by both the `set_workflow_status` and `start_workflow`.
+    Absolute paths and ``..`` escapes are treated as *absent*: a restart may
+    only reference workflow-source files genuinely contained in the workspace.
     """
+    if not relative_path:
+        return False
+    workspace_path = os.path.abspath(workspace_path)
+    full_path = os.path.abspath(os.path.join(workspace_path, relative_path))
+    if os.path.commonpath([workspace_path, full_path]) != workspace_path:
+        return False
+    return os.path.isfile(full_path)
+
+
+def _workspace_specification_path(workspace_path):
+    """Return the canonical raw specification path in a workflow workspace."""
+    for filename in REANA_SPEC_FILENAMES:
+        candidate = os.path.join(workspace_path, filename)
+        if os.path.lexists(candidate):
+            return candidate
+    raise REANAValidationError(
+        "No REANA specification file is present in the workflow workspace."
+    )
+
+
+def _stage_workspace_validation_snapshot(workspace_path, specification_path=None):
+    """Create one bounded immutable definition snapshot of a workspace."""
+    specification_path = specification_path or _workspace_specification_path(
+        workspace_path
+    )
+    staged_directory, _relative_path, _total_bytes, _legacy_parameters = (
+        stage_validation_snapshot(
+            specification_path,
+            SHARED_VOLUME_PATH,
+            source_base_directory=workspace_path,
+        )
+    )
+    return staged_directory
+
+
+def _copy_regular_file(source_root, source_path, destination):
+    """Copy one securely opened regular file to a new private destination."""
+    relative_source = os.path.relpath(
+        os.path.abspath(source_path), os.path.abspath(source_root)
+    ).replace(os.sep, "/")
+    source_descriptor = open_regular_file_beneath(
+        source_root, relative_source, "restart specification"
+    )
+    source_size = os.fstat(source_descriptor).st_size
+    if source_size > REANA_SPEC_BUNDLE_MAX_BYTES:
+        os.close(source_descriptor)
+        raise REANAValidationError(
+            "Restart specification is too large (maximum is {} bytes).".format(
+                REANA_SPEC_BUNDLE_MAX_BYTES
+            )
+        )
+    destination_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        destination_flags |= os.O_NOFOLLOW
+    try:
+        destination_descriptor = os.open(destination, destination_flags, 0o600)
+    except Exception:
+        os.close(source_descriptor)
+        raise
+    try:
+        with os.fdopen(source_descriptor, "rb") as source, os.fdopen(
+            destination_descriptor, "wb"
+        ) as target:
+            copied = 0
+            while True:
+                chunk = source.read(_FILE_COPY_CHUNK_SIZE)
+                if not chunk:
+                    break
+                copied += len(chunk)
+                if copied > REANA_SPEC_BUNDLE_MAX_BYTES:
+                    raise REANAValidationError(
+                        "Restart specification is too large (maximum is {} bytes).".format(
+                            REANA_SPEC_BUNDLE_MAX_BYTES
+                        )
+                    )
+                target.write(chunk)
+            target.flush()
+            os.fsync(target.fileno())
+    except Exception:
+        try:
+            os.unlink(destination)
+        except OSError:
+            pass
+        raise
+
+
+def _promote_restart_specification(workspace_path, staged_directory):
+    """Atomically install a validated replacement and retain a rollback copy."""
+    try:
+        canonical_path = _workspace_specification_path(workspace_path)
+        had_original = True
+    except REANAValidationError:
+        canonical_path = os.path.join(workspace_path, "reana.yaml")
+        had_original = False
+    suffix = uuid.uuid4().hex
+    candidate_path = os.path.join(workspace_path, ".reana-promote-{}".format(suffix))
+    backup_path = os.path.join(workspace_path, ".reana-backup-{}".format(suffix))
+    if had_original:
+        _copy_regular_file(workspace_path, canonical_path, backup_path)
+    try:
+        _copy_regular_file(
+            staged_directory,
+            os.path.join(staged_directory, "reana.yaml"),
+            candidate_path,
+        )
+        os.replace(candidate_path, canonical_path)
+    except Exception:
+        for temporary_path in (candidate_path, backup_path):
+            try:
+                os.unlink(temporary_path)
+            except OSError:
+                pass
+        raise
+    return canonical_path, backup_path if had_original else None
+
+
+def _rollback_restart_specification(promotion):
+    """Restore the canonical specification after a failed submission."""
+    canonical_path, backup_path = promotion
+    if backup_path:
+        os.replace(backup_path, canonical_path)
+    else:
+        try:
+            os.unlink(canonical_path)
+        except FileNotFoundError:
+            pass
+
+
+def _complete_restart_specification_promotion(promotion):
+    """Discard a restart rollback copy after successful submission."""
+    _canonical_path, backup_path = promotion
+    if backup_path:
+        try:
+            os.unlink(backup_path)
+        except OSError:
+            logging.warning("Could not remove restart specification backup.")
+
+
+def _load_and_validate_workspace_snapshot(workspace_path):
+    """Validate only the declared definition snapshot of a mutable workspace."""
+    staged_directory = None
+    try:
+        staged_directory = _stage_workspace_validation_snapshot(workspace_path)
+        return load_and_validate_spec(staged_directory)
+    finally:
+        if staged_directory:
+            shutil.rmtree(staged_directory, ignore_errors=True)
+
+
+def _workspace_retention_rule_states(workspace_path):
+    """Return current retention-rule states for every run sharing a workspace."""
+    rules = (
+        Session.query(WorkspaceRetentionRule)
+        .join(Workflow, WorkspaceRetentionRule.workflow_id == Workflow.id_)
+        .filter(Workflow.workspace_path == workspace_path)
+        .all()
+    )
+    return {rule.id_: rule.status for rule in rules}
+
+
+def _recalculate_shared_workspace_quota(workflow, user):
+    """Synchronise quota rows for all runs that share one mutable workspace."""
+    workspace_size = get_disk_usage_or_zero(
+        workflow.workspace_path, override_policy_checks=True
+    )
+    disk_resource = get_default_quota_resource(ResourceType.disk.name)
+    siblings = (
+        Session.query(Workflow).filter_by(workspace_path=workflow.workspace_path).all()
+    )
+    for sibling in siblings:
+        resource = (
+            Session.query(WorkflowResource)
+            .filter_by(workflow_id=sibling.id_, resource_id=disk_resource.id_)
+            .one_or_none()
+        )
+        if resource is None:
+            resource = WorkflowResource(
+                workflow_id=sibling.id_, resource_id=disk_resource.id_
+            )
+            Session.add(resource)
+        resource.quota_used = workspace_size
+    Session.flush()
+    update_users_disk_quota(user, override_policy_checks=True)
+
+
+def _compensate_failed_restart(workflow, retention_rule_states, user):
+    """Make a cloned but unsubmitted restart non-live and restore shared state."""
+    Session.rollback()
+    try:
+        # Bypass the mapped status listener: assigning ``workflow.status`` can
+        # commit independently, breaking compensation into partially durable
+        # steps. Keep clone deletion and retention restoration in one unit.
+        Session.query(Workflow).filter(Workflow.id_ == workflow.id_).update(
+            {Workflow.status: RunStatus.deleted}, synchronize_session=False
+        )
+        for rule in Session.query(WorkspaceRetentionRule).filter_by(
+            workflow_id=workflow.id_
+        ):
+            rule.status = WorkspaceRetentionRuleStatus.inactive
+        if retention_rule_states:
+            for rule in Session.query(WorkspaceRetentionRule).filter(
+                WorkspaceRetentionRule.id_.in_(retention_rule_states)
+            ):
+                rule.status = retention_rule_states[rule.id_]
+        Session.commit()
+    except Exception:
+        Session.rollback()
+        logging.exception("Could not compensate failed restart %s.", workflow.id_)
+    try:
+        _recalculate_shared_workspace_quota(workflow, user)
+    except Exception:
+        Session.rollback()
+        logging.exception("Could not recalculate quota after failed restart.")
+
+
+def _enforce_restart_spec_constraints(workflow, new_spec, source_root=None):
+    """Enforce the narrowed restart contract for a replacement specification.
+
+    A restart reuses the workflow *source* files already present in the
+    workspace; ``-f``/``--file`` only replaces the *specification* (input
+    parameters, operational options, workflow type/definition metadata).
+    Staging a replacement ``reana.yaml`` does not bring new source files into
+    the workspace, so every workflow-source file the replacement references
+    (``workflow.file`` and any ``workflow.files`` entries) must already exist in
+    the workspace. Keeping the referenced source current -- including uploading
+    a new ``workflow.file`` to the workspace before restarting -- is the user's
+    responsibility. Changing ``workflow.file`` is allowed as long as the new
+    source is present in the workspace.
+
+    Serial specifications carry their steps inline in
+    ``workflow.specification`` (they have no ``workflow.file``) and are skipped.
+
+    :raises REANAValidationError: if the replacement spec references a
+        workflow-source file missing from the workspace (surfaced to the client
+        as HTTP 400).
+    """
+    source_root = source_root or workflow.workspace_path
+    new_workflow = new_spec.get("workflow", {}) or {}
+    if not isinstance(new_workflow, dict):
+        return
+    new_file = new_workflow.get("file")
+    if not new_file:
+        # Serial (inline specification) or fileless spec: nothing to enforce.
+        return
+
+    referenced_main_file = (
+        new_file.partition("#")[0]
+        if new_workflow.get("type") == "cwl" and isinstance(new_file, str)
+        else new_file
+    )
+    referenced_files = [referenced_main_file] + list(
+        new_workflow.get("files", []) or []
+    )
+    workflow_parameters = new_workflow.get("parameters") or {}
+    if isinstance(workflow_parameters, dict) and workflow_parameters.get("file"):
+        referenced_files.append(workflow_parameters["file"])
+    inputs = new_spec.get("inputs") or {}
+    inputs_parameters = (
+        inputs.get("parameters") or {} if isinstance(inputs, dict) else {}
+    )
+    if (
+        new_workflow.get("type") in ("cwl", "snakemake")
+        and isinstance(inputs_parameters, dict)
+        and inputs_parameters.get("input")
+    ):
+        referenced_files.append(inputs_parameters["input"])
+    for referenced in referenced_files:
+        if not _workspace_has_source_file(source_root, referenced):
+            raise REANAValidationError(
+                "Workflow source file '{file}' referenced by the restart "
+                "specification is not present in the workspace. A restart "
+                "reuses the workflow source files already in the workspace; "
+                "to run different source, create a new workflow.".format(
+                    file=referenced
+                )
+            )
+    for referenced in list(new_workflow.get("directories", []) or []):
+        directory = os.path.abspath(os.path.join(source_root, referenced))
+        workspace = os.path.abspath(source_root)
+        if (
+            os.path.commonpath([workspace, directory]) != workspace
+            or not os.path.isdir(directory)
+            or os.path.islink(directory)
+        ):
+            raise REANAValidationError(
+                "Workflow source directory '{directory}' referenced by the "
+                "restart specification is not present in the workspace.".format(
+                    directory=referenced
+                )
+            )
+
+
+def _restart_specification_path_error(error):
+    """Return a stable restart diagnostic from typed path-error attributes."""
+    path = error.path
+    if error.reason == "max_length":
+        return REANAValidationError(
+            "Workflow source path in {} exceeds {} encoded bytes.".format(
+                error.field, SPECIFICATION_BUNDLE_MAX_PATH_BYTES
+            )
+        )
+    reason_messages = {
+        "missing": (
+            "Workflow source path '{}' referenced by the restart specification "
+            "is not present in the workspace."
+        ),
+        "unsafe": (
+            "Workflow source path '{}' referenced by the restart specification "
+            "is unsafe."
+        ),
+        "symlink": (
+            "Workflow source path '{}' referenced by the restart specification "
+            "is a symbolic link; only regular workspace files and directories "
+            "are allowed."
+        ),
+        "wrong_type": (
+            "Workflow source path '{}' referenced by the restart specification "
+            "does not have the required regular file or directory type."
+        ),
+        "conflict": (
+            "Workflow source path '{}' has conflicting declarations in the "
+            "restart specification."
+        ),
+        "max_depth": (
+            "Workflow source path '{}' referenced by the restart specification "
+            "exceeds the maximum path depth."
+        ),
+        "max_length": (
+            "Workflow source path '{}' referenced by the restart specification "
+            "exceeds the maximum path length."
+        ),
+        "unreadable": (
+            "Workflow source path '{}' referenced by the restart specification "
+            "could not be read securely."
+        ),
+        "changed": (
+            "Workflow source path '{}' referenced by the restart specification "
+            "changed while it was being read."
+        ),
+    }
+    template = reason_messages.get(
+        error.reason,
+        "Workflow source path '{}' referenced by the restart specification "
+        "could not be used safely (reason: {}).",
+    )
+    if error.reason in reason_messages:
+        message = template.format(path)
+    else:
+        message = template.format(path, error.reason)
+    return REANAValidationError(message)
+
+
+def _submit_workflow_locked(workflow, user, **parameters):  # noqa: C901
+    """Validate and submit a workflow while its workspace lock is held."""
     operational_options = parameters.get("operational_options", {})
     input_parameters = parameters.get("input_parameters", {})
     restart = parameters.get("restart", False)
-    reana_specification = parameters.get("reana_specification")
+    replacement_specification_path = parameters.pop(
+        "_replacement_specification_path", None
+    )
+    staged_restart_directory = None
+    restart_promotion = None
+    cloned_restart_workflow = None
+    retention_rule_states = None
+    restart_completed = False
 
     try:
-        if not workflow_id_or_name:
-            raise ValueError("workflow_id_or_name is not supplied")
+        validate_operational_options(workflow.type_, operational_options)
 
-        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, str(user.id_))
-        operational_options = validate_operational_options(
-            workflow.type_, operational_options
-        )
-
-        restart_type = None
+        validation_warnings = []
+        restart_spec_validated = False
         if restart:
             if workflow.status not in [RunStatus.finished, RunStatus.failed]:
                 raise ValueError("Only finished or failed workflows can be restarted.")
@@ -1212,28 +2323,108 @@ def _start_workflow(workflow_id_or_name, user, **parameters):
                     "The workflow cannot be restarted because some retention rules are "
                     "currently being applied to the workspace. Please retry later."
                 )
-            if reana_specification:
-                restart_type = reana_specification.get("workflow", {}).get("type", None)
-            workflow = clone_workflow(workflow, reana_specification, restart_type)
+            if replacement_specification_path:
+                retention_rule_states = _workspace_retention_rule_states(
+                    workflow.workspace_path
+                )
+                try:
+                    staged_restart_directory = _stage_workspace_validation_snapshot(
+                        workflow.workspace_path,
+                        specification_path=replacement_specification_path,
+                    )
+                except REANASpecificationPathError as error:
+                    raise _restart_specification_path_error(error) from error
+                workspace_specification = load_raw_spec_mapping(
+                    staged_restart_directory
+                )
+                if not workspace_specification:
+                    raise REANAValidationError(
+                        "A supplied restart specification must be a non-empty "
+                        "YAML mapping."
+                    )
+                restart_type = workspace_specification.get("workflow", {}).get("type")
+                _enforce_restart_spec_constraints(
+                    workflow,
+                    workspace_specification,
+                    source_root=staged_restart_directory,
+                )
+                reana_specification, validation_warnings = load_and_validate_spec(
+                    staged_restart_directory
+                )
+                restart_spec_validated = True
+                workflow = clone_workflow(
+                    workflow, reana_specification, restart_type, validate_spec=False
+                )
+                cloned_restart_workflow = workflow
+            else:
+                retention_rule_states = _workspace_retention_rule_states(
+                    workflow.workspace_path
+                )
+                workflow = clone_workflow(workflow, None, None)
+                cloned_restart_workflow = workflow
         elif workflow.status != RunStatus.created:
             raise ValueError(
                 "Workflow {} is already {} and cannot be started "
                 "again.".format(workflow.get_full_workflow_name(), workflow.status.name)
             )
-        if "yadage" in (workflow.type_, restart_type):
-            _load_and_save_yadage_spec(workflow, operational_options)
-
-        validate_workflow(
-            workflow.reana_specification, input_parameters=input_parameters
+        # Binding validation gate. The workspace is the source of truth (A1) and
+        # is mutable, so when it carries a reana.yaml we re-load + re-validate it
+        # *now* -- right before queueing -- and refresh the stored specification
+        # from the loaded result. Loading runs in the sandboxed validator for
+        # Snakemake/CWL/Yadage (never in-process) and in-process for serial. This
+        # binds what runs to what was validated; an invalid workspace fails the
+        # start and the workflow keeps its current status (nothing is queued).
+        #
+        # Two cases deliberately do NOT re-load from the workspace and instead
+        # validate the stored authoritative specification in-process (pure, no
+        # code execution -- safe and the only sound option, since an
+        # already-serialized spec cannot be round-tripped through the engine
+        # loaders):
+        #  * plain restart -- clone_workflow already validated the stored spec;
+        #    replacement restarts were handled above before cloning from the
+        #    staged raw specification; and
+        #  * a workspace with no reana.yaml -- launched workflows have it
+        #    stripped by filter_input_files and pre-seeding (legacy) workflows
+        #    never had it, yet the stored spec is a valid, vetted artifact.
+        # The (pure) policy validator is the authoritative check in every branch,
+        # and runtime per-job policy is independently re-enforced regardless.
+        if restart and restart_spec_validated:
+            pass
+        elif restart:
+            validation_warnings = validate_loaded_spec(workflow.reana_specification)
+        elif has_reana_spec_file(workflow.workspace_path):
+            (
+                workflow.reana_specification,
+                validation_warnings,
+            ) = _load_and_validate_workspace_snapshot(workflow.workspace_path)
+        else:
+            validation_warnings = validate_loaded_spec(workflow.reana_specification)
+        original_parameters = workflow.reana_specification.get("inputs", {}).get(
+            "parameters", {}
         )
+        validate_input_parameters(input_parameters, original_parameters)
+        Session.object_session(workflow).commit()
 
         # Backfill the Dask service row for legacy workflows created before this fix
         if ensure_dask_service(workflow):
             Session.object_session(workflow).commit()
 
-        # when starting the workflow, the scheduler will call RWC's `set_workflow_status`
-        # with the given `parameters`
-        publish_workflow_submission(workflow, user.id_, parameters)
+        # when starting the workflow, the scheduler will call RWC's
+        # `set_workflow_status` with this payload. Drop server-only fields that
+        # RWC does not accept in its start schema.
+        submission_parameters = dict(parameters)
+        submission_parameters.pop("reana_specification", None)
+        if staged_restart_directory:
+            restart_promotion = _promote_restart_specification(
+                workflow.workspace_path, staged_restart_directory
+            )
+        if cloned_restart_workflow:
+            _recalculate_shared_workspace_quota(cloned_restart_workflow, user)
+        publish_workflow_submission(workflow, user.id_, submission_parameters)
+        if restart_promotion:
+            _complete_restart_specification_promotion(restart_promotion)
+            restart_promotion = None
+        restart_completed = True
         response = {
             "message": "Workflow submitted.",
             "workflow_id": workflow.id_,
@@ -1242,8 +2433,15 @@ def _start_workflow(workflow_id_or_name, user, **parameters):
             "run_number": workflow.run_number,
             "user": str(user.id_),
         }
+        if validation_warnings:
+            response["validation_warnings"] = validation_warnings
         return response, 200
     except HTTPError as e:
+        if e.response.status_code >= 500:
+            return (
+                _internal_error_response("Controller error while starting a workflow."),
+                e.response.status_code,
+            )
         logging.error(traceback.format_exc())
         return e.response.json(), e.response.status_code
     except (REANAValidationError, ValidationError) as e:
@@ -1252,9 +2450,238 @@ def _start_workflow(workflow_id_or_name, user, **parameters):
     except ValueError as e:
         logging.error(traceback.format_exc())
         return {"message": str(e)}, 403
-    except Exception as e:
+    except Exception:
+        return _internal_error_response("Unexpected error starting a workflow."), 500
+    finally:
+        if restart_promotion:
+            try:
+                _rollback_restart_specification(restart_promotion)
+            except OSError:
+                logging.exception("Could not roll back restart specification.")
+        if cloned_restart_workflow and not restart_completed:
+            _compensate_failed_restart(
+                cloned_restart_workflow, retention_rule_states or {}, user
+            )
+        if staged_restart_directory:
+            shutil.rmtree(staged_restart_directory, ignore_errors=True)
+
+
+def _submit_workflow(workflow_id_or_name, user, _resolved_workflow=None, **parameters):
+    """Resolve, serialize, and submit a workflow through one application boundary."""
+    try:
+        if user.has_exceeded_quota():
+            raise REANAQuotaExceededError(get_quota_excess_message(user))
+        if not workflow_id_or_name:
+            raise ValueError("workflow_id_or_name is not supplied")
+        workflow = _resolved_workflow or _get_workflow_with_uuid_or_name(
+            workflow_id_or_name, str(user.id_)
+        )
+        with _workspace_mutation_lock(workflow.workspace_path):
+            # The identifier must be resolved before taking the workspace lock,
+            # but submission decisions must use state refreshed while holding it.
+            #
+            # KNOWN LIMITATION (tracked in
+            # https://github.com/reanahub/reana-workflow-validator/issues/9):
+            # for a non-serial workflow whose
+            # workspace carries a reana.yaml, _submit_workflow_locked performs the
+            # synchronous sandbox validation *inside* this lock. Because the
+            # advisory lock is transaction-scoped on the dedicated lock engine,
+            # that transaction (and its backend connection) stays open for the
+            # whole sandbox wait. Moving validation off the lock-hold path is the
+            # proper fix and is deferred to the async-validation work.
+            Session.object_session(workflow).refresh(workflow)
+            return _submit_workflow_locked(workflow, user, **parameters)
+    except WorkspaceMutationConflict:
+        return {"message": "The workflow workspace is currently being modified."}, 409
+    except WorkspaceMutationUnavailable:
+        return (
+            _internal_error_response(
+                "Workspace mutation serialization is unavailable."
+            ),
+            503,
+        )
+    except REANAQuotaExceededError as error:
+        return {"message": error.message}, 403
+    except ValueError as error:
         logging.error(traceback.format_exc())
-        return {"message": str(e)}, 500
+        return {"message": str(error)}, 403
+    except Exception:
+        return (
+            _internal_error_response("Unexpected error resolving workflow submission."),
+            500,
+        )
+
+
+def _deletion_workspace_paths(workflow_id_or_name, user, all_runs=False):
+    """Resolve every workspace a status-deleted operation can mutate."""
+    try:
+        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, str(user.id_))
+    except ValueError:
+        # Preserve the existing proxy contract for unknown identifiers; RWC
+        # remains authoritative for the eventual not-found response.
+        return ["workflow-id-or-name:{}".format(workflow_id_or_name)]
+    workflows = [workflow]
+    if all_runs:
+        workflows.extend(
+            Session.query(Workflow)
+            .filter(
+                Workflow.name == workflow.name,
+                Workflow.owner_id == workflow.owner_id,
+            )
+            .all()
+        )
+    return [candidate.workspace_path for candidate in workflows]
+
+
+@blueprint.route("/workflows/<workflow_id_or_name>/restart", methods=["POST"])
+@signin_required()
+@check_quota
+def restart_workflow(workflow_id_or_name, user):
+    r"""Restart a workflow using one raw replacement specification.
+
+    ---
+    post:
+      summary: Restart a workflow with a replacement specification.
+      description: >-
+        Atomically validates and applies one raw replacement REANA specification.
+        Workflow source files are reused from the existing workspace.
+      operationId: restart_workflow
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: workflow_id_or_name
+          in: path
+          required: true
+          type: string
+        - name: access_token
+          in: query
+          required: false
+          type: string
+        - name: replacement
+          in: formData
+          required: true
+          type: file
+          description: Raw replacement REANA specification.
+        - name: parameters
+          in: formData
+          required: false
+          type: string
+          description: >-
+            JSON object containing optional input_parameters and
+            operational_options objects.
+      responses:
+        200:
+          description: Workflow restart was submitted.
+          schema:
+            $ref: '#/definitions/WorkflowSubmissionResponse'
+        400:
+          description: Replacement or parameters are malformed or invalid.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        401:
+          description: Request malformed or missing access token.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        403:
+          description: Restart is not permitted.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        404:
+          description: Workflow does not exist.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        409:
+          description: The workspace is currently being mutated.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        413:
+          description: Replacement exceeds the configured request limit.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        429:
+          description: Request rate limit exceeded.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        503:
+          description: Workspace mutation serialization is unavailable.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+    """
+    request_directory = None
+    try:
+        _validate_spec_bundle_request_size()
+        _cap_bundle_request_body(max_form_parts=2)
+        replacements = request.files.getlist("replacement")
+        if set(request.files) != {"replacement"} or len(replacements) != 1:
+            return jsonify({"message": "Upload exactly one replacement file."}), 400
+
+        raw_parameters = request.form.get("parameters", "{}")
+        try:
+            parameters = json.loads(raw_parameters)
+        except (TypeError, ValueError):
+            return jsonify({"message": "parameters must be a JSON object."}), 400
+        if not isinstance(parameters, dict):
+            return jsonify({"message": "parameters must be a JSON object."}), 400
+        unknown = set(parameters) - {"input_parameters", "operational_options"}
+        if unknown:
+            return (
+                jsonify(
+                    {
+                        "message": "Unknown restart parameters: {}.".format(
+                            ", ".join(sorted(unknown))
+                        )
+                    }
+                ),
+                400,
+            )
+        for name in ("input_parameters", "operational_options"):
+            if name in parameters and not isinstance(parameters[name], dict):
+                return jsonify({"message": "{} must be an object.".format(name)}), 400
+
+        replacement_stream = replacements[0].stream
+        replacement_size = _remaining_stream_size(replacement_stream)
+        if replacement_size > REANA_SPEC_BUNDLE_MAX_BYTES:
+            raise RequestEntityTooLarge(
+                description="Restart specification is too large (maximum is {} bytes).".format(
+                    REANA_SPEC_BUNDLE_MAX_BYTES
+                )
+            )
+        request_root = os.path.join(SHARED_VOLUME_PATH, "validation-tmp")
+        os.makedirs(request_root, mode=0o700, exist_ok=True)
+        request_directory = tempfile.mkdtemp(prefix="restart-", dir=request_root)
+        replacement_path = os.path.join(request_directory, "reana.yaml")
+        with open(replacement_path, "xb") as destination:
+            while True:
+                chunk = replacement_stream.read(_FILE_COPY_CHUNK_SIZE)
+                if not chunk:
+                    break
+                destination.write(chunk)
+
+        source_workflow = _get_workflow_with_uuid_or_name(
+            workflow_id_or_name, str(user.id_)
+        )
+        response, status_code = _submit_workflow(
+            workflow_id_or_name,
+            user,
+            _resolved_workflow=source_workflow,
+            restart=True,
+            _replacement_specification_path=replacement_path,
+            **parameters,
+        )
+        return jsonify(response), status_code
+    except RequestEntityTooLarge as error:
+        return jsonify({"message": error.description}), 413
+    except ValueError as error:
+        return jsonify({"message": str(error)}), 404
+    finally:
+        if request_directory:
+            shutil.rmtree(request_directory, ignore_errors=True)
 
 
 @blueprint.route("/workflows/<workflow_id_or_name>/start", methods=["POST"])
@@ -1264,6 +2691,10 @@ def _start_workflow(workflow_id_or_name, user, **parameters):
         "operational_options": fields.Dict(),
         "input_parameters": fields.Dict(),
         "restart": fields.Boolean(),
+        # Accepted by the parser only so a released client's replacement restart
+        # is answered with an actionable upgrade message instead of an unknown-
+        # field complaint. Deliberately absent from the OpenAPI contract: it is
+        # rejected in the view and is not part of the supported request.
         "reana_specification": fields.Raw(),
     },
     location="json",
@@ -1277,6 +2708,15 @@ def start_workflow(workflow_id_or_name, user, **parameters):  # noqa
       description: >-
         This resource starts the workflow execution process.
         Resource is expecting a workflow UUID.
+
+
+        The workspace is the authoritative copy of the specification: before the
+        workflow is queued, the server re-loads and re-validates the
+        specification *from the current workspace* (in a sandbox for
+        Snakemake/CWL/Yadage, in-process for serial) and refreshes the stored
+        specification from it. A workspace that no longer loads or fails policy
+        is rejected with a 400 and the workflow keeps its current status. Any
+        non-blocking validation findings are returned in ``validation_warnings``.
       operationId: start_workflow
       consumes:
         - application/json
@@ -1309,11 +2749,6 @@ def start_workflow(workflow_id_or_name, user, **parameters):  # noqa
                   Optional. Additional input parameters that override the ones from
                   the workflow specification.
                 type: object
-              reana_specification:
-                description: >-
-                  Optional. Replace the original workflow specification with the given one.
-                  Only considered when restarting a workflow.
-                type: object
               restart:
                 description: Optional. If true, restart the given workflow.
                 type: boolean
@@ -1323,24 +2758,14 @@ def start_workflow(workflow_id_or_name, user, **parameters):  # noqa
             Request succeeded. Info about a workflow, including the execution
             status is returned.
           schema:
-            type: object
-            properties:
-              message:
-                type: string
-              workflow_id:
-                type: string
-              workflow_name:
-                type: string
-              status:
-                type: string
-              user:
-                type: string
+            $ref: '#/definitions/WorkflowSubmissionResponse'
           examples:
             application/json:
               {
-                "message": "Workflow submitted",
-                "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
-                "workflow_name": "mytest.1",
+                "message": "Workflow submitted.",
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest",
+                "run_number": "1",
                 "status": "queued",
                 "user": "00000000-0000-0000-0000-000000000000"
               }
@@ -1402,6 +2827,19 @@ def start_workflow(workflow_id_or_name, user, **parameters):  # noqa
                             could not be started because it is already
                             running."
               }
+        429:
+          description: Request rate limit exceeded.
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+        503:
+          description: Workspace mutation serialization is unavailable.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         500:
           description: >-
             Request failed. Internal controller error.
@@ -1413,7 +2851,7 @@ def start_workflow(workflow_id_or_name, user, **parameters):  # noqa
           examples:
             application/json:
               {
-                "message": "Internal controller error."
+                "message": "An internal server error occurred."
               }
         501:
           description: >-
@@ -1429,7 +2867,20 @@ def start_workflow(workflow_id_or_name, user, **parameters):  # noqa
                 "message": "Status resume is not supported yet."
               }
     """
-    response, status_code = _start_workflow(workflow_id_or_name, user, **parameters)
+    if "reana_specification" in parameters:
+        return (
+            jsonify(
+                {
+                    "message": _legacy_specification_message(
+                        "A restart that replaces the specification now uploads the "
+                        "raw specification to the multipart "
+                        "'/api/workflows/{id}/restart' operation."
+                    )
+                }
+            ),
+            400,
+        )
+    response, status_code = _submit_workflow(workflow_id_or_name, user, **parameters)
     return jsonify(response), status_code
 
 
@@ -1471,7 +2922,10 @@ def set_workflow_status(workflow_id_or_name, user, status, **parameters):  # noq
           type: string
         - name: status
           in: query
-          description: Required. New workflow status.
+          description: >-
+            Required. New workflow status. The `start` value is retained for
+            compatibility; new clients should use
+            POST /api/workflows/<workflow_id_or_name>/start.
           required: true
           type: string
           enum:
@@ -1491,20 +2945,21 @@ def set_workflow_status(workflow_id_or_name, user, status, **parameters):  # noq
           schema:
             type: object
             properties:
-              operational_options:
-                description: >-
-                  Optional. Additional operational options for workflow execution.
-                  Only allowed when status is `start`.
-                type: object
               input_parameters:
                 description: >-
                   Optional. Additional input parameters that override the ones
-                  from the workflow specification. Only allowed when status is `start`.
+                  from the workflow specification. Only allowed when status is
+                  `start`.
+                type: object
+              operational_options:
+                description: >-
+                  Optional. Additional operational options for workflow
+                  execution. Only allowed when status is `start`.
                 type: object
               restart:
                 description: >-
-                  Optional. If true, the workflow is a restart of an earlier workflow execution.
-                  Only allowed when status is `start`.
+                  Optional. If true, restart the given workflow. Only allowed
+                  when status is `start`.
                 type: boolean
               all_runs:
                 description: >-
@@ -1523,24 +2978,13 @@ def set_workflow_status(workflow_id_or_name, user, status, **parameters):  # noq
             Request succeeded. Info about a workflow, including the status is
             returned.
           schema:
-            type: object
-            properties:
-              message:
-                type: string
-              workflow_id:
-                type: string
-              workflow_name:
-                type: string
-              status:
-                type: string
-              user:
-                type: string
+            $ref: '#/definitions/WorkflowSubmissionResponse'
           examples:
             application/json:
               {
                 "message": "Workflow successfully launched",
-                "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
-                "workflow_name": "mytest.1",
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest",
                 "status": "created",
                 "user": "00000000-0000-0000-0000-000000000000"
               }
@@ -1602,6 +3046,19 @@ def set_workflow_status(workflow_id_or_name, user, status, **parameters):  # noq
                             could not be started because it is already
                             running."
               }
+        429:
+          description: Request rate limit exceeded.
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+        503:
+          description: Workspace mutation serialization is unavailable.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         500:
           description: >-
             Request failed. Internal controller error.
@@ -1634,30 +3091,79 @@ def set_workflow_status(workflow_id_or_name, user, status, **parameters):  # noq
             raise ValueError("workflow_id_or_name is not supplied")
 
         if status == "start":
-            # We can't call directly RWC when starting a workflow, as otherwise
-            # the workflow would skip the queue. Instead, we do what the
-            # `start_workflow` endpoint does.
-            response, status_code = _start_workflow(
+            response, status_code = _submit_workflow(
                 workflow_id_or_name, user, **parameters
             )
-            if "run_number" in response:
-                # run_number is returned by `start_workflow`,
-                # but not by `set_status_workflow`
-                del response["run_number"]
+            # Preserve the legacy response shape of this endpoint.
+            response.pop("run_number", None)
             return jsonify(response), status_code
 
         parameters = request.json if request.is_json else None
-        response, http_response = current_rwc_api_client.api.set_workflow_status(
-            user=str(user.id_),
-            workflow_id_or_name=workflow_id_or_name,
-            status=status,
-            parameters=parameters,
-        ).result()
+
+        def set_controller_status():
+            return current_rwc_api_client.api.set_workflow_status(
+                user=str(user.id_),
+                workflow_id_or_name=workflow_id_or_name,
+                status=status,
+                parameters=parameters,
+                _request_options=_RWC_MUTATION_REQUEST_OPTIONS,
+            ).result()
+
+        if status == "deleted":
+            all_runs = (parameters or {}).get("all_runs", False)
+            if all_runs:
+                try:
+                    workflow = _get_workflow_with_uuid_or_name(
+                        workflow_id_or_name, str(user.id_)
+                    )
+                except ValueError:
+                    lock_paths = _deletion_workspace_paths(
+                        workflow_id_or_name, user, all_runs=True
+                    )
+                    with workspace_mutation_locks(lock_paths):
+                        response, http_response = set_controller_status()
+                else:
+                    with workflow_family_mutation_lock(
+                        workflow.owner_id, workflow.name
+                    ):
+                        # Creation takes the family lock before its row becomes
+                        # visible. Once held, this query is the closed set of
+                        # workspaces the controller can select, including a run
+                        # that becomes terminal before controller deletion.
+                        lock_paths = _deletion_workspace_paths(
+                            workflow_id_or_name, user, all_runs=True
+                        )
+                        with workspace_mutation_locks(lock_paths):
+                            response, http_response = set_controller_status()
+            else:
+                lock_paths = _deletion_workspace_paths(
+                    workflow_id_or_name, user, all_runs=False
+                )
+                with workspace_mutation_locks(lock_paths):
+                    response, http_response = set_controller_status()
+        else:
+            response, http_response = set_controller_status()
 
         return jsonify(response), http_response.status_code
+    except WorkspaceMutationConflict:
+        return (
+            jsonify({"message": "The workflow workspace is currently being modified."}),
+            409,
+        )
+    except WorkspaceMutationUnavailable:
+        return (
+            jsonify(
+                _internal_error_response(
+                    "Workspace mutation serialization is unavailable."
+                )
+            ),
+            503,
+        )
     except HTTPError as e:
         logging.error(traceback.format_exc())
         return jsonify(e.response.json()), e.response.status_code
+    except BravadoTimeoutError:
+        return jsonify({"message": "Workflow controller request timed out."}), 503
     except ValueError as e:
         logging.error(traceback.format_exc())
         return jsonify({"message": str(e)}), 403
@@ -1669,6 +3175,7 @@ def set_workflow_status(workflow_id_or_name, user, status, **parameters):  # noq
 @blueprint.route("/workflows/<workflow_id_or_name>/workspace", methods=["POST"])
 @signin_required()
 @check_quota
+@_serialize_workspace_mutation
 def upload_file(workflow_id_or_name, user):  # noqa
     r"""Upload file to workspace.
 
@@ -1762,6 +3269,18 @@ def upload_file(workflow_id_or_name, user):  # noqa
                 "message": "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does
                             not exist"
               }
+        409:
+          description: The workspace is currently being mutated.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        411:
+          description: A Content-Length header is required for streaming uploads.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        503:
+          description: Workspace mutation or controller service is unavailable.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         500:
           description: >-
             Request failed. Internal server error.
@@ -1781,7 +3300,7 @@ def upload_file(workflow_id_or_name, user):  # noqa
         filename = request.args.get("file_name")
         if not filename:
             return jsonify({"message": "No file_name provided"}), 400
-        if not ("application/octet-stream" in request.headers.get("Content-Type")):
+        if request.mimetype != "application/octet-stream":
             return (
                 jsonify(
                     {
@@ -1792,12 +3311,17 @@ def upload_file(workflow_id_or_name, user):  # noqa
                 ),
                 400,
             )
+        if request.content_length is None:
+            return jsonify({"message": "Content-Length header is required."}), 411
+        upload_stream = request.stream
+        upload_size = request.content_length
 
         if not workflow_id_or_name:
             raise ValueError("workflow_id_or_name is not supplied")
 
+        forwarded_stream = RequestStreamWithLen(upload_stream, upload_size)
         prevent_disk_quota_excess(
-            user, request.content_length, action=f"Uploading file {filename}"
+            user, len(forwarded_stream), action=f"Uploading file {filename}"
         )
         api_url = current_rwc_api_client.swagger_spec.__dict__.get("api_url")
         endpoint = current_rwc_api_client.api.upload_file.operation.path_name.format(
@@ -1805,9 +3329,13 @@ def upload_file(workflow_id_or_name, user):  # noqa
         )
         http_response = requests.post(
             urlparse.urljoin(api_url, endpoint),
-            data=RequestStreamWithLen(request.stream),
+            data=forwarded_stream,
             params={"user": str(user.id_), "file_name": request.args.get("file_name")},
             headers={"Content-Type": "application/octet-stream"},
+            timeout=(
+                RWC_MUTATION_CONNECT_TIMEOUT,
+                RWC_MUTATION_READ_TIMEOUT,
+            ),
         )
         return jsonify(http_response.json()), http_response.status_code
     except HTTPError as e:
@@ -1819,6 +3347,9 @@ def upload_file(workflow_id_or_name, user):  # noqa
     except (REANAQuotaExceededError, ValueError) as e:
         logging.error(traceback.format_exc())
         return jsonify({"message": str(e)}), 403
+    except requests.exceptions.RequestException:
+        logging.error(traceback.format_exc())
+        return jsonify({"message": "Workflow controller request failed."}), 503
     except Exception as e:
         logging.error(traceback.format_exc())
         return jsonify({"message": str(e)}), 500
@@ -1954,6 +3485,7 @@ def download_file(workflow_id_or_name, file_name, user):  # noqa
     "/workflows/<workflow_id_or_name>/workspace/<path:file_name>", methods=["DELETE"]
 )
 @signin_required()
+@_serialize_workspace_mutation
 def delete_file(workflow_id_or_name, file_name, user):  # noqa
     r"""Delete a file from the workspace.
 
@@ -2031,6 +3563,14 @@ def delete_file(workflow_id_or_name, file_name, user):  # noqa
               {
                 "message": "input.csv does not exist"
               }
+        409:
+          description: The workspace is currently being mutated.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        503:
+          description: Workspace mutation serialization is unavailable.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         500:
           description: >-
             Request failed. Internal server error.
@@ -2053,12 +3593,15 @@ def delete_file(workflow_id_or_name, file_name, user):  # noqa
             user=str(user.id_),
             workflow_id_or_name=workflow_id_or_name,
             file_name=file_name,
+            _request_options=_RWC_MUTATION_REQUEST_OPTIONS,
         ).result()
 
         return jsonify(http_response.json()), http_response.status_code
     except HTTPError as e:
         logging.error(traceback.format_exc())
         return jsonify(e.response.json()), e.response.status_code
+    except BravadoTimeoutError:
+        return jsonify({"message": "Workflow controller request timed out."}), 503
     except ValueError as e:
         logging.error(traceback.format_exc())
         return jsonify({"message": str(e)}), 403
@@ -2798,6 +4341,7 @@ def close_interactive_session(workflow_id_or_name, user):  # noqa
 
 @blueprint.route("/workflows/move_files/<workflow_id_or_name>", methods=["PUT"])
 @signin_required()
+@_serialize_workspace_mutation
 def move_files(workflow_id_or_name, user):  # noqa
     r"""Move files within workspace.
     ---
@@ -2908,6 +4452,10 @@ def move_files(workflow_id_or_name, user):  # noqa
               {
                 "message": "Path folder/ does not exist"
               }
+        503:
+          description: Workspace mutation serialization is unavailable.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         500:
           description: >-
             Request failed. Internal controller error.
@@ -2932,12 +4480,15 @@ def move_files(workflow_id_or_name, user):  # noqa
             workflow_id_or_name=workflow_id_or_name,
             source=source,
             target=target,
+            _request_options=_RWC_MUTATION_REQUEST_OPTIONS,
         ).result()
 
         return jsonify(response), http_response.status_code
     except HTTPError as e:
         logging.error(traceback.format_exc())
         return jsonify(e.response.json()), e.response.status_code
+    except BravadoTimeoutError:
+        return jsonify({"message": "Workflow controller request timed out."}), 503
     except ValueError as e:
         logging.error(traceback.format_exc())
         return jsonify({"message": str(e)}), 403
@@ -3263,6 +4814,7 @@ def get_workflow_retention_rules(workflow_id_or_name, user):
     unknown=marshmallow.EXCLUDE,
 )
 @signin_required()
+@_serialize_workspace_mutation
 def prune_workspace(
     workflow_id_or_name, user, include_inputs=False, include_outputs=False
 ):
@@ -3321,6 +4873,14 @@ def prune_workspace(
                 "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
                 "workflow_name": "mytest.1"
               }
+        409:
+          description: The workspace is currently being mutated.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        503:
+          description: Workspace mutation serialization is unavailable.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         400:
           description: >-
             Request failed. The incoming data specification seems malformed.

--- a/reana_server/specification_bundles.py
+++ b/reana_server/specification_bundles.py
@@ -1,0 +1,542 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Secure staging helpers for workflow specification snapshots."""
+
+import os
+import posixpath
+import shutil
+import stat
+import struct
+import uuid
+import zipfile
+from typing import Dict, Tuple
+
+from reana_commons.errors import (
+    REANASpecificationScopeError,
+    REANAValidationError,
+)
+from reana_commons.specification_paths import (
+    CANONICAL_REANA_SPECIFICATION,
+    SPECIFICATION_BUNDLE_MAX_DEPTH,
+    SPECIFICATION_BUNDLE_MAX_DIRECTORIES,
+    gather_validation_members,
+    gather_workspace_seed_members,
+    open_regular_file_beneath,
+)
+
+from reana_server.config import (
+    REANA_SPEC_BUNDLE_MAX_BYTES,
+    REANA_SPEC_BUNDLE_MAX_FILES,
+    REANA_SPEC_BUNDLE_MAX_PATH_BYTES,
+    SHARED_VOLUME_PATH,
+)
+
+VALIDATION_STAGING_SUBDIR = "validation-tmp"
+_COPY_CHUNK_SIZE = 1024 * 1024
+ZIP_MAXIMUM_CENTRAL_DIRECTORY_BYTES = 64 * 1024 * 1024
+_ZIP_EOCD = struct.Struct("<4s4H2LH")
+_ZIP64_LOCATOR = struct.Struct("<4sLQL")
+_ZIP_CENTRAL_DIRECTORY_ENTRY = struct.Struct("<4s6H3L5H2L")
+
+
+def preflight_zip_metadata(  # noqa: C901
+    stream,
+    maximum_entries: int,
+    maximum_central_directory_bytes: int = ZIP_MAXIMUM_CENTRAL_DIRECTORY_BYTES,
+) -> None:
+    """Reject excessive ZIP metadata before ``ZipFile`` materialises entries."""
+    original_position = stream.tell()
+    try:
+        stream.seek(0, os.SEEK_END)
+        archive_size = stream.tell()
+        tail_size = min(archive_size, _ZIP_EOCD.size + 65535)
+        stream.seek(archive_size - tail_size)
+        tail = stream.read(tail_size)
+        eocd_index = -1
+        search_end = len(tail)
+        while search_end:
+            candidate = tail.rfind(b"PK\x05\x06", 0, search_end)
+            if candidate < 0:
+                break
+            if len(tail) - candidate >= _ZIP_EOCD.size:
+                candidate_comment_size = _ZIP_EOCD.unpack_from(tail, candidate)[-1]
+                if candidate + _ZIP_EOCD.size + candidate_comment_size == len(tail):
+                    eocd_index = candidate
+                    break
+            search_end = candidate
+        if eocd_index < 0:
+            raise ValueError("ZIP end-of-central-directory record is missing")
+        eocd_offset = archive_size - tail_size + eocd_index
+        (
+            _signature,
+            disk_number,
+            directory_disk,
+            entries_on_disk,
+            entry_count,
+            directory_size,
+            directory_offset,
+            _comment_size,
+        ) = _ZIP_EOCD.unpack_from(tail, eocd_index)
+        if disk_number or directory_disk or entries_on_disk != entry_count:
+            raise ValueError("multi-disk ZIP archives are not supported")
+
+        locator_offset = eocd_offset - _ZIP64_LOCATOR.size
+        if locator_offset >= 0:
+            stream.seek(locator_offset)
+            if stream.read(4) == b"PK\x06\x07":
+                raise ValueError("ZIP64 archives are not supported")
+        if (
+            entry_count == 0xFFFF
+            or directory_size == 0xFFFFFFFF
+            or directory_offset == 0xFFFFFFFF
+        ):
+            raise ValueError("ZIP64 archives are not supported")
+
+        if entry_count > maximum_entries:
+            raise ValueError(
+                "ZIP archive contains too many entries (maximum is {})".format(
+                    maximum_entries
+                )
+            )
+        if directory_size > maximum_central_directory_bytes:
+            raise ValueError(
+                "ZIP central directory is too large (maximum is {} bytes)".format(
+                    maximum_central_directory_bytes
+                )
+            )
+        if directory_offset + directory_size != eocd_offset:
+            raise ValueError(
+                "ZIP central directory offset or size does not match the archive"
+            )
+
+        stream.seek(directory_offset)
+        consumed = 0
+        actual_entries = 0
+        while consumed < directory_size:
+            header = stream.read(_ZIP_CENTRAL_DIRECTORY_ENTRY.size)
+            if len(header) != _ZIP_CENTRAL_DIRECTORY_ENTRY.size:
+                raise ValueError("ZIP central directory entry is truncated")
+            (
+                signature,
+                _created_by,
+                _extract_version,
+                _flags,
+                _compression,
+                _modified_time,
+                _modified_date,
+                _crc,
+                compressed_size,
+                uncompressed_size,
+                filename_size,
+                extra_size,
+                comment_size,
+                entry_disk,
+                _internal_attributes,
+                _external_attributes,
+                local_header_offset,
+            ) = _ZIP_CENTRAL_DIRECTORY_ENTRY.unpack(header)
+            if signature != b"PK\x01\x02":
+                raise ValueError("ZIP central directory entry is malformed")
+            if entry_disk:
+                raise ValueError("multi-disk ZIP archives are not supported")
+            if (
+                compressed_size == 0xFFFFFFFF
+                or uncompressed_size == 0xFFFFFFFF
+                or local_header_offset == 0xFFFFFFFF
+            ):
+                raise ValueError("ZIP64 archives are not supported")
+            variable_size = filename_size + extra_size + comment_size
+            consumed += _ZIP_CENTRAL_DIRECTORY_ENTRY.size + variable_size
+            if consumed > directory_size:
+                raise ValueError(
+                    "ZIP central directory entry exceeds its declared size"
+                )
+            stream.seek(variable_size, os.SEEK_CUR)
+            actual_entries += 1
+            if actual_entries > maximum_entries:
+                raise ValueError(
+                    "ZIP archive contains too many entries (maximum is {})".format(
+                        maximum_entries
+                    )
+                )
+        if consumed != directory_size or actual_entries != entry_count:
+            raise ValueError(
+                "ZIP central directory entry count does not match metadata"
+            )
+    finally:
+        stream.seek(original_position)
+
+
+def _unsafe_archive_path(name: str) -> bool:
+    """Return whether an archive member name violates the POSIX path contract."""
+    if (
+        not name
+        or "\x00" in name
+        or "\\" in name
+        or name.startswith("/")
+        or (len(name) >= 2 and name[1] == ":")
+    ):
+        return True
+    normalized = posixpath.normpath(name)
+    return (
+        normalized in ("", ".", "..")
+        or normalized != name
+        or any(part in ("", ".", "..") for part in normalized.split("/"))
+    )
+
+
+def _regular_zip_member(info: zipfile.ZipInfo) -> bool:
+    """Whether ``info`` represents a regular file (or has no Unix type bits)."""
+    if info.is_dir():
+        return False
+    mode = (info.external_attr >> 16) & 0xFFFF
+    file_type = stat.S_IFMT(mode)
+    return file_type in (0, stat.S_IFREG)
+
+
+def _write_stream(destination: str, source, already_written: int) -> int:
+    """Write ``source`` exclusively without following links and enforce limits."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(destination, flags, 0o640)
+    os.fchmod(descriptor, 0o640)
+    total = already_written
+    try:
+        with os.fdopen(descriptor, "wb") as output:
+            while True:
+                chunk = source.read(_COPY_CHUNK_SIZE)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > REANA_SPEC_BUNDLE_MAX_BYTES:
+                    raise REANAValidationError(
+                        "Specification bundle is too large (maximum is {} bytes).".format(
+                            REANA_SPEC_BUNDLE_MAX_BYTES
+                        )
+                    )
+                output.write(chunk)
+    except Exception:
+        try:
+            os.unlink(destination)
+        except OSError:
+            pass
+        raise
+    return total
+
+
+def _fresh_staging_directory(
+    shared_volume_path: str = None,
+) -> Tuple[str, str]:
+    shared_volume_path = shared_volume_path or SHARED_VOLUME_PATH
+    staging_root = os.path.join(shared_volume_path, VALIDATION_STAGING_SUBDIR)
+    try:
+        os.mkdir(staging_root, mode=0o2750)
+    except FileExistsError:
+        mode = os.lstat(staging_root).st_mode
+        if stat.S_ISLNK(mode) or not stat.S_ISDIR(mode):
+            raise REANAValidationError(
+                "The validation staging root is not a regular directory."
+            )
+    # Preserve the shared-volume group on every descendant. This supports a
+    # non-default fsGroup without exposing snapshots to unrelated users.
+    os.chmod(staging_root, 0o2750)
+
+    identifier = uuid.uuid4().hex
+    relative_path = posixpath.join(VALIDATION_STAGING_SUBDIR, identifier)
+    absolute_path = os.path.join(staging_root, identifier)
+    os.mkdir(absolute_path, mode=0o2750)
+    os.chmod(absolute_path, 0o2750)
+    return absolute_path, relative_path
+
+
+def _validate_archive_entries(entries):
+    """Validate uploaded ZIP metadata and return unique member names."""
+    if not entries:
+        raise REANAValidationError("The specification bundle is empty.")
+    if len(entries) > REANA_SPEC_BUNDLE_MAX_FILES:
+        raise REANAValidationError(
+            "Specification bundle has too many files (maximum is {}).".format(
+                REANA_SPEC_BUNDLE_MAX_FILES
+            )
+        )
+
+    names = set()
+    directories = set()
+    declared_size = 0
+    for info in entries:
+        if _unsafe_archive_path(info.filename):
+            raise REANAValidationError("Unsafe bundle path: {}".format(info.filename))
+        if len(info.filename.encode("utf-8")) > REANA_SPEC_BUNDLE_MAX_PATH_BYTES:
+            raise REANAValidationError(
+                "Bundle path exceeds {} encoded bytes: {}".format(
+                    REANA_SPEC_BUNDLE_MAX_PATH_BYTES, info.filename
+                )
+            )
+        components = info.filename.split("/")
+        if len(components) > SPECIFICATION_BUNDLE_MAX_DEPTH:
+            raise REANAValidationError(
+                "Bundle path exceeds the maximum depth of {} components: {}".format(
+                    SPECIFICATION_BUNDLE_MAX_DEPTH, info.filename
+                )
+            )
+        for index in range(1, len(components)):
+            directories.add("/".join(components[:index]))
+            if len(directories) > SPECIFICATION_BUNDLE_MAX_DIRECTORIES:
+                raise REANAValidationError(
+                    "Specification bundle has too many directories "
+                    "(maximum is {}).".format(SPECIFICATION_BUNDLE_MAX_DIRECTORIES)
+                )
+        if info.filename in names:
+            raise REANAValidationError(
+                "Duplicate bundle path: {}".format(info.filename)
+            )
+        names.add(info.filename)
+        if info.flag_bits & 0x1:
+            raise REANAValidationError("Encrypted bundle entries are not supported.")
+        if info.compress_type != zipfile.ZIP_STORED:
+            raise REANAValidationError(
+                "Specification bundles must use uncompressed ZIP entries."
+            )
+        if not _regular_zip_member(info):
+            raise REANAValidationError(
+                "Only regular files are allowed in specification bundles: "
+                "{}".format(info.filename)
+            )
+        declared_size += info.file_size
+        if declared_size > REANA_SPEC_BUNDLE_MAX_BYTES:
+            raise REANAValidationError(
+                "Specification bundle is too large (maximum is {} bytes).".format(
+                    REANA_SPEC_BUNDLE_MAX_BYTES
+                )
+            )
+    for name in names:
+        components = name.split("/")
+        for index in range(1, len(components)):
+            parent = "/".join(components[:index])
+            if parent in names:
+                raise REANAValidationError(
+                    "Bundle path is nested below a regular file: {}".format(parent)
+                )
+    return names
+
+
+def _extract_archive_entries(archive, entries, absolute_path):
+    """Extract validated ZIP entries and return their cumulative bytes."""
+    total_bytes = 0
+    for info in entries:
+        destination = os.path.join(absolute_path, *info.filename.split("/"))
+        destination_directory = os.path.dirname(destination)
+        try:
+            os.makedirs(destination_directory, mode=0o2750, exist_ok=True)
+            os.chmod(destination_directory, 0o2750)
+            with archive.open(info, "r") as source:
+                before = total_bytes
+                total_bytes = _write_stream(destination, source, total_bytes)
+            if total_bytes - before != info.file_size:
+                raise REANAValidationError(
+                    "Bundle entry size changed while extracting: {}".format(
+                        info.filename
+                    )
+                )
+        except (OSError, EOFError, RuntimeError, zipfile.BadZipFile) as exc:
+            raise REANAValidationError(
+                "Could not extract bundle entry {}: {}".format(info.filename, exc)
+            )
+    return total_bytes
+
+
+def extract_uploaded_bundle(
+    storage, shared_volume_path: str = None
+) -> Tuple[str, str, int, bool]:
+    """Extract and validate one uploaded ``ZIP_STORED`` specification snapshot.
+
+    The archive must contain exactly the members selected by its own canonical
+    ``reana.yaml``. This makes the server, rather than the client, authoritative
+    for the validation scope.
+    """
+    absolute_path, relative_path = _fresh_staging_directory(shared_volume_path)
+    try:
+        storage.stream.seek(0)
+        try:
+            preflight_zip_metadata(storage.stream, REANA_SPEC_BUNDLE_MAX_FILES)
+            archive = zipfile.ZipFile(storage.stream, mode="r")
+        except (OSError, ValueError, zipfile.BadZipFile) as exc:
+            message = str(exc).replace(
+                "ZIP archive contains too many entries",
+                "Specification bundle has too many files",
+            )
+            raise REANAValidationError(
+                "The specification bundle is not a valid ZIP archive: {}".format(
+                    message
+                )
+            )
+
+        with archive:
+            entries = archive.infolist()
+            names = _validate_archive_entries(entries)
+            total_bytes = _extract_archive_entries(archive, entries, absolute_path)
+
+        specification_path = os.path.join(absolute_path, CANONICAL_REANA_SPECIFICATION)
+        if not os.path.isfile(specification_path):
+            raise REANAValidationError(
+                "The specification bundle must contain a top-level reana.yaml."
+            )
+        try:
+            selected, _specification, legacy_parameters = gather_validation_members(
+                specification_path
+            )
+        except REANASpecificationScopeError:
+            # Let the validation endpoint turn an unloadable specification into
+            # its structured ``load`` report.  There is no trustworthy declared
+            # scope in this case, so only the canonical file itself is allowed.
+            if names == {CANONICAL_REANA_SPECIFICATION}:
+                return absolute_path, relative_path, total_bytes, False
+            raise
+        selected_names = set(selected)
+        if names != selected_names:
+            unexpected = sorted(names - selected_names)
+            missing = sorted(selected_names - names)
+            details = []
+            if unexpected:
+                details.append("undeclared: {}".format(", ".join(unexpected)))
+            if missing:
+                details.append("missing: {}".format(", ".join(missing)))
+            raise REANAValidationError(
+                "Specification bundle does not match its declared validation "
+                "scope ({})".format("; ".join(details))
+            )
+        return absolute_path, relative_path, total_bytes, legacy_parameters
+    except Exception:
+        shutil.rmtree(absolute_path, ignore_errors=True)
+        raise
+
+
+def stage_validation_snapshot(
+    specification_path: str,
+    shared_volume_path: str = None,
+    source_base_directory: str = None,
+) -> Tuple[str, str, int, bool]:
+    """Copy the declared validation scope into a fresh shared staging directory."""
+    absolute_path, relative_path = _fresh_staging_directory(shared_volume_path)
+    total_bytes = 0
+    base_directory = source_base_directory or os.path.dirname(
+        os.path.abspath(specification_path)
+    )
+    base_directory = os.path.abspath(base_directory)
+    specification_directory = os.path.dirname(os.path.abspath(specification_path))
+    try:
+        staged_specification = os.path.join(
+            absolute_path, CANONICAL_REANA_SPECIFICATION
+        )
+        descriptor = open_regular_file_beneath(
+            specification_directory,
+            os.path.basename(os.path.abspath(specification_path)),
+            "REANA specification",
+        )
+        with os.fdopen(descriptor, "rb") as source:
+            total_bytes = _write_stream(staged_specification, source, total_bytes)
+
+        members, _specification, legacy_parameters = gather_validation_members(
+            staged_specification,
+            source_base_directory=base_directory,
+            selected_specification_name=os.path.basename(
+                os.path.abspath(specification_path)
+            ),
+        )
+        if len(members) > REANA_SPEC_BUNDLE_MAX_FILES:
+            raise REANAValidationError(
+                "Specification bundle has too many files (maximum is {}).".format(
+                    REANA_SPEC_BUNDLE_MAX_FILES
+                )
+            )
+        for member in sorted(members):
+            if member == CANONICAL_REANA_SPECIFICATION:
+                continue
+            destination = os.path.join(absolute_path, *member.split("/"))
+            destination_directory = os.path.dirname(destination)
+            os.makedirs(destination_directory, mode=0o2750, exist_ok=True)
+            os.chmod(destination_directory, 0o2750)
+            source_relative_path = os.path.relpath(
+                os.path.abspath(members[member]), base_directory
+            ).replace(os.sep, "/")
+            descriptor = open_regular_file_beneath(
+                base_directory, source_relative_path, "validation snapshot"
+            )
+            with os.fdopen(descriptor, "rb") as source:
+                total_bytes = _write_stream(destination, source, total_bytes)
+        return absolute_path, relative_path, total_bytes, legacy_parameters
+    except Exception:
+        shutil.rmtree(absolute_path, ignore_errors=True)
+        raise
+
+
+def workspace_seed_members(specification_path: str) -> Tuple[Dict[str, str], int]:
+    """Return the declared workspace seed and its exact current byte size."""
+    members, _specification, _legacy_parameters = gather_workspace_seed_members(
+        specification_path
+    )
+    base_directory = os.path.dirname(os.path.abspath(specification_path))
+    total = 0
+    for member in members:
+        source_relative_path = os.path.relpath(
+            os.path.abspath(members[member]), base_directory
+        ).replace(os.sep, "/")
+        descriptor = open_regular_file_beneath(
+            base_directory, source_relative_path, "workspace seed"
+        )
+        try:
+            total += os.fstat(descriptor).st_size
+        finally:
+            os.close(descriptor)
+    return members, total
+
+
+def seed_workspace(members: Dict[str, str], workspace_path: str) -> int:
+    """Copy a declared seed into an empty workspace without following links."""
+    os.makedirs(workspace_path, exist_ok=True)
+    specification_path = members.get(CANONICAL_REANA_SPECIFICATION)
+    if specification_path is None:
+        raise REANAValidationError("Workspace seed is missing canonical reana.yaml.")
+    base_directory = os.path.dirname(os.path.abspath(specification_path))
+    copied = 0
+    for member in sorted(members):
+        destination = os.path.join(workspace_path, *member.split("/"))
+        os.makedirs(os.path.dirname(destination), mode=0o700, exist_ok=True)
+        source_relative_path = os.path.relpath(
+            os.path.abspath(members[member]), base_directory
+        ).replace(os.sep, "/")
+        source_descriptor = open_regular_file_beneath(
+            base_directory, source_relative_path, "workspace seed"
+        )
+        destination_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            destination_flags |= os.O_NOFOLLOW
+        try:
+            destination_descriptor = os.open(destination, destination_flags, 0o600)
+        except Exception:
+            os.close(source_descriptor)
+            raise
+        try:
+            with os.fdopen(source_descriptor, "rb") as source, os.fdopen(
+                destination_descriptor, "wb"
+            ) as target:
+                while True:
+                    chunk = source.read(_COPY_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    copied += len(chunk)
+                    target.write(chunk)
+        except Exception:
+            try:
+                os.unlink(destination)
+            except OSError:
+                pass
+            raise
+    return copied

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -23,7 +23,6 @@ from typing import Dict, List, Optional, Tuple, Union
 from uuid import UUID, uuid4
 
 import click
-import yaml
 from flask import url_for
 from invenio_oauthclient.errors import OAuthClientUnAuthorized
 from jinja2 import Environment, PackageLoader, select_autoescape
@@ -37,7 +36,6 @@ from reana_commons.errors import (
     REANAEmailNotificationError,
 )
 from reana_commons.utils import get_dask_component_name, get_quota_resource_usage
-from reana_commons.yadage import yadage_load_from_workspace
 from reana_db.database import Session
 from reana_db.models import (
     ResourceType,
@@ -89,7 +87,7 @@ from reana_server.gitlab_client import (
     GitLabClient,
     GitLabClientException,
 )
-from reana_server.validation import validate_retention_rule, validate_workflow
+from reana_server.validation import validate_retention_rule, validate_loaded_spec
 
 
 def is_uuid_v4(uuid_or_name):
@@ -431,18 +429,6 @@ def serialize_utc_datetime(dt: Optional[datetime]) -> Optional[str]:
     return dt.isoformat() + "Z" if dt else None
 
 
-def _load_and_save_yadage_spec(workflow: Workflow, operational_options: Dict):
-    """Load and save in DB the Yadage workflow specification."""
-    operational_options.update({"accept_metadir": True})
-    toplevel = operational_options.get("toplevel", "")
-    workflow.reana_specification = yadage_load_from_workspace(
-        workflow.workspace_path,
-        workflow.reana_specification,
-        toplevel,
-    )
-    Session.commit()
-
-
 def _get_admin_user_or_raise(*, requested_via: str) -> User:
     """Return the configured admin user or raise on server misconfiguration."""
     admin = Session.query(User).filter_by(id_=ADMIN_USER_ID).one_or_none()
@@ -667,18 +653,21 @@ def _get_user_from_invenio_user(id):
 
 
 def _get_reana_yaml_from_gitlab(webhook_data, user_id):
-    reana_yaml = "reana.yaml"
+    """Return immutable GitLab source metadata from a workflow webhook.
+
+    The specification itself is loaded later from the bounded archive for the
+    exact commit SHA. Fetching ``reana.yaml`` separately from the moving branch
+    would introduce a race and duplicate the source of truth.
+    """
+    del user_id
     if webhook_data["object_kind"] == "push":
         branch = webhook_data["project"]["default_branch"]
         commit_sha = webhook_data["checkout_sha"]
     elif webhook_data["object_kind"] == "merge_request":
         branch = webhook_data["object_attributes"]["source_branch"]
         commit_sha = webhook_data["object_attributes"]["last_commit"]["id"]
-    project_id = webhook_data["project"]["id"]
-    gitlab_client = GitLabClient.from_k8s_secret(user_id)
-    yaml_file = gitlab_client.get_file(project_id, reana_yaml, branch).content
     return (
-        yaml.safe_load(yaml_file),
+        None,
         webhook_data["project"]["path_with_namespace"],
         webhook_data["project"]["name"],
         branch,
@@ -735,7 +724,7 @@ def _get_gitlab_hook_id(project_id, gitlab_client: GitLabClient):
 
 
 class RequestStreamWithLen(object):
-    """Wrap ``request.stream`` object to have ``__len__`` attribute.
+    """Wrap a request stream to have an exact ``__len__`` attribute.
 
     Users can upload files to REANA through REANA-Server (RS). RS passes then
     the content of the file uploads to the next REANA component,
@@ -754,16 +743,26 @@ class RequestStreamWithLen(object):
     Requests stream upload.
     """
 
-    def __init__(self, limitedstream):
-        """Wrap the stream to have ``len``."""
+    def __init__(self, limitedstream, content_length=None):
+        """Wrap the stream to have ``len``.
+
+        :param limitedstream: Stream to expose to Requests.
+        :param content_length: Optional exact number of bytes remaining in the
+            stream. Multipart uploads use a seekable Werkzeug temporary stream
+            which does not expose the ``limit`` attribute used by
+            ``request.stream``.
+        """
         self.limitedstream = limitedstream
+        self.content_length = content_length
 
     def read(self, *args, **kwargs):
         """Expose ``request.stream``s read method."""
         return self.limitedstream.read(*args, **kwargs)
 
     def __len__(self):
-        """Expose the length of the ``request.stream``."""
+        """Expose the exact number of bytes forwarded to the controller."""
+        if self.content_length is not None:
+            return self.content_length
         if not hasattr(self.limitedstream, "limit"):
             return 0
         return self.limitedstream.limit
@@ -831,10 +830,11 @@ def ensure_dask_service(workflow: Workflow) -> bool:
     return True
 
 
-def clone_workflow(workflow, reana_spec, restart_type):
+def clone_workflow(workflow, reana_spec, restart_type, validate_spec=True):
     """Create a copy of workflow in DB for restarting."""
     reana_specification = reana_spec or workflow.reana_specification
-    validate_workflow(reana_specification, input_parameters={})
+    if validate_spec:
+        validate_loaded_spec(reana_specification)
 
     retention_days = reana_specification.get("workspace", {}).get("retention_days")
     retention_rules = get_workspace_retention_rules(retention_days)
@@ -853,15 +853,24 @@ def clone_workflow(workflow, reana_spec, restart_type):
         if workflow_uses_dask(reana_specification):
             cloned_workflow.services.append(build_dask_service(cloned_workflow))
         Session.add(cloned_workflow)
-        Session.object_session(cloned_workflow).commit()
-        workflow.inactivate_workspace_retention_rules()
-        cloned_workflow.set_workspace_retention_rules(retention_rules)
+        workflow.inactivate_workspace_retention_rules(commit=False)
+        cloned_workflow.set_workspace_retention_rules(retention_rules, commit=False)
+        Session.commit()
         return cloned_workflow
     except SQLAlchemyError as e:
+        Session.rollback()
         message = "Database connection failed, please retry."
         logging.error(
-            f"Error while creating {cloned_workflow.id_}: {message}\n{e}", exc_info=True
+            f"Error while creating a restart of workflow {workflow.id_}: "
+            f"{message}\n{e}",
+            exc_info=True,
         )
+        # Re-raise so callers never receive ``None`` (which would surface as an
+        # opaque AttributeError/500); this maps to a 500 with a retry hint.
+        raise RuntimeError(message) from e
+    except Exception:
+        Session.rollback()
+        raise
 
 
 def _get_user_by_criteria(id_: Optional[str], email: Optional[str]) -> Optional[User]:

--- a/reana_server/validation.py
+++ b/reana_server/validation.py
@@ -8,20 +8,45 @@
 
 """REANA Server validation utilities."""
 
-import itertools
-import pathlib
-from typing import Dict, List
+import logging
+import os
+from typing import Dict, List, Optional, Tuple
 
-from reana_commons.config import WORKSPACE_PATHS
-from reana_commons.validation.images import extract_images
+import requests
+import yaml
+
+from reana_commons.config import (
+    OPENAPI_SPECS,
+    SHARED_VOLUME_PATH,
+    WORKFLOW_RUNTIME_USER_GID,
+    WORKFLOW_RUNTIME_USER_UID,
+    WORKSPACE_PATHS,
+)
 from reana_commons.errors import REANAValidationError
-from reana_commons.validation.compute_backends import build_compute_backends_validator
-from reana_commons.validation.operational_options import validate_operational_options
-from reana_commons.validation.parameters import build_parameters_validator
-from reana_commons.validation.utils import validate_reana_yaml, validate_workspace
-from reana_commons.job_utils import kubernetes_memory_to_bytes
+from reana_commons.specification_paths import (
+    uses_legacy_validation_scope,
+    workflow_parameter_file,
+)
+from reana_commons.validation.environments import check_environment_tags
+from reana_commons.validation.images import extract_image_environments, extract_images
+from reana_commons.validation.report import (
+    MAX_VALIDATION_REPORT_ENTRIES,
+    validate_serialized_spec,
+)
+from reana_commons.validation.sandbox import (
+    ERROR_CODE_INTERNAL,
+    EXIT_INTERNAL_ERROR,
+    EXIT_LOAD_ERROR,
+    EXIT_LOADED,
+    REANA_SPEC_FILENAMES,
+)
+from reana_commons.validation.utils import (
+    bound_error_message,
+    validate_retention_rule as _validate_retention_rule,
+)
 
 from reana_server.config import (
+    REANA_SPEC_VALIDATION_TIMEOUT,
     SUPPORTED_COMPUTE_BACKENDS,
     WORKSPACE_RETENTION_PERIOD,
     DASK_ENABLED,
@@ -34,43 +59,6 @@ from reana_server.config import (
     REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_THREADS,
     REANA_VETTED_CONTAINER_IMAGES,
 )
-
-
-def validate_parameters(reana_yaml: Dict) -> None:
-    """Validate the presence of input parameters in workflow step commands and viceversa.
-
-    :param reana_yaml: REANA YAML specification.
-
-    :raises REANAValidationError: Given there are parameter validation errors in REANA spec file.
-    """
-    validator = build_parameters_validator(reana_yaml)
-    validator.validate_parameters()
-
-
-def validate_workspace_path(reana_yaml: Dict) -> None:
-    """Validate workspace in REANA specification file.
-
-    :param reana_yaml: REANA YAML specification.
-
-    :raises REANAValidationError: Given workspace in REANA spec file does not validate against
-        allowed workspaces.
-    """
-    root_path = reana_yaml.get("workspace", {}).get("root_path")
-    if root_path:
-        available_paths = list(WORKSPACE_PATHS.values())
-        validate_workspace(root_path, available_paths)
-
-
-def validate_compute_backends(reana_yaml: Dict) -> None:
-    """Validate compute backends in REANA specification file according to workflow type.
-
-    :param reana_yaml: dictionary which represents REANA specification file.
-
-    :raises REANAValidationError: Given compute backend specified in REANA spec file does not validate against
-        supported compute backends.
-    """
-    validator = build_compute_backends_validator(reana_yaml, SUPPORTED_COMPUTE_BACKENDS)
-    validator.validate()
 
 
 def validate_input_parameters(
@@ -91,71 +79,27 @@ def validate_input_parameters(
     return input_parameters
 
 
-def validate_inputs(reana_yaml: Dict) -> None:
-    """Check whether the paths of the input files/directories are valid or not.
+def validate_loaded_spec(reana_spec: Dict) -> List[Dict]:
+    """Validate an already fully-loaded REANA specification.
 
-    :param reana_yaml: REANA specification.
+    This is the thin in-process counterpart to :func:`load_and_validate_spec`
+    for paths that already hold a *trusted*, fully-loaded specification (workflow
+    loaded + input parameters resolved) and therefore do not need to load any
+    untrusted bundle -- e.g. clone/restart from the stored specification. It runs
+    the single shared validator
+    (:func:`reana_commons.validation.report.validate_serialized_spec`) against the
+    cluster validation policy.
+
+    :param reana_spec: A fully-loaded REANA specification dictionary.
+    :returns: The list of advisory validation warnings.
+    :raises reana_commons.errors.REANAValidationError: if the specification is
+        invalid.
     """
-    inputs = reana_yaml.get("inputs", {})
-    files = inputs.get("files", [])
-    directories = inputs.get("directories", [])
-    paths = [pathlib.Path(path) for path in files + directories]
-
-    unique_paths = set()
-    for path in paths:
-        if path.is_absolute():
-            raise REANAValidationError(f"Input path cannot be absolute: {path}")
-        if not path.parts:
-            raise REANAValidationError("Input path cannot be empty")
-        if ".." in path.parts:
-            raise REANAValidationError(f"Input path cannot contain '..': {path}")
-        if path in unique_paths:
-            raise REANAValidationError(f"Input path declared multiple times: {path}")
-        unique_paths.add(path)
-
-    from reana_server import utils
-
-    for x, y in itertools.permutations(paths, r=2):
-        if utils.is_relative_to(x, y):
-            raise REANAValidationError(
-                f"Duplicate input paths '{y}' and '{x}' found. Please deduplicate inputs first."
-            )
-
-
-def validate_images(reana_yaml: Dict) -> None:
-    """Check whether the images used in the workflow are allowed or not.
-
-    :param reana_yaml: REANA specification.
-    """
-    if not REANA_VETTED_CONTAINER_IMAGES["enabled"]:
-        return
-
-    allowed_images = REANA_VETTED_CONTAINER_IMAGES["allowlist"]
-    for image in extract_images(reana_yaml):
-        if image and image not in allowed_images:
-            raise REANAValidationError(f"Image not allowed: {image}")
-
-
-def validate_workflow(reana_yaml: Dict, input_parameters: Dict) -> Dict:
-    """Validate REANA workflow specification by calling all the validation utilities.
-
-    :param reana_yaml: dictionary which represents REANA specification file.
-    :param input_parameters: dictionary which represents additional workflow input parameters.
-
-    :raises REANAValidationError: Given there are validation errors in REANA spec file.
-    """
-    workflow_type = reana_yaml["workflow"]["type"]
-    operational_options = reana_yaml.get("inputs", {}).get("options", {})
-    original_parameters = reana_yaml.get("inputs", {}).get("parameters", {})
-
-    reana_yaml_warnings = validate_reana_yaml(reana_yaml)
-    validate_operational_options(workflow_type, operational_options)
-    validate_input_parameters(input_parameters, original_parameters)
-    validate_compute_backends(reana_yaml)
-    validate_workspace_path(reana_yaml)
-    validate_inputs(reana_yaml)
-    validate_images(reana_yaml)
-    return reana_yaml_warnings
+    report = validate_serialized_spec(reana_spec, build_validation_policy())
+    if not report["valid"]:
+        message = "; ".join(e.get("message", "") for e in report.get("errors", []))
+        raise REANAValidationError(message or "Invalid workflow specification.")
+    return report.get("warnings", [])
 
 
 def validate_retention_rule(rule: str, days: int) -> None:
@@ -169,71 +113,405 @@ def validate_retention_rule(rule: str, days: int) -> None:
 
     :raises reana_commons.errors.REANAValidationError: if rule is not valid
     """
-    rule_path = pathlib.Path(rule)
-    if rule_path.is_absolute():
-        raise REANAValidationError(f"Retention rule {rule} cannot be an absolute path")
-    if not rule_path.parts:
-        raise REANAValidationError(f"Retention rule {rule} cannot be empty")
-    if ".." in rule_path.parts:
-        raise REANAValidationError(f"Retention rule {rule} cannot contain '..'")
+    _validate_retention_rule(
+        rule, days, max_retention_period=WORKSPACE_RETENTION_PERIOD
+    )
 
-    default_retention_rules_are_not_disabled = WORKSPACE_RETENTION_PERIOD is not None
-    if default_retention_rules_are_not_disabled and days >= WORKSPACE_RETENTION_PERIOD:
+
+def list_spec_image_environments(reana_spec: Dict) -> List[Dict]:
+    """Return distinct runtime image and effective UID/GID combinations."""
+    try:
+        return extract_image_environments(
+            reana_spec,
+            int(WORKFLOW_RUNTIME_USER_UID),
+            int(WORKFLOW_RUNTIME_USER_GID),
+        )
+    except Exception as e:
+        logging.warning(
+            "Could not extract image runtime identities from the specification: %s",
+            e,
+        )
+        return []
+
+
+def check_spec_environment_tags(reana_spec: Dict) -> List[Dict]:
+    """Return offline image-tag warnings for a loaded specification.
+
+    Returns advisory warning entries (``{code, message, path}``) ready to append
+    to a validation report's ``warnings``. Registry availability and image
+    filesystem checks run only through the client's explicit ``--pull`` option.
+    """
+    try:
+        images = extract_images(reana_spec)
+    except Exception as e:
+        logging.warning("Could not extract images for environment check: %s", e)
+        return []
+    findings = check_environment_tags(images)
+    return [
+        {"code": f["code"], "message": f["message"], "path": f["image"]}
+        for f in findings
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Server-side spec loading + validation orchestration
+#
+# These power the "raw spec bundle" flow used by thin clients (e.g. the Go
+# client) that cannot run the workflow engines themselves. The bundle (raw
+# reana.yaml + referenced workflow/config files) is staged on the shared volume;
+# serial specs are loaded + validated in-process (loading serial is pure), while
+# Snakemake/CWL/Yadage specs -- whose loading executes untrusted code -- are sent
+# to reana-workflow-controller, which runs the sandboxed validator Job.
+# ---------------------------------------------------------------------------
+
+
+def build_validation_policy() -> Dict:
+    """Build the cluster validation policy passed to the shared validator.
+
+    The same dict shape is consumed by
+    :func:`reana_commons.validation.report.validate_serialized_spec` (in-process,
+    for serial) and injected into the sandbox Job (for non-serial).
+    """
+    return {
+        "vetted_images_enabled": REANA_VETTED_CONTAINER_IMAGES["enabled"],
+        "vetted_images_allowlist": list(REANA_VETTED_CONTAINER_IMAGES["allowlist"]),
+        "supported_backends": SUPPORTED_COMPUTE_BACKENDS,
+        "workspace_paths": list(WORKSPACE_PATHS.values()),
+        "dask_config": {
+            "enabled": DASK_ENABLED,
+            "max_memory_limit": REANA_DASK_CLUSTER_MAX_MEMORY_LIMIT,
+            "default_number_of_workers": REANA_DASK_CLUSTER_DEFAULT_NUMBER_OF_WORKERS,
+            "max_number_of_workers": REANA_DASK_CLUSTER_MAX_NUMBER_OF_WORKERS,
+            "default_single_worker_memory": REANA_DASK_CLUSTER_DEFAULT_SINGLE_WORKER_MEMORY,
+            "max_single_worker_memory": REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_MEMORY,
+            "default_single_worker_threads": REANA_DASK_CLUSTER_DEFAULT_SINGLE_WORKER_THREADS,
+            "max_single_worker_threads": REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_THREADS,
+        },
+        "max_retention_period": WORKSPACE_RETENTION_PERIOD,
+    }
+
+
+def _find_reana_yaml(bundle_dir: str) -> str:
+    """Return the path to the REANA specification file in a bundle directory."""
+    for name in REANA_SPEC_FILENAMES:
+        candidate = os.path.join(bundle_dir, name)
+        if os.path.isfile(candidate):
+            return candidate
+    raise REANAValidationError(
+        "No REANA specification file ({}) found in the uploaded bundle.".format(
+            " or ".join(REANA_SPEC_FILENAMES)
+        )
+    )
+
+
+def has_reana_spec_file(workspace_path: str) -> bool:
+    """Whether a workspace directory contains a ``reana.yaml``/``reana.yml``.
+
+    Used by the start gate to decide between re-loading the workspace
+    (workspace-authoritative) and falling back to the stored specification:
+    launched workflows have their spec file stripped by ``filter_input_files``
+    and legacy (pre-seeding) workflows never had one seeded.
+    """
+    return any(
+        os.path.lexists(os.path.join(workspace_path, name))
+        for name in REANA_SPEC_FILENAMES
+    )
+
+
+class SpecValidationServiceError(Exception):
+    """The validation *service* failed -- the validator could not run.
+
+    Distinct from an invalid specification: this means the sandbox/controller
+    could not do its job (controller unreachable, controller 5xx, or the sandbox
+    exited with the internal-error code 2), so it must surface as a server-side
+    error (HTTP 500), not a "bad specification" (HTTP 400).
+    """
+
+
+def _call_rwc_validate(
+    bundle_rel_path: str, timeout: Optional[int] = None
+) -> Tuple[Optional[int], Dict]:
+    """Ask reana-workflow-controller to load a spec in the sandbox.
+
+    The sandbox is a pure loader and applies no policy, so none is sent; the
+    server validates the returned specification itself.
+
+    :param bundle_rel_path: Bundle path relative to the shared volume root.
+    :returns: ``(exit_code, report)`` from the sandbox, where ``report`` is
+        ``{reana_specification, error}``.
+    :raises SpecValidationServiceError: if the validation service itself fails
+        (controller unreachable or a non-OK controller response). This is a
+        service outage, not an invalid specification.
+    """
+    rwc_url = OPENAPI_SPECS["reana-workflow-controller"][0]
+    try:
+        response = requests.post(
+            "{}/api/workflows/validate".format(rwc_url),
+            json={
+                "bundle_path": bundle_rel_path,
+                "timeout": timeout,
+            },
+            # Safety net so a stuck controller cannot hang the request forever;
+            # the real bound is the sandbox Job's activeDeadlineSeconds. The read
+            # timeout is derived from REANA_SPEC_VALIDATION_TIMEOUT (the shared
+            # sandbox deadline) with a buffer above the controller's own
+            # ``timeout + 60`` wait, so the server never gives up first.
+            timeout=(10, REANA_SPEC_VALIDATION_TIMEOUT + 120),
+        )
+    except requests.exceptions.RequestException as e:
+        logging.error("Could not reach the spec validation service: %s", e)
+        raise SpecValidationServiceError(
+            "Could not reach the workflow specification validation service."
+        )
+    if not response.ok:
+        message = "Workflow specification validation service error."
+        try:
+            payload = response.json()
+            if isinstance(payload, dict):
+                message = payload.get("message", message)
+        except ValueError:
+            pass
+        raise SpecValidationServiceError(message)
+    # A 200 with a non-JSON body or without a ``report`` key is still a service
+    # failure (a misbehaving controller), not an invalid specification: classify
+    # it as such so callers surface a clean 500 rather than an opaque one.
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+    if (
+        not isinstance(payload, dict)
+        or "report" not in payload
+        or not isinstance(payload["report"], dict)
+    ):
+        raise SpecValidationServiceError(
+            "Workflow specification validation service returned a malformed response."
+        )
+    return payload.get("exit_code"), payload["report"]
+
+
+def _load_error_report(message: str) -> Dict:
+    """Build the standard "specification could not be loaded" invalid report.
+
+    Shared by the in-process serial path and the sandbox path so a spec that
+    fails to load produces an identical structured (``code == "load"``) report --
+    and hence the same HTTP 400 + message -- regardless of engine.
+    """
+    return {
+        "valid": False,
+        "reana_specification": None,
+        "errors": [{"code": "load", "message": message, "path": ""}],
+        "warnings": [],
+    }
+
+
+def load_raw_spec_mapping(bundle_dir: str) -> Dict:
+    """Safely load the bundle's top-level REANA YAML mapping.
+
+    This preliminary parse is used only to discover the workflow type and to
+    bind restart payloads to the canonical workspace specification. YAML syntax
+    failures and non-mapping top-level values are ordinary user specification
+    errors, never validation-service failures.
+
+    :raises REANAValidationError: if the YAML is malformed or not a mapping.
+    """
+    reana_yaml_path = _find_reana_yaml(bundle_dir)
+    try:
+        with open(reana_yaml_path) as spec_file:
+            raw_yaml = yaml.safe_load(spec_file)
+    except (OSError, yaml.YAMLError) as e:
         raise REANAValidationError(
-            "Maximum workflow retention period was reached. "
-            f"Please use less than {WORKSPACE_RETENTION_PERIOD} days."
-        )
-
-
-def validate_dask_limits(reana_yaml: Dict) -> None:
-    """Validate Dask workflows are allowed in the cluster and memory limits are respected."""
-    # Validate Dask workflows are allowed in the cluster
-    dask_resources = reana_yaml["workflow"].get("resources", {}).get("dask", {})
-    if not DASK_ENABLED and dask_resources != {}:
-        raise REANAValidationError("Dask workflows are not allowed in this cluster.")
-
-    # Validate Dask memory limit requested by the workflow
-    if dask_resources:
-        single_worker_memory = dask_resources.get(
-            "single_worker_memory", REANA_DASK_CLUSTER_DEFAULT_SINGLE_WORKER_MEMORY
-        )
-        if kubernetes_memory_to_bytes(
-            single_worker_memory
-        ) > kubernetes_memory_to_bytes(REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_MEMORY):
-            raise REANAValidationError(
-                f'The "single_worker_memory" provided in the dask resources exceeds the limit ({REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_MEMORY}).'
-            )
-
-        number_of_workers = int(
-            dask_resources.get(
-                "number_of_workers", REANA_DASK_CLUSTER_DEFAULT_NUMBER_OF_WORKERS
+            "Could not load the REANA specification YAML: {}".format(
+                bound_error_message(e)
             )
         )
+    if not isinstance(raw_yaml, dict):
+        raise REANAValidationError(
+            "The REANA specification must be a YAML mapping at the top level."
+        )
+    workflow = raw_yaml.get("workflow")
+    if workflow is not None and not isinstance(workflow, dict):
+        raise REANAValidationError(
+            "The REANA specification 'workflow' field must be a mapping."
+        )
+    return raw_yaml
 
-        if number_of_workers > REANA_DASK_CLUSTER_MAX_NUMBER_OF_WORKERS:
-            raise REANAValidationError(
-                f"The number of requested Dask workers ({number_of_workers}) exceeds the maximum limit ({REANA_DASK_CLUSTER_MAX_NUMBER_OF_WORKERS})."
-            )
 
-        single_worker_threads = dask_resources.get(
-            "single_worker_threads",
-            REANA_DASK_CLUSTER_DEFAULT_SINGLE_WORKER_THREADS,
+def _authoritative_report(report: Dict, exit_code: Optional[int], policy: Dict) -> Dict:
+    """Decide valid/invalid server-side from a sandbox *loader* report.
+
+    The sandbox only loads (running untrusted code) and returns the serialized
+    ``reana_specification`` -- it computes no verdict, so there is nothing to
+    trust or forge. We run the *pure*, code-execution-free policy validator
+    (:func:`reana_commons.validation.report.validate_serialized_spec`) on that
+    candidate in-process; that in-process result is the authoritative decision.
+
+    The sandbox report is ``{reana_specification, error}`` and the exit code
+    classifies the loading outcome (0 loaded, 1 load error, 2 internal).
+
+    :raises SpecValidationServiceError: on an infrastructure failure (sandbox
+        exit code 2 or an ``internal``-coded error), which is not a spec problem.
+    """
+    error = report.get("error") or {}
+    candidate = report.get("reana_specification")
+
+    if error.get("code") == ERROR_CODE_INTERNAL:
+        raise SpecValidationServiceError(
+            error.get("message") or "internal validation error"
         )
 
-        if single_worker_threads > REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_THREADS:
-            raise REANAValidationError(
-                f'The "single_worker_threads" provided in the dask resources exceeds the limit ({REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_THREADS}).'
-            )
-
-        requested_dask_cluster_memory = (
-            kubernetes_memory_to_bytes(single_worker_memory) * number_of_workers
+    if type(exit_code) is not int or exit_code not in (
+        EXIT_LOADED,
+        EXIT_LOAD_ERROR,
+        EXIT_INTERNAL_ERROR,
+    ):
+        raise SpecValidationServiceError(
+            "Unexpected workflow specification validator exit code."
         )
 
-        if requested_dask_cluster_memory > kubernetes_memory_to_bytes(
-            REANA_DASK_CLUSTER_MAX_MEMORY_LIMIT
+    if exit_code == EXIT_INTERNAL_ERROR:
+        raise SpecValidationServiceError(
+            error.get("message") or "internal validation error"
+        )
+
+    if exit_code == EXIT_LOAD_ERROR:
+        if candidate:
+            raise SpecValidationServiceError(
+                "Workflow specification validator returned a candidate for a "
+                "failed load."
+            )
+        # The specification could not be loaded at all (e.g. a Snakefile that
+        # fails to parse). That is a user-facing validation error, not a service
+        # failure -- report it as invalid, surfacing the loader message. The
+        # sandbox already bounds it, but re-bound here defensively: the message
+        # comes from untrusted-code execution and the server never trusts the
+        # sandbox to have kept it small.
+        return _load_error_report(bound_error_message(error.get("message") or ""))
+
+    if not candidate:
+        raise SpecValidationServiceError(
+            "Workflow specification validator reported a successful load without "
+            "a candidate specification."
+        )
+
+    # Authoritative validation in-process (pure, no code execution).
+    authoritative = validate_serialized_spec(candidate, policy)
+    authoritative["reana_specification"] = candidate
+    return authoritative
+
+
+def _add_legacy_scope_warnings(report, legacy_parameter_file, legacy_scope):
+    """Add bounded migration warnings for legacy validation declarations."""
+    warnings = report.setdefault("warnings", [])
+    findings = []
+    if legacy_parameter_file:
+        findings.append(
+            {
+                "code": "deprecated_parameters_input",
+                "message": (
+                    "inputs.parameters.input is deprecated; use "
+                    "workflow.parameters.file instead."
+                ),
+                "path": "inputs.parameters.input",
+            }
+        )
+    if legacy_scope:
+        findings.append(
+            {
+                "code": "deprecated_input_workflow_sources",
+                "message": (
+                    "Legacy inputs.files or inputs.directories were included in "
+                    "validation; declare loader dependencies under workflow.files "
+                    "or workflow.directories instead."
+                ),
+                "path": "inputs",
+            }
+        )
+    for finding in findings:
+        if len(report.get("errors", [])) + len(warnings) >= (
+            MAX_VALIDATION_REPORT_ENTRIES
         ):
-            raise REANAValidationError(
-                f'The "memory" requested in the dask resources exceeds the limit ({REANA_DASK_CLUSTER_MAX_MEMORY_LIMIT}).\nDecrease the number of workers requested or amount of memory consumed by a single worker.'
-            )
+            break
+        warnings.append(finding)
 
-    return None
+
+def validate_spec_bundle(bundle_dir: str, bundle_rel_path: str) -> Dict:
+    """Load and validate a raw spec bundle, returning a structured report.
+
+    Loading is done in-process for serial specs (pure dictionary manipulation)
+    and in the sandboxed loader Job spawned by reana-workflow-controller for
+    Snakemake/CWL/Yadage (because it executes untrusted code). In *both* cases
+    the policy validation is applied in-process here -- the sandbox only loads;
+    see :func:`_authoritative_report`.
+
+    :param bundle_dir: Absolute path of the staged bundle on the shared volume.
+    :param bundle_rel_path: Bundle path relative to the shared volume root.
+    :returns: Report dict ``{valid, reana_specification, errors, warnings}``.
+    :raises SpecValidationServiceError: if the validation service itself failed.
+    """
+    try:
+        raw_yaml = load_raw_spec_mapping(bundle_dir)
+    except REANAValidationError as e:
+        return _load_error_report(bound_error_message(e))
+    try:
+        _parameter_file, legacy_parameter_file = workflow_parameter_file(raw_yaml)
+    except REANAValidationError as e:
+        return _load_error_report(bound_error_message(e))
+
+    workflow = raw_yaml.get("workflow") or {}
+    workflow_type = workflow.get("type") if isinstance(workflow, dict) else None
+    legacy_scope = uses_legacy_validation_scope(raw_yaml)
+    policy = build_validation_policy()
+
+    if workflow_type == "serial":
+        # Safe to do in-process: serial loading does not execute user code.
+        from reana_commons.specification import load_reana_spec
+
+        try:
+            reana_yaml = load_reana_spec(
+                _find_reana_yaml(bundle_dir), workspace_path=bundle_dir
+            )
+        except Exception as e:
+            # A serial spec that fails to load is a user-facing validation error,
+            # not a service failure -- report it as invalid with the same bounded
+            # "load" message shape as the sandbox path (rather than letting it
+            # bubble up as a 500).
+            return _load_error_report(bound_error_message(e))
+        report = validate_serialized_spec(reana_yaml, policy)
+        report["reana_specification"] = reana_yaml
+        _add_legacy_scope_warnings(report, legacy_parameter_file, legacy_scope)
+        return report
+
+    exit_code, report = _call_rwc_validate(bundle_rel_path)
+    authoritative = _authoritative_report(report, exit_code, policy)
+    _add_legacy_scope_warnings(authoritative, legacy_parameter_file, legacy_scope)
+    return authoritative
+
+
+def load_and_validate_spec(bundle_dir: str) -> Tuple[Dict, List[Dict]]:
+    """Load and validate a raw spec bundle, returning the authoritative spec.
+
+    This is the single chokepoint for every server-side path that must load an
+    *untrusted* workflow specification (raw-bundle create, launch, GitLab).
+    Loading is done in-process for serial workflows and inside the sandboxed
+    validator Job for Snakemake/CWL/Yadage, so the API process never executes
+    untrusted workflow code. The valid/invalid decision is always made
+    server-side (the sandbox is only a loader). Invalid specs raise immediately
+    (fail early).
+
+    :param bundle_dir: Absolute path of the staged bundle on the shared volume.
+    :returns: ``(reana_specification, warnings)`` where ``reana_specification``
+        is the fully loaded spec (workflow loaded + input parameters resolved).
+    :raises REANAValidationError: if the bundle is missing a reana.yaml or the
+        specification is invalid.
+    :raises SpecValidationServiceError: if the validation service itself failed
+        (the validator could not run, as opposed to the spec being invalid).
+    """
+    bundle_rel_path = os.path.relpath(bundle_dir, SHARED_VOLUME_PATH)
+    report = validate_spec_bundle(bundle_dir, bundle_rel_path)
+
+    if not report.get("valid"):
+        message = "; ".join(e.get("message", "") for e in report.get("errors", []))
+        raise REANAValidationError(message or "Invalid workflow specification.")
+
+    return report["reana_specification"], report.get("warnings", [])

--- a/reana_server/workflow_creation.py
+++ b/reana_server/workflow_creation.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Reconcile ambiguous workflow-controller creation failures."""
+
+import logging
+import os
+import time
+
+from bravado.exception import HTTPError
+
+from reana_db.database import Session
+from reana_db.models import Workflow
+
+_CREATION_RECONCILIATION_TIMEOUT = 1.0
+_CREATION_RECONCILIATION_INTERVAL = 0.1
+
+
+def _find_created_workflow(workflow_uuid, user_id):
+    """Return the freshly committed workflow, bypassing stale ORM state."""
+    Session.rollback()
+    return (
+        Session.query(Workflow)
+        .filter(Workflow.id_ == workflow_uuid, Workflow.owner_id == user_id)
+        .first()
+    )
+
+
+def _reconcile_failed_creation(
+    workflow_uuid,
+    user_id,
+    workspace_path,
+    compensate,
+    wait_for_commit,
+):
+    """Compensate a controller-created row while its server lock is held."""
+    deadline = time.monotonic() + (
+        _CREATION_RECONCILIATION_TIMEOUT if wait_for_commit else 0
+    )
+    while True:
+        workflow = _find_created_workflow(workflow_uuid, user_id)
+        if workflow is not None:
+            if os.path.abspath(workflow.workspace_path) != os.path.abspath(
+                workspace_path
+            ):
+                logging.error(
+                    "Controller created workflow %s with an unexpected workspace.",
+                    workflow_uuid,
+                )
+                return False
+            compensate(workflow)
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_CREATION_RECONCILIATION_INTERVAL)
+
+
+def create_workflow_on_controller(
+    create,
+    workflow_uuid,
+    user_id,
+    workspace_path,
+    compensate,
+):
+    """Call RWC and compensate visible commits after ambiguous failures.
+
+    The caller must own the workflow-creation mutation lock for this complete
+    call, including reconciliation.
+    """
+    try:
+        return create()
+    except HTTPError as error:
+        if error.response.status_code >= 500:
+            try:
+                _reconcile_failed_creation(
+                    workflow_uuid,
+                    user_id,
+                    workspace_path,
+                    compensate,
+                    wait_for_commit=False,
+                )
+            except Exception:
+                Session.rollback()
+                logging.exception(
+                    "Could not reconcile failed creation of workflow %s.",
+                    workflow_uuid,
+                )
+        raise
+    except Exception:
+        try:
+            _reconcile_failed_creation(
+                workflow_uuid,
+                user_id,
+                workspace_path,
+                compensate,
+                wait_for_commit=True,
+            )
+        except Exception:
+            Session.rollback()
+            logging.exception(
+                "Could not reconcile ambiguous creation of workflow %s.",
+                workflow_uuid,
+            )
+        raise

--- a/reana_server/workspace_mutations.py
+++ b/reana_server/workspace_mutations.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Cross-process serialization for shared-workspace mutations."""
+
+import hashlib
+import logging
+import os
+import threading
+from contextlib import contextmanager
+
+from reana_db.config import SQLALCHEMY_DATABASE_URI
+from reana_db.database import Session
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
+
+class WorkspaceMutationConflict(Exception):
+    """Another operation currently owns one of the requested workspaces."""
+
+
+class WorkspaceMutationUnavailable(Exception):
+    """Workspace serialization infrastructure is unavailable."""
+
+
+_engine = None
+_engine_guard = threading.Lock()
+_local_locks = {}
+_local_locks_guard = threading.Lock()
+
+
+def _get_lock_engine():
+    """Return the lazy, unpooled engine reserved for advisory locks.
+
+    ``NullPool`` keeps advisory-lock checkouts independent from the ORM pool.
+    Synchronous validation can prolong a lock checkout; moving that wait off the
+    request path is tracked in reanahub/reana-workflow-validator#9.
+    """
+    global _engine
+    if _engine is None:
+        with _engine_guard:
+            if _engine is None:
+                _engine = create_engine(
+                    SQLALCHEMY_DATABASE_URI,
+                    poolclass=NullPool,
+                    pool_pre_ping=True,
+                )
+    return _engine
+
+
+def _normalise_paths(workspace_paths):
+    """Return unique absolute workspace paths in deadlock-safe order."""
+    return sorted({os.path.abspath(os.fspath(path)) for path in workspace_paths})
+
+
+def _workflow_family_key(owner_id, workflow_name):
+    """Return an opaque lock key shared by all runs of one workflow name."""
+    identity = "{}\0{}".format(owner_id, workflow_name).encode("utf-8")
+    return "workflow-family:" + hashlib.sha256(identity).hexdigest()
+
+
+@contextmanager
+def _mutation_locks(keys):
+    """Own a normalized set of opaque mutation keys."""
+    keys = sorted(set(keys))
+    if not keys:
+        yield
+        return
+    if Session.get_bind().dialect.name == "postgresql":
+        with _postgresql_locks(keys):
+            yield
+    else:
+        with _local_process_locks(keys):
+            yield
+
+
+def _advisory_key(workspace_path):
+    """Map a normalized workspace path to a signed PostgreSQL bigint."""
+    return int.from_bytes(
+        hashlib.sha256(workspace_path.encode("utf-8")).digest()[:8],
+        byteorder="big",
+        signed=True,
+    )
+
+
+def _release_postgresql_locks(connection, transaction):
+    """Best-effort release that never masks the protected operation's result."""
+    if transaction is not None and transaction.is_active:
+        try:
+            transaction.rollback()
+        except Exception as error:
+            logging.exception("Could not roll back workspace-lock transaction.")
+            try:
+                connection.invalidate(error)
+            except Exception:
+                logging.exception("Could not invalidate workspace-lock connection.")
+    if connection is not None:
+        try:
+            connection.close()
+        except Exception:
+            logging.exception("Could not close workspace-lock connection.")
+
+
+@contextmanager
+def _postgresql_locks(workspace_paths):
+    """Own transaction-scoped advisory locks on a dedicated connection."""
+    connection = None
+    transaction = None
+    try:
+        connection = _get_lock_engine().connect()
+        transaction = connection.begin()
+        for workspace_path in workspace_paths:
+            acquired = connection.execute(
+                text("SELECT pg_try_advisory_xact_lock(:key)"),
+                {"key": _advisory_key(workspace_path)},
+            ).scalar()
+            if not acquired:
+                raise WorkspaceMutationConflict()
+    except WorkspaceMutationConflict:
+        _release_postgresql_locks(connection, transaction)
+        raise
+    except Exception as error:
+        _release_postgresql_locks(connection, transaction)
+        raise WorkspaceMutationUnavailable() from error
+
+    try:
+        yield
+    finally:
+        # The lock-only transaction has nothing to commit. Rollback releases
+        # every xact lock and cleanup errors must not turn a completed mutation
+        # into a retryable response-after-success ambiguity.
+        _release_postgresql_locks(connection, transaction)
+
+
+@contextmanager
+def _local_process_locks(workspace_paths):
+    """Own refcounted process-local locks for non-PostgreSQL development."""
+    entries = []
+    acquired = []
+    with _local_locks_guard:
+        for workspace_path in workspace_paths:
+            entry = _local_locks.get(workspace_path)
+            if entry is None:
+                entry = {"lock": threading.Lock(), "references": 0}
+                _local_locks[workspace_path] = entry
+            entry["references"] += 1
+            entries.append((workspace_path, entry))
+    try:
+        for _workspace_path, entry in entries:
+            if not entry["lock"].acquire(blocking=False):
+                raise WorkspaceMutationConflict()
+            acquired.append(entry["lock"])
+        yield
+    finally:
+        for lock in reversed(acquired):
+            lock.release()
+        with _local_locks_guard:
+            for workspace_path, entry in entries:
+                entry["references"] -= 1
+                if entry["references"] == 0:
+                    _local_locks.pop(workspace_path, None)
+
+
+@contextmanager
+def workspace_mutation_locks(workspace_paths):
+    """Serialize mutations of one or more workspaces without waiting."""
+    normalized_paths = _normalise_paths(workspace_paths)
+    with _mutation_locks(normalized_paths):
+        yield
+
+
+@contextmanager
+def workspace_mutation_lock(workspace_path):
+    """Serialize mutation of a single shared workspace."""
+    with workspace_mutation_locks([workspace_path]):
+        yield
+
+
+@contextmanager
+def workflow_family_mutation_lock(owner_id, workflow_name):
+    """Serialize operations that can add or remove runs of one workflow name."""
+    with _mutation_locks([_workflow_family_key(owner_id, workflow_name)]):
+        yield
+
+
+@contextmanager
+def workflow_creation_mutation_lock(owner_id, workflow_name, workspace_path):
+    """Reserve a workflow family and its preallocated workspace together."""
+    with _mutation_locks(
+        [
+            _workflow_family_key(owner_id, workflow_name),
+            os.path.abspath(os.fspath(workspace_path)),
+        ]
+    ):
+        yield

--- a/scripts/generate_openapi_spec.py
+++ b/scripts/generate_openapi_spec.py
@@ -62,6 +62,39 @@ def build_openapi_spec(publish):
         plugins=(FlaskPlugin(),),
     )
 
+    spec.components.schema(
+        "ErrorResponse",
+        {
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+        },
+    )
+    spec.components.schema(
+        "WorkflowSubmissionResponse",
+        {
+            "type": "object",
+            "properties": {
+                "message": {"type": "string"},
+                "workflow_id": {"type": "string"},
+                "workflow_name": {"type": "string"},
+                "run_number": {"type": "string"},
+                "status": {"type": "string"},
+                "user": {"type": "string"},
+                "validation_warnings": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "code": {"type": "string"},
+                            "message": {"type": "string"},
+                            "path": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        },
+    )
+
     # Add marshmallow schemas to the specification here
     # spec.definition('Example', schema=Example_schema)
 

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ extras_require = {
     "tests": [
         "apispec[yaml]>=3.0",
         "apispec-webframeworks",
-        "reana-commons[kubernetes,yadage,snakemake,cwl,tests]>=0.95.0a21,<0.96.0",
-        "reana-db[tests]>=0.95.0a10,<0.96.0",
+        "reana-commons[kubernetes,yadage,snakemake,cwl,tests]>=0.95.0a22,<0.96.0",
+        "reana-db[tests]>=0.95.0a11,<0.96.0",
     ],
 }
 
@@ -51,8 +51,8 @@ install_requires = [
     "Flask>=3.0.0,<4.0.0",
     "gitpython>=3.1",
     "marshmallow>=3.5.0,<4.0.0",
-    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.95.0a21,<0.96.0",
-    "reana-db>=0.95.0a10,<0.96.0",
+    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.95.0a22,<0.96.0",
+    "reana-db>=0.95.0a11,<0.96.0",
     "requests>=2.25.0",
     "tablib>=0.12.1",
     "uWSGI>=2.0.31",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,7 @@ from reana_server.utils import (
     _create_and_associate_reana_user,
     _get_user_from_invenio_user,
 )
+from reana_server.workspace_mutations import WorkspaceMutationConflict
 
 
 def test_export_users(user0):
@@ -732,6 +733,33 @@ def test_retention_rules_apply_error(
     apply_rule_mock.assert_called()
     for rule in workflow.retention_rules:
         assert rule.status == WorkspaceRetentionRuleStatus.active
+
+
+def test_retention_rules_contention_preserves_rule_states(
+    workflow_with_retention_rules, user0
+):
+    """A busy workspace is retried without active/pending state changes."""
+    workflow = workflow_with_retention_rules
+    original_states = {rule.id_: rule.status for rule in workflow.retention_rules}
+
+    with patch(
+        "reana_server.reana_admin.cli.workspace_mutation_lock",
+        side_effect=WorkspaceMutationConflict(),
+    ):
+        result = CliRunner().invoke(
+            reana_admin,
+            [
+                "retention-rules-apply",
+                "--admin-access-token",
+                user0.access_token,
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "will be retried later" in result.output
+    assert {
+        rule.id_: rule.status for rule in workflow.retention_rules
+    } == original_states
 
 
 def test_retention_rules_extend(workflow_with_retention_rules, user0):

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -12,6 +12,8 @@ import pytest
 from flask import Flask
 from invenio_rest import InvenioREST
 from mock import patch
+from marshmallow.exceptions import ValidationError
+from werkzeug.exceptions import UnprocessableEntity
 
 _TEST_ORIGIN = "https://example.com:30443"
 
@@ -89,3 +91,51 @@ def test_cors_non_matching_origin_rejected(ext_app):
     with ext_app.test_client() as client:
         res = client.get("/test", headers={"Origin": "https://example.com"})
     assert "Access-Control-Allow-Origin" not in res.headers
+
+
+def _render_args_validation_error(app, messages):
+    """Return the message an argument-validation failure would produce."""
+    from reana_server.ext import handle_args_validation_error
+
+    error = UnprocessableEntity()
+    error.exc = ValidationError(messages)
+    with app.test_request_context():
+        response, status_code = handle_args_validation_error(error)
+    return response.get_json()["message"], status_code
+
+
+def test_nested_argument_errors_render_the_actual_complaint(ext_app):
+    """Webargs namespaces messages per location; the leaf message must survive."""
+    message, status_code = _render_args_validation_error(
+        ext_app, {"json": {"reana_specification": ["Unknown field."]}}
+    )
+
+    assert status_code == 400
+    # Joining the nested dict directly used to render its keys instead, i.e.
+    # "Field 'json': reana_specification".
+    assert message == "Field 'reana_specification': Unknown field."
+
+
+def test_deeply_nested_argument_errors_keep_their_field_path(ext_app):
+    """Nested schemas and collections keep an unambiguous field path."""
+    message, _status_code = _render_args_validation_error(
+        ext_app, {"json": {"input_parameters": {"nested": ["Not a valid integer."]}}}
+    )
+
+    assert message == "Field 'input_parameters.nested': Not a valid integer."
+
+
+def test_multiple_argument_errors_are_all_reported(ext_app):
+    """Every failing field is reported, not just the first one."""
+    message, _status_code = _render_args_validation_error(
+        ext_app,
+        {
+            "query": {
+                "status": ["Missing data for required field."],
+                "size": ["Not a valid integer."],
+            }
+        },
+    )
+
+    assert "Field 'status': Missing data for required field." in message
+    assert "Field 'size': Not a valid integer." in message

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -8,10 +8,12 @@
 """REANA-Server workflow fetcher tests."""
 
 import os
+import subprocess
 from urllib.request import urlretrieve
 import pytest
 from unittest.mock import MagicMock, Mock, patch
 import zipfile
+import struct
 
 from git import Repo
 
@@ -43,13 +45,13 @@ YAML_URL = "https://raw.githubusercontent.com/reanahub/reana-demo-root6-roofit/m
 @pytest.mark.parametrize(
     "url, expected_fetcher_class",
     [
-        (GIT_URL, WorkflowFetcherGit),
-        (GIT_URL + "/", WorkflowFetcherGit),
-        (GITHUB_REPO_URL, WorkflowFetcherGit),
-        (GITHUB_REPO_URL + "/", WorkflowFetcherGit),
+        (GIT_URL, WorkflowFetcherZip),
+        (GIT_URL + "/", WorkflowFetcherZip),
+        (GITHUB_REPO_URL, WorkflowFetcherZip),
+        (GITHUB_REPO_URL + "/", WorkflowFetcherZip),
         (GITHUB_REPO_ZIP, WorkflowFetcherZip),
-        (GITLAB_REPO_URL, WorkflowFetcherGit),
-        (GITLAB_REPO_URL + "/", WorkflowFetcherGit),
+        (GITLAB_REPO_URL, WorkflowFetcherZip),
+        (GITLAB_REPO_URL + "/", WorkflowFetcherZip),
         (GITLAB_REPO_ZIP, WorkflowFetcherZip),
         (ZENODO_URL, WorkflowFetcherZip),
         (YAML_URL, WorkflowFetcherYaml),
@@ -161,6 +163,101 @@ def test_fetcher_git(with_git_ref, spec, tmp_path):
     assert os.path.isfile(expected_path)
 
 
+def test_fetcher_git_enforces_temporary_clone_limit(tmp_path):
+    """The generic Git fallback is killed before its clone tree grows unbounded."""
+    repository_path = tmp_path / "repository"
+    repository = Repo.init(repository_path, initial_branch="main")
+    (repository_path / "reana.yaml").write_text("x" * 4096)
+    repository.index.add("reana.yaml")
+    repository.index.commit("Add specification")
+
+    fetcher = WorkflowFetcherGit(
+        ParsedUrl(f"file://{repository_path}"), str(tmp_path / "output")
+    )
+    with patch("reana_server.fetcher.FETCHER_MAXIMUM_CLONE_SIZE", 128):
+        with pytest.raises(REANAFetcherError, match="Cannot clone|storage limit"):
+            fetcher.fetch()
+
+
+def test_fetcher_git_timeout_kills_and_reaps_process(tmp_path):
+    """A stalled generic Git process is terminated at the shared deadline."""
+
+    class StalledProcess:
+        def __init__(self):
+            self.pid = 123
+            self.returncode = None
+            self.killed = False
+            self.wait_timeouts = []
+
+        def poll(self):
+            return self.returncode
+
+        def kill(self):
+            self.killed = True
+            self.returncode = -9
+
+        def wait(self, timeout=None):
+            self.wait_timeouts.append(timeout)
+            if timeout is not None:
+                raise subprocess.TimeoutExpired("git", timeout)
+            return self.returncode
+
+    process = StalledProcess()
+    fetcher = WorkflowFetcherGit(
+        ParsedUrl("https://example.org/repository.git"),
+        str(tmp_path / "output"),
+    )
+    fetcher._clone_tree_exceeds_limits = Mock(return_value=False)
+
+    with patch("reana_server.fetcher.subprocess.Popen", return_value=process), patch(
+        "reana_server.fetcher.resource.prlimit"
+    ), patch("reana_server.fetcher.FETCHER_REQUEST_TIMEOUT", 1), patch(
+        "reana_server.fetcher.time.monotonic", side_effect=[0, 0, 2]
+    ):
+        with pytest.raises(REANAFetcherError, match="timed out"):
+            fetcher._run_bounded_git(["git", "clone"])
+
+    assert process.killed
+    assert process.wait_timeouts == [0.5, None]
+    assert fetcher._clone_tree_exceeds_limits.call_count == 2
+
+
+def test_fetcher_git_fast_completion_keeps_final_strict_scan(tmp_path):
+    """A completed clone is reaped promptly and receives the strict final scan."""
+
+    class CompletingProcess:
+        def __init__(self):
+            self.pid = 123
+            self.returncode = None
+            self.wait_timeouts = []
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout=None):
+            self.wait_timeouts.append(timeout)
+            self.returncode = 0
+            return self.returncode
+
+        def kill(self):
+            raise AssertionError("successful process must not be killed")
+
+    process = CompletingProcess()
+    fetcher = WorkflowFetcherGit(
+        ParsedUrl("https://example.org/repository.git"),
+        str(tmp_path / "output"),
+    )
+    fetcher._clone_tree_exceeds_limits = Mock(side_effect=[False, False])
+
+    with patch("reana_server.fetcher.subprocess.Popen", return_value=process), patch(
+        "reana_server.fetcher.resource.prlimit"
+    ), patch("reana_server.fetcher.time.monotonic", side_effect=[0, 0]):
+        assert fetcher._run_bounded_git(["git", "clone"])
+
+    assert process.wait_timeouts == [0.5]
+    assert fetcher._clone_tree_exceeds_limits.call_args_list[1].kwargs["strict"]
+
+
 @pytest.mark.parametrize(
     "spec_name, spec_argument",
     [
@@ -261,6 +358,101 @@ def test_fetcher_zip(with_top_level_dir, spec, tmp_path):
         assert os.path.isfile(expected_path)
 
 
+def test_fetcher_zip_counts_directory_entries_towards_limit():
+    """An archive cannot bypass its entry cap using empty directories."""
+    entries = [zipfile.ZipInfo("one/"), zipfile.ZipInfo("two/")]
+    with patch("reana_server.fetcher.FETCHER_MAXIMUM_FILES", 1):
+        with pytest.raises(REANAFetcherError, match="too many archive entries"):
+            WorkflowFetcherZip._validate_archive_entries(entries)
+
+
+def test_fetcher_zip_bounds_depth_and_implicit_directories():
+    """Remote archive metadata cannot create an unbounded directory tree."""
+    with patch("reana_server.fetcher.SPECIFICATION_BUNDLE_MAX_DEPTH", 2):
+        with pytest.raises(REANAFetcherError, match="metadata limits"):
+            WorkflowFetcherZip._validate_archive_entries(
+                [zipfile.ZipInfo("one/two/file")]
+            )
+
+    with patch("reana_server.fetcher._FETCHER_MAXIMUM_DIRECTORIES", 1):
+        with pytest.raises(REANAFetcherError, match="too many directories"):
+            WorkflowFetcherZip._validate_archive_entries(
+                [zipfile.ZipInfo("one/file"), zipfile.ZipInfo("two/file")]
+            )
+
+
+def test_fetcher_git_scan_bounds_directory_breadth(tmp_path):
+    """A clone with few files but excessive directories is rejected."""
+    output = tmp_path / "output"
+    output.mkdir()
+    (output / "one").mkdir()
+    (output / "two").mkdir()
+    fetcher = WorkflowFetcherGit(
+        ParsedUrl("https://example.org/repository.git"), str(output)
+    )
+
+    with patch("reana_server.fetcher._FETCHER_MAXIMUM_DIRECTORIES", 1):
+        assert fetcher._clone_tree_exceeds_limits(file_limit=10, strict=True)
+
+
+@pytest.mark.parametrize(
+    "names",
+    [
+        ["a", "a/b"],
+        ["a/b", "a"],
+        ["a", "a/"],
+        ["a/", "a"],
+    ],
+)
+def test_fetcher_zip_rejects_file_ancestor_collision(names):
+    """Remote archives cannot represent a file as a directory or ancestor."""
+    entries = [zipfile.ZipInfo(name) for name in names]
+    with pytest.raises(REANAFetcherError):
+        WorkflowFetcherZip._validate_archive_entries(entries)
+
+
+def test_fetcher_zip_converts_extraction_oserror(monkeypatch, tmp_path):
+    """Filesystem extraction failures use the controlled fetcher error."""
+    archive_path = tmp_path / "archive.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("reana.yaml", "workflow: {}")
+    output_path = tmp_path / "output"
+    output_path.mkdir()
+    fetcher = WorkflowFetcherZip(
+        ParsedUrl("file:///archive.zip"),
+        str(output_path),
+    )
+
+    with zipfile.ZipFile(archive_path) as archive:
+        entries = archive.infolist()
+
+        def fail_makedirs(*args, **kwargs):
+            raise PermissionError("denied")
+
+        monkeypatch.setattr("reana_server.fetcher.os.makedirs", fail_makedirs)
+        with pytest.raises(REANAFetcherError):
+            fetcher._extract_archive_entries(archive, entries)
+
+
+def test_fetcher_rejects_entry_count_before_zipfile(monkeypatch, tmp_path):
+    """Remote archive metadata is bounded before entry materialisation."""
+    archive_path = tmp_path / "archive.zip"
+    archive_path.write_bytes(
+        struct.pack("<4s4H2LH", b"PK\x05\x06", 0, 0, 2, 2, 0, 0, 0)
+    )
+    output_path = tmp_path / "output"
+    output_path.mkdir()
+    fetcher = WorkflowFetcherZip(ParsedUrl("file:///archive.zip"), str(output_path))
+    monkeypatch.setattr("reana_server.fetcher.FETCHER_MAXIMUM_FILES", 1)
+    zip_file = Mock(side_effect=AssertionError("ZipFile must not be constructed"))
+    monkeypatch.setattr("reana_server.fetcher.zipfile.ZipFile", zip_file)
+
+    with pytest.raises(REANAFetcherError, match="too many entries"):
+        fetcher.extract_archive(str(archive_path))
+
+    zip_file.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "url, username, repository, git_ref",
     [
@@ -285,22 +477,26 @@ def test_fetcher_zip(with_top_level_dir, spec, tmp_path):
     ],
 )
 def test_github_fetcher(url, username, repository, git_ref, tmp_path):
-    """Test creating a valid fetcher for GitHub URLs."""
-    mock_git_fetcher = Mock()
-    with patch("reana_server.fetcher.WorkflowFetcherGit", mock_git_fetcher):
+    """GitHub repositories use bounded provider ZIP snapshots."""
+    mock_zip_fetcher = Mock()
+    with patch("reana_server.fetcher.WorkflowFetcherZip", mock_zip_fetcher):
         _get_github_fetcher(ParsedUrl(url), tmp_path)
-        mock_git_fetcher.assert_called_once()
-        expected_repo_url = f"https://github.com/{username}/{repository}.git"
+        mock_zip_fetcher.assert_called_once()
         (
             call_parsed_url,
             call_tmp_path,
-            call_git_ref,
             call_spec,
-        ) = mock_git_fetcher.call_args.args
-        assert call_parsed_url.original_url == expected_repo_url
+            call_workflow_name,
+        ) = mock_zip_fetcher.call_args.args
+        assert call_parsed_url.original_url.startswith(
+            f"https://github.com/{username}/{repository}/archive/"
+        )
+        assert call_parsed_url.original_url.endswith(".zip")
         assert call_tmp_path == tmp_path
-        assert call_git_ref == git_ref
         assert call_spec is None
+        assert call_workflow_name == (
+            repository if not git_ref else f"{repository}-{git_ref}"
+        )
 
 
 @pytest.mark.parametrize(
@@ -375,23 +571,27 @@ def test_invalid_github_fetcher(url, tmp_path):
     ],
 )
 def test_gitlab_fetcher(url, username, repository, git_ref, tmp_path):
-    """Test creating a valid fetcher for GitLab URLs."""
-    mock_git_fetcher = Mock()
-    with patch("reana_server.fetcher.WorkflowFetcherGit", mock_git_fetcher):
+    """GitLab repositories use bounded provider ZIP snapshots."""
+    mock_zip_fetcher = Mock()
+    with patch("reana_server.fetcher.WorkflowFetcherZip", mock_zip_fetcher):
         parsed_url = ParsedUrl(url)
         _get_gitlab_fetcher(ParsedUrl(url), tmp_path)
-        mock_git_fetcher.assert_called_once()
-        expected_repo_url = f"https://{parsed_url.hostname}/{username}/{repository}.git"
+        mock_zip_fetcher.assert_called_once()
         (
             call_parsed_url,
             call_tmp_path,
-            call_git_ref,
             call_spec,
-        ) = mock_git_fetcher.call_args.args
-        assert call_parsed_url.original_url == expected_repo_url
+            call_workflow_name,
+        ) = mock_zip_fetcher.call_args.args
+        assert call_parsed_url.original_url.startswith(
+            f"https://{parsed_url.hostname}/api/v4/projects/"
+        )
+        assert "repository/archive.zip?sha=" in call_parsed_url.original_url
         assert call_tmp_path == tmp_path
-        assert call_git_ref == git_ref
         assert call_spec is None
+        assert call_workflow_name == (
+            repository if not git_ref else f"{repository}-{git_ref}"
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gitlab_client.py
+++ b/tests/test_gitlab_client.py
@@ -99,6 +99,31 @@ def test_gitlab_client_get_file():
     assert res.content == b"file content"
 
 
+def test_gitlab_client_get_repository_archive():
+    """Test streaming an exact GitLab repository snapshot."""
+    response = mock_response()
+
+    def request(verb, url, params, data, stream, timeout):
+        assert verb == "GET"
+        assert (
+            url
+            == "https://gitlab.example.org/api/v4/projects/group%2Frepo/repository/archive.zip"
+        )
+        assert params == {"access_token": "gitlab_token", "sha": "deadbeef"}
+        assert data is None
+        assert stream is True
+        assert timeout == config.FETCHER_REQUEST_TIMEOUT
+        return response
+
+    gitlab_client = GitLabClient(
+        access_token="gitlab_token",
+        host="gitlab.example.org",
+        http_request=request,
+    )
+
+    assert gitlab_client.get_repository_archive("group/repo", "deadbeef") is response
+
+
 def test_gitlab_client_get_projects():
     """Test getting projects from GitLab."""
 

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test the unauthenticated ping and protocol-capability contract."""
+
+from flask import url_for
+
+from reana_server import __version__
+from reana_server.config import WORKFLOW_SPECIFICATION_BUNDLES_CAPABILITY
+
+
+def test_ping_advertises_protocol_capabilities(base_app):
+    """Ping stays unauthenticated and carries the protocol bootstrap signal."""
+    with base_app.app_context(), base_app.test_client() as client:
+        res = client.get(url_for("ping.ping"))
+
+        assert res.status_code == 200
+        payload = res.json
+        # Released clients parse ``status`` as a string; keep it one.
+        assert payload["message"] == "OK"
+        assert payload["status"] == "200"
+        assert payload["reana_server_version"] == __version__
+        assert WORKFLOW_SPECIFICATION_BUNDLES_CAPABILITY in payload["api_capabilities"]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,16 +6,39 @@
 
 """REANA-Server tests for validation module."""
 
+import io
+import struct
+import os
+import pathlib
+import shutil
+import stat
+import zipfile
+
 import pytest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from contextlib import nullcontext as does_not_raise
 
-from reana_commons.config import REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE
-from reana_commons.errors import REANAValidationError
+from flask import Flask
+from werkzeug.datastructures import FileStorage, MultiDict
+from werkzeug.exceptions import RequestEntityTooLarge
 
+from reana_commons.config import REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE
+from reana_commons.errors import REANASpecificationPathError, REANAValidationError
+
+# The per-check server wrappers (``validate_inputs``/``validate_images``) have
+# been removed: every server path now validates through the single shared
+# validator (``validate_serialized_spec``). These low-level checks live in
+# reana-commons, so the remaining unit tests target them there directly.
+from reana_commons.validation.images import validate_images
+from reana_commons.validation.utils import MAX_LOAD_ERROR_MESSAGE_CHARS, validate_inputs
+from reana_server.rest import workflows
+from reana_server import specification_bundles
+
+import reana_server.validation as server_validation
 from reana_server.validation import (
-    validate_inputs,
-    validate_images,
+    SpecValidationServiceError,
+    _authoritative_report,
+    _call_rwc_validate,
     validate_retention_rule,
 )
 
@@ -33,6 +56,923 @@ from reana_server.validation import (
 def test_validate_inputs(paths, error):
     with pytest.raises(REANAValidationError, match=error):
         validate_inputs({"inputs": {"directories": paths}})
+
+
+def test_spec_bundle_request_size_rejected_before_multipart_parsing(monkeypatch):
+    """Oversized bundle requests are rejected using Content-Length."""
+    monkeypatch.setattr(workflows, "REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES", 10)
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/api/workflows/validate",
+        method="POST",
+        data=b"01234567890",
+        content_type="multipart/form-data",
+    ):
+        with pytest.raises(RequestEntityTooLarge, match="too large"):
+            workflows._validate_spec_bundle_request_size()
+
+
+def test_bundle_request_sets_explicit_single_part_limit():
+    """The framework parser and REANA contract enforce the same part count."""
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/api/workflows/validate",
+        method="POST",
+        data=b"",
+        content_type="multipart/form-data",
+    ):
+        workflows._cap_bundle_request_body()
+        assert workflows.request.max_form_parts == 1
+        assert (
+            workflows.request.max_content_length
+            == workflows.REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES
+        )
+
+
+def test_multipart_upload_requires_seekable_temporary_stream():
+    """A stream whose size cannot be established is rejected before forwarding."""
+
+    class NonSeekableStream:
+        def tell(self):
+            raise OSError("not seekable")
+
+    with pytest.raises(REANAValidationError, match="determine the uploaded file size"):
+        workflows._remaining_stream_size(NonSeekableStream())
+
+
+def test_bundle_request_cap_allows_bounded_zip_and_multipart_framing():
+    """The HTTP cap has room beyond the extracted-content limit."""
+    from reana_server import config
+
+    assert (
+        config.REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES > config.REANA_SPEC_BUNDLE_MAX_BYTES
+    )
+
+
+def test_environment_check_is_offline():
+    """Server environment checks only report offline tag findings."""
+    specification = {
+        "workflow": {
+            "type": "serial",
+            "specification": {
+                "steps": [
+                    {
+                        "name": "step",
+                        "environment": "docker.io/library/busybox:1",
+                        "commands": ["true"],
+                    }
+                ]
+            },
+        }
+    }
+    with patch(
+        "reana_server.validation.check_environment_tags", return_value=[]
+    ) as check_mock:
+        server_validation.check_spec_environment_tags(specification)
+
+    check_mock.assert_called_once_with(["docker.io/library/busybox:1"])
+
+
+def _uploaded_zip(entries, compression=zipfile.ZIP_STORED):
+    """Build one uploaded ZIP bundle."""
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w", compression=compression) as archive:
+        for name, content in entries:
+            archive.writestr(name, content)
+    stream.seek(0)
+    return FileStorage(stream=stream, filename="validation-bundle.zip")
+
+
+def _declared_entry_count_zip(entry_count):
+    """Build a minimal EOCD record declaring ``entry_count`` members."""
+    return io.BytesIO(
+        struct.pack(
+            "<4s4H2LH",
+            b"PK\x05\x06",
+            0,
+            0,
+            entry_count,
+            entry_count,
+            0,
+            0,
+            0,
+        )
+    )
+
+
+def test_bundle_rejects_entry_count_before_zipfile(monkeypatch, tmp_path):
+    """Excessive central-directory declarations never reach ``ZipFile``."""
+    monkeypatch.setattr(specification_bundles, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(specification_bundles, "REANA_SPEC_BUNDLE_MAX_FILES", 1)
+    zip_file = Mock(side_effect=AssertionError("ZipFile must not be constructed"))
+    monkeypatch.setattr(specification_bundles.zipfile, "ZipFile", zip_file)
+    storage = FileStorage(
+        stream=_declared_entry_count_zip(2), filename="validation-bundle.zip"
+    )
+
+    with pytest.raises(REANAValidationError, match="too many files"):
+        specification_bundles.extract_uploaded_bundle(storage, str(tmp_path))
+
+    zip_file.assert_not_called()
+
+
+def test_uploaded_bundle_regathers_legacy_external_workflow_scope(tmp_path):
+    """Server scope equality accepts a complete legacy client snapshot."""
+    specification = (
+        "inputs:\n"
+        "  directories: [workflow]\n"
+        "workflow:\n"
+        "  type: cwl\n"
+        "  file: workflow/main.cwl\n"
+    )
+    storage = _uploaded_zip(
+        [
+            ("reana.yaml", specification),
+            ("workflow/main.cwl", "class: Workflow"),
+            ("workflow/step.cwl", "class: CommandLineTool"),
+        ]
+    )
+
+    absolute_path, _relative_path, _size, _legacy = (
+        specification_bundles.extract_uploaded_bundle(storage, str(tmp_path))
+    )
+
+    assert os.path.isfile(os.path.join(absolute_path, "workflow", "step.cwl"))
+
+
+def test_zip64_archives_are_rejected_before_zipfile():
+    """ZIP64 is unnecessary under REANA's limits and is rejected outright."""
+    zip64_record = struct.pack(
+        "<4sQ2H2L4Q",
+        b"PK\x06\x06",
+        44,
+        45,
+        45,
+        0,
+        0,
+        2,
+        2,
+        0,
+        0,
+    )
+    locator = struct.pack("<4sLQL", b"PK\x06\x07", 0, 0, 1)
+    eocd = struct.pack(
+        "<4s4H2LH",
+        b"PK\x05\x06",
+        0,
+        0,
+        0xFFFF,
+        0xFFFF,
+        0xFFFFFFFF,
+        0xFFFFFFFF,
+        0,
+    )
+
+    with pytest.raises(ValueError, match="ZIP64 archives are not supported"):
+        specification_bundles.preflight_zip_metadata(
+            io.BytesIO(zip64_record + locator + eocd), 1
+        )
+
+
+def test_zip64_locator_is_rejected_without_classic_sentinels():
+    """A ZIP64 locator is authoritative even if classic EOCD values look small."""
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        archive.writestr("reana.yaml", "workflow: {type: serial}")
+    contents = stream.getvalue()
+    eocd_offset = contents.rfind(b"PK\x05\x06")
+    locator = struct.pack("<4sLQL", b"PK\x06\x07", 0, 0, 1)
+
+    with pytest.raises(ValueError, match="ZIP64 archives are not supported"):
+        specification_bundles.preflight_zip_metadata(
+            io.BytesIO(contents[:eocd_offset] + locator + contents[eocd_offset:]), 2
+        )
+
+
+def test_zip_preflight_rejects_underreported_entry_count():
+    """The scanner enforces the actual central-directory count, not only EOCD."""
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        archive.writestr("reana.yaml", "workflow: {type: serial}")
+        archive.writestr("Snakefile", "rule all: input: []")
+    contents = bytearray(stream.getvalue())
+    eocd_offset = contents.rfind(b"PK\x05\x06")
+    # entries_on_disk and total_entries are adjacent 16-bit fields.
+    struct.pack_into("<HH", contents, eocd_offset + 8, 1, 1)
+
+    with pytest.raises(ValueError, match="entry count does not match"):
+        specification_bundles.preflight_zip_metadata(io.BytesIO(contents), 2)
+
+
+def test_zip_preflight_ignores_eocd_signature_inside_comment():
+    """An EOCD-like byte sequence in a valid ZIP comment is not selected."""
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        archive.writestr("reana.yaml", "workflow: {type: serial}")
+        archive.comment = b"comment with PK\x05\x06 marker and trailing bytes"
+    stream.seek(0)
+
+    specification_bundles.preflight_zip_metadata(stream, 1)
+
+
+def test_stage_validation_bundle_rejects_too_many_files(monkeypatch, tmp_path):
+    """Bundle staging is bounded by the configured file-count limit."""
+    monkeypatch.setattr(specification_bundles, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(workflows, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(specification_bundles, "REANA_SPEC_BUNDLE_MAX_FILES", 1)
+
+    with pytest.raises(REANAValidationError, match="too many files"):
+        workflows._stage_validation_bundle(
+            {
+                "bundle": _uploaded_zip(
+                    [
+                        (
+                            "reana.yaml",
+                            b"workflow:\n  type: snakemake\n  file: Snakefile\n",
+                        ),
+                        ("Snakefile", b""),
+                    ]
+                )
+            }
+        )
+
+
+def test_stage_validation_bundle_rejects_overlong_member_path(monkeypatch, tmp_path):
+    """ZIP metadata is bounded independently of extracted content bytes."""
+    monkeypatch.setattr(specification_bundles, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(workflows, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(specification_bundles, "REANA_SPEC_BUNDLE_MAX_PATH_BYTES", 10)
+
+    with pytest.raises(REANAValidationError, match="encoded bytes"):
+        workflows._stage_validation_bundle(
+            {
+                "bundle": _uploaded_zip(
+                    [
+                        (
+                            "reana.yaml",
+                            b"workflow:\n  type: serial\n"
+                            b"  files: [long-name.yaml]\n"
+                            b"  specification: {steps: []}\n",
+                        ),
+                        ("long-name.yaml", b"value: 1\n"),
+                    ]
+                )
+            }
+        )
+
+
+def test_stage_validation_bundle_rejects_excessive_depth(monkeypatch, tmp_path):
+    """Direct ZIP callers cannot bypass the fixed component-depth contract."""
+    monkeypatch.setattr(specification_bundles, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(workflows, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(specification_bundles, "SPECIFICATION_BUNDLE_MAX_DEPTH", 2)
+
+    with pytest.raises(REANAValidationError, match="maximum depth"):
+        workflows._stage_validation_bundle(
+            {
+                "bundle": _uploaded_zip(
+                    [
+                        (
+                            "reana.yaml",
+                            b"workflow:\n  type: serial\n"
+                            b"  files: [one/two/value]\n"
+                            b"  specification: {steps: []}\n",
+                        ),
+                        ("one/two/value", b"value"),
+                    ]
+                )
+            }
+        )
+
+
+def test_stage_validation_bundle_rejects_too_many_implicit_directories(
+    monkeypatch, tmp_path
+):
+    """ZIP paths have a cumulative implicit-parent directory budget."""
+    monkeypatch.setattr(specification_bundles, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(workflows, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(
+        specification_bundles, "SPECIFICATION_BUNDLE_MAX_DIRECTORIES", 1
+    )
+
+    with pytest.raises(REANAValidationError, match="too many directories"):
+        workflows._stage_validation_bundle(
+            {
+                "bundle": _uploaded_zip(
+                    [
+                        (
+                            "reana.yaml",
+                            b"workflow:\n  type: serial\n"
+                            b"  files: [one/value, two/value]\n"
+                            b"  specification: {steps: []}\n",
+                        ),
+                        ("one/value", b"one"),
+                        ("two/value", b"two"),
+                    ]
+                )
+            }
+        )
+
+
+def test_stage_validation_bundle_rejects_duplicate_bundle_fields(monkeypatch, tmp_path):
+    """Duplicate same-name multipart fields cannot bypass the one-part contract."""
+    monkeypatch.setattr(specification_bundles, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(workflows, "SHARED_VOLUME_PATH", str(tmp_path))
+    files = MultiDict(
+        [
+            (
+                "bundle",
+                _uploaded_zip(
+                    [
+                        (
+                            "reana.yaml",
+                            b"workflow:\n  type: serial\n"
+                            b"  specification: {steps: []}\n",
+                        )
+                    ]
+                ),
+            ),
+            ("bundle", _uploaded_zip([("reana.yaml", b"other: value\n")])),
+        ]
+    )
+    with pytest.raises(REANAValidationError, match="exactly one"):
+        workflows._stage_validation_bundle(files)
+
+
+@pytest.mark.parametrize(
+    "colliding_entries",
+    [
+        [("a", b"file"), ("a/b", b"nested")],
+        [("a/b", b"nested"), ("a", b"file")],
+    ],
+)
+def test_stage_validation_bundle_rejects_file_ancestor_collision(
+    monkeypatch, tmp_path, colliding_entries
+):
+    """A regular ZIP member cannot also be an ancestor of another member."""
+    monkeypatch.setattr(specification_bundles, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(workflows, "SHARED_VOLUME_PATH", str(tmp_path))
+    entries = [
+        (
+            "reana.yaml",
+            b"workflow:\n  type: serial\n  specification: {steps: []}\n",
+        ),
+        *colliding_entries,
+    ]
+
+    with pytest.raises(REANAValidationError, match="nested below a regular file"):
+        workflows._stage_validation_bundle({"bundle": _uploaded_zip(entries)})
+
+    assert not list(
+        (tmp_path / specification_bundles.VALIDATION_STAGING_SUBDIR).glob("*")
+    )
+
+
+def test_stage_validation_bundle_rejects_unsafe_member_and_cleans_up(
+    monkeypatch, tmp_path
+):
+    """Unsafe relative paths are rejected and partial staging is removed."""
+    monkeypatch.setattr(specification_bundles, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(workflows, "SHARED_VOLUME_PATH", str(tmp_path))
+
+    with pytest.raises(REANAValidationError, match="Unsafe bundle path"):
+        workflows._stage_validation_bundle(
+            {
+                "bundle": _uploaded_zip(
+                    [
+                        (
+                            "reana.yaml",
+                            b"workflow:\n  type: serial\n  specification: {steps: []}\n",
+                        ),
+                        ("../escape", b""),
+                    ]
+                )
+            }
+        )
+
+    assert not list(
+        (tmp_path / specification_bundles.VALIDATION_STAGING_SUBDIR).glob("*")
+    )
+
+
+def test_stage_validation_bundle_enforces_size_cap_while_streaming(
+    monkeypatch, tmp_path
+):
+    """An oversized member is rejected mid-stream, even with no Content-Length.
+
+    The cap is enforced while streaming each member to disk, so a chunked upload
+    (which bypasses the up-front Content-Length check) cannot land a huge file.
+    """
+    monkeypatch.setattr(specification_bundles, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(workflows, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(specification_bundles, "REANA_SPEC_BUNDLE_MAX_BYTES", 8)
+
+    with pytest.raises(REANAValidationError, match="too large"):
+        workflows._stage_validation_bundle(
+            {
+                "bundle": _uploaded_zip(
+                    [
+                        (
+                            "reana.yaml",
+                            b"workflow:\n  type: serial\n  specification: {steps: []}\n",
+                        )
+                    ]
+                )
+            }
+        )
+
+    assert not list(
+        (tmp_path / specification_bundles.VALIDATION_STAGING_SUBDIR).glob("*")
+    )
+
+
+def test_stage_validation_bundle_rejects_compressed_and_link_entries(
+    monkeypatch, tmp_path
+):
+    """Validation ZIPs are uncompressed and regular-file-only."""
+    monkeypatch.setattr(specification_bundles, "SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(workflows, "SHARED_VOLUME_PATH", str(tmp_path))
+    specification = b"workflow:\n  type: serial\n  specification: {steps: []}\n"
+    with pytest.raises(REANAValidationError, match="uncompressed"):
+        workflows._stage_validation_bundle(
+            {
+                "bundle": _uploaded_zip(
+                    [("reana.yaml", specification)],
+                    compression=zipfile.ZIP_DEFLATED,
+                )
+            }
+        )
+
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        archive.writestr("reana.yaml", specification)
+        link = zipfile.ZipInfo("linked")
+        link.create_system = 3
+        link.external_attr = (stat.S_IFLNK | 0o777) << 16
+        archive.writestr(link, "target")
+    stream.seek(0)
+    with pytest.raises(REANAValidationError, match="regular files"):
+        workflows._stage_validation_bundle(
+            {"bundle": FileStorage(stream=stream, filename="bundle.zip")}
+        )
+
+
+def test_stage_validation_bundle_is_readable_by_validator_group(monkeypatch, tmp_path):
+    """Snapshots and nested files preserve the configured shared-volume group."""
+    monkeypatch.setattr(workflows, "SHARED_VOLUME_PATH", str(tmp_path))
+    absolute_path = None
+    try:
+        absolute_path, _relative, _bytes, _legacy = workflows._stage_validation_bundle(
+            {
+                "bundle": _uploaded_zip(
+                    [
+                        (
+                            "reana.yaml",
+                            b"workflow:\n"
+                            b"  type: serial\n"
+                            b"  files: [rules/common.yaml]\n"
+                            b"  specification: {steps: []}\n",
+                        ),
+                        ("rules/common.yaml", b"common: true\n"),
+                    ]
+                )
+            }
+        )
+        shared_gid = os.stat(tmp_path).st_gid
+        assert stat.S_IMODE(os.stat(absolute_path).st_mode) == 0o2750
+        assert (
+            stat.S_IMODE(os.stat(os.path.join(absolute_path, "reana.yaml")).st_mode)
+            == 0o640
+        )
+        for path in (
+            absolute_path,
+            os.path.join(absolute_path, "reana.yaml"),
+            os.path.join(absolute_path, "rules"),
+            os.path.join(absolute_path, "rules", "common.yaml"),
+        ):
+            assert os.stat(path).st_gid == shared_gid
+    finally:
+        if absolute_path:
+            shutil.rmtree(absolute_path, ignore_errors=True)
+
+
+def test_stage_validation_snapshot_rejects_ancestor_swap(monkeypatch, tmp_path):
+    """A selected source cannot be redirected through a swapped ancestor."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "reana.yaml").write_text(
+        "workflow:\n  type: snakemake\n  file: defs/Snakefile\n"
+    )
+    (workspace / "defs").mkdir()
+    (workspace / "defs" / "Snakefile").write_text("ORIGINAL")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "Snakefile").write_text("OUTSIDE")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    gather = specification_bundles.gather_validation_members
+
+    def gather_then_swap(path, source_base_directory=None, **kwargs):
+        result = gather(path, source_base_directory=source_base_directory, **kwargs)
+        (workspace / "defs").rename(workspace / "defs-original")
+        (workspace / "defs").symlink_to(outside, target_is_directory=True)
+        return result
+
+    monkeypatch.setattr(
+        specification_bundles,
+        "gather_validation_members",
+        gather_then_swap,
+    )
+    with pytest.raises(REANAValidationError, match="securely open"):
+        specification_bundles.stage_validation_snapshot(
+            str(workspace / "reana.yaml"), str(shared)
+        )
+    staging = shared / specification_bundles.VALIDATION_STAGING_SUBDIR
+    assert not staging.exists() or not list(staging.iterdir())
+
+
+def test_stage_validation_snapshot_bounds_yaml_before_scope_discovery(
+    monkeypatch, tmp_path
+):
+    """Canonical YAML is size-limited before scope discovery can parse it."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "reana.yaml").write_text("workflow: {type: serial}\n")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    monkeypatch.setattr(specification_bundles, "REANA_SPEC_BUNDLE_MAX_BYTES", 8)
+
+    def unexpected_gather(*args, **kwargs):
+        pytest.fail("oversized YAML reached scope discovery")
+
+    monkeypatch.setattr(
+        specification_bundles,
+        "gather_validation_members",
+        unexpected_gather,
+    )
+    with pytest.raises(REANAValidationError, match="too large"):
+        specification_bundles.stage_validation_snapshot(
+            str(workspace / "reana.yaml"), str(shared)
+        )
+
+    staging = shared / specification_bundles.VALIDATION_STAGING_SUBDIR
+    assert not staging.exists() or not list(staging.iterdir())
+
+
+def test_stage_validation_snapshot_uses_copied_yaml_for_scope(monkeypatch, tmp_path):
+    """Workspace YAML changes after copying cannot change snapshot membership."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    original = "workflow:\n  type: snakemake\n  file: Snakefile\n"
+    (workspace / "reana.yaml").write_text(original)
+    (workspace / "Snakefile").write_text("ORIGINAL")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    gather = specification_bundles.gather_validation_members
+
+    def mutate_then_gather(path, source_base_directory=None, **kwargs):
+        (workspace / "reana.yaml").write_text(
+            "workflow:\n  type: snakemake\n  file: Otherfile\n"
+        )
+        return gather(path, source_base_directory=source_base_directory, **kwargs)
+
+    monkeypatch.setattr(
+        specification_bundles,
+        "gather_validation_members",
+        mutate_then_gather,
+    )
+    staged = None
+    try:
+        staged, _relative, _bytes, _legacy = (
+            specification_bundles.stage_validation_snapshot(
+                str(workspace / "reana.yaml"), str(shared)
+            )
+        )
+        assert pathlib.Path(staged, "reana.yaml").read_text() == original
+        assert pathlib.Path(staged, "Snakefile").read_text() == "ORIGINAL"
+        assert not pathlib.Path(staged, "Otherfile").exists()
+    finally:
+        if staged:
+            shutil.rmtree(staged)
+
+
+def test_stage_validation_snapshot_canonicalizes_selected_filename(tmp_path):
+    """Descriptor-relative copying keeps the canonical archive destination name."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    specification = workspace / "selected.yaml"
+    contents = "workflow:\n  type: serial\n  specification: {steps: []}\n"
+    specification.write_text(contents)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    absolute_path = None
+    try:
+        absolute_path, _relative, _bytes, _legacy = (
+            specification_bundles.stage_validation_snapshot(
+                str(specification), str(shared)
+            )
+        )
+        assert pathlib.Path(absolute_path, "reana.yaml").read_text() == contents
+    finally:
+        if absolute_path:
+            shutil.rmtree(absolute_path, ignore_errors=True)
+
+
+def test_stage_validation_snapshot_deduplicates_legacy_canonical_input(tmp_path):
+    """A copied reana.yaml remains identical to its legacy input declaration."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    specification = workspace / "reana.yaml"
+    specification.write_text(
+        "inputs:\n"
+        "  files: [reana.yaml]\n"
+        "workflow:\n"
+        "  type: cwl\n"
+        "  file: main.cwl\n"
+    )
+    (workspace / "main.cwl").write_text("class: Workflow")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    absolute_path = None
+    try:
+        absolute_path, _relative, _bytes, _legacy = (
+            specification_bundles.stage_validation_snapshot(
+                str(specification), str(shared)
+            )
+        )
+        assert sorted(path.name for path in pathlib.Path(absolute_path).iterdir()) == [
+            "main.cwl",
+            "reana.yaml",
+        ]
+    finally:
+        if absolute_path:
+            shutil.rmtree(absolute_path, ignore_errors=True)
+
+
+def test_stage_validation_snapshot_rejects_sibling_canonical_input(tmp_path):
+    """A copied differently named selection cannot alias a sibling reana.yaml."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "reana.yaml").write_text("workflow: {type: serial}\n")
+    specification = workspace / "selected.yaml"
+    specification.write_text(
+        "inputs:\n"
+        "  files: [reana.yaml]\n"
+        "workflow:\n"
+        "  type: cwl\n"
+        "  file: main.cwl\n"
+    )
+    (workspace / "main.cwl").write_text("class: Workflow")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    with pytest.raises(REANASpecificationPathError) as error:
+        specification_bundles.stage_validation_snapshot(str(specification), str(shared))
+
+    assert error.value.reason == "conflict"
+    assert error.value.field == "inputs.files"
+
+
+# --- SNDBX-03 / SNDBX-07: server-side re-validation + error taxonomy ---------
+
+
+def _candidate_serial_spec(image):
+    """A minimal already-serialized serial spec usable as a sandbox candidate."""
+    return {
+        "workflow": {
+            "type": "serial",
+            "specification": {
+                "steps": [{"name": "s", "environment": image, "commands": ["echo hi"]}]
+            },
+        },
+        "inputs": {"parameters": {}},
+    }
+
+
+def test_authoritative_report_validates_loader_candidate_against_policy():
+    """The server validates the sandbox's candidate spec itself (loader-only).
+
+    The sandbox emits only the loaded spec (no verdict); the server runs the
+    pure policy validator on it and decides. A non-vetted image is rejected.
+    """
+    candidate = _candidate_serial_spec("evil.io/malware:latest")
+    loader_report = {"reana_specification": candidate, "error": None}
+    policy = {
+        "vetted_images_enabled": True,
+        "vetted_images_allowlist": ["docker.io/library/busybox:1.36"],
+    }
+    result = _authoritative_report(loader_report, exit_code=0, policy=policy)
+    assert result["valid"] is False
+    assert any(e["code"] == "image_not_allowed" for e in result["errors"])
+
+
+def test_authoritative_report_valid_candidate_passes():
+    """A loaded spec that meets policy is reported valid, keeping the spec."""
+    candidate = _candidate_serial_spec("docker.io/library/busybox:1.36")
+    loader_report = {"reana_specification": candidate, "error": None}
+    policy = {
+        "vetted_images_enabled": True,
+        "vetted_images_allowlist": ["docker.io/library/busybox:1.36"],
+    }
+    result = _authoritative_report(loader_report, exit_code=0, policy=policy)
+    assert result["valid"] is True
+    assert result["reana_specification"] == candidate
+
+
+def test_authoritative_report_internal_exit_code_is_service_error():
+    """Sandbox exit code 2 (internal error) is a service failure, not invalid."""
+    report = {"reana_specification": None, "error": None}
+    with pytest.raises(SpecValidationServiceError):
+        _authoritative_report(report, exit_code=2, policy={})
+
+
+def test_authoritative_report_internal_coded_error_is_service_error():
+    """An ``internal``-coded error is a service failure regardless of exit code."""
+    report = {
+        "reana_specification": None,
+        "error": {"code": "internal", "message": "boom"},
+    }
+    with pytest.raises(SpecValidationServiceError, match="boom"):
+        _authoritative_report(report, exit_code=None, policy={})
+
+
+@pytest.mark.parametrize("exit_code", [None, False, True, -1, 3, 255])
+def test_authoritative_report_unknown_exit_code_is_service_error(exit_code):
+    """Any undocumented validator exit code fails closed."""
+    report = {
+        "reana_specification": _candidate_serial_spec("docker.io/library/busybox:1.36"),
+        "error": None,
+    }
+    with pytest.raises(SpecValidationServiceError, match="Unexpected.*exit code"):
+        _authoritative_report(report, exit_code=exit_code, policy={})
+
+
+def test_authoritative_report_success_without_candidate_is_service_error():
+    """Exit code 0 is valid only when it carries a loaded candidate."""
+    report = {"reana_specification": None, "error": None}
+    with pytest.raises(SpecValidationServiceError, match="without a candidate"):
+        _authoritative_report(report, exit_code=0, policy={})
+
+
+def test_authoritative_report_load_failure_with_candidate_is_service_error():
+    """Exit code 1 cannot carry a contradictory successfully loaded candidate."""
+    report = {
+        "reana_specification": _candidate_serial_spec("docker.io/library/busybox:1.36"),
+        "error": {"code": "load", "message": "bad Snakefile"},
+    }
+    with pytest.raises(SpecValidationServiceError, match="candidate.*failed load"):
+        _authoritative_report(report, exit_code=1, policy={})
+
+
+def test_authoritative_report_load_failure_is_invalid_not_service_error():
+    """A spec that fails to load is a user-facing invalid result (not a 500)."""
+    report = {
+        "reana_specification": None,
+        "error": {"code": "load", "message": "bad Snakefile"},
+    }
+    result = _authoritative_report(report, exit_code=1, policy={})
+    assert result["valid"] is False
+    assert result["reana_specification"] is None
+    assert result["errors"][0]["code"] == "load"
+    assert result["errors"][0]["message"] == "bad Snakefile"
+
+
+def test_authoritative_report_load_message_is_bounded():
+    """A huge/multi-line loader message is reduced to a bounded first line."""
+    report = {
+        "reana_specification": None,
+        "error": {"code": "load", "message": "X" * 5000 + "\nsecond line"},
+    }
+    message = _authoritative_report(report, exit_code=1, policy={})["errors"][0][
+        "message"
+    ]
+    assert len(message) == MAX_LOAD_ERROR_MESSAGE_CHARS + len("...")
+    assert message.endswith("...")
+    assert "second line" not in message
+
+
+def test_validate_spec_bundle_serial_load_failure_is_invalid(monkeypatch, tmp_path):
+    """A serial spec that fails to load is invalid (not a 500) -- sandbox parity.
+
+    The serial branch loads in-process; a load failure must yield the same
+    ``code == "load"`` invalid report (bounded message) as the sandbox path,
+    rather than propagating as an unhandled 500.
+    """
+    (tmp_path / "reana.yaml").write_text("version: 0.3.0\nworkflow:\n  type: serial\n")
+    monkeypatch.setattr(server_validation, "build_validation_policy", lambda: {})
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError(
+            "[Errno 2] No such file or directory: 'code/helloworld.py'\nframe"
+        )
+
+    monkeypatch.setattr("reana_commons.specification.load_reana_spec", _boom)
+
+    report = server_validation.validate_spec_bundle(str(tmp_path), "validation-tmp/x")
+    assert report["valid"] is False
+    assert report["reana_specification"] is None
+    assert report["errors"][0]["code"] == "load"
+    assert report["errors"][0]["message"] == (
+        "[Errno 2] No such file or directory: 'code/helloworld.py'"
+    )
+
+
+def test_validate_spec_bundle_warns_about_legacy_external_workflow_scope(
+    monkeypatch, tmp_path
+):
+    """Legacy external workflow inputs produce an actionable warning."""
+    (tmp_path / "workflow.cwl").write_text("class: Workflow")
+    (tmp_path / "step.cwl").write_text("class: CommandLineTool")
+    (tmp_path / "reana.yaml").write_text(
+        "inputs:\n"
+        "  files: [step.cwl]\n"
+        "workflow:\n"
+        "  type: cwl\n"
+        "  file: workflow.cwl\n"
+    )
+    monkeypatch.setattr(server_validation, "build_validation_policy", lambda: {})
+    monkeypatch.setattr(
+        server_validation,
+        "_call_rwc_validate",
+        lambda _path: (
+            0,
+            {
+                "reana_specification": _candidate_serial_spec(
+                    "docker.io/library/busybox:1.36"
+                ),
+                "error": None,
+            },
+        ),
+    )
+
+    report = server_validation.validate_spec_bundle(str(tmp_path), "validation-tmp/x")
+
+    assert report["warnings"][-1]["code"] == ("deprecated_input_workflow_sources")
+
+
+def test_call_rwc_validate_transport_error_is_service_error(monkeypatch):
+    """A controller transport failure surfaces as a service error (-> 500)."""
+
+    def _boom(*args, **kwargs):
+        raise server_validation.requests.exceptions.RequestException("unreachable")
+
+    monkeypatch.setattr(server_validation.requests, "post", _boom)
+    with pytest.raises(SpecValidationServiceError):
+        _call_rwc_validate("validation-tmp/x")
+
+
+def test_call_rwc_validate_controller_error_is_service_error(monkeypatch):
+    """A non-OK controller response surfaces as a service error (-> 500)."""
+
+    class _Resp:
+        ok = False
+
+        def json(self):
+            return {"message": "controller exploded"}
+
+    monkeypatch.setattr(server_validation.requests, "post", lambda *a, **k: _Resp())
+    with pytest.raises(SpecValidationServiceError, match="controller exploded"):
+        _call_rwc_validate("validation-tmp/x")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param([], id="list-payload"),
+        pytest.param({}, id="missing-report"),
+        pytest.param({"report": None}, id="null-report"),
+        pytest.param({"report": []}, id="list-report"),
+    ],
+)
+def test_call_rwc_validate_malformed_success_is_service_error(monkeypatch, payload):
+    """A malformed successful controller response is an infrastructure failure."""
+
+    class _Resp:
+        ok = True
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(server_validation.requests, "post", lambda *a, **k: _Resp())
+    with pytest.raises(SpecValidationServiceError, match="malformed response"):
+        _call_rwc_validate("validation-tmp/x")
+
+
+def test_call_rwc_validate_non_json_success_is_service_error(monkeypatch):
+    """A non-JSON successful controller response is an infrastructure failure."""
+
+    class _Resp:
+        ok = True
+
+        def json(self):
+            raise ValueError("not JSON")
+
+    monkeypatch.setattr(server_validation.requests, "post", lambda *a, **k: _Resp())
+    with pytest.raises(SpecValidationServiceError, match="malformed response"):
+        _call_rwc_validate("validation-tmp/x")
 
 
 ALLOWLIST = {
@@ -277,9 +1217,12 @@ def snakemake_workflow(*images):
     ],
 )
 def test_validate_images(config, workflow, error):
-    with patch("reana_server.validation.REANA_VETTED_CONTAINER_IMAGES", config):
-        with error:
-            validate_images({"workflow": workflow})
+    with error:
+        validate_images(
+            {"workflow": workflow},
+            enabled=config["enabled"],
+            allowlist=config["allowlist"],
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -11,21 +11,63 @@
 import copy
 import json
 import logging
+import os
+import shutil
+import zipfile
+import yaml
+from contextlib import contextmanager
 from io import BytesIO
 from uuid import uuid4
 
 import pytest
 from flask import Flask, url_for
 from mock import Mock, patch
+from werkzeug.test import EnvironBuilder
+from reana_commons.config import (
+    WORKFLOW_RUNTIME_USER_GID,
+    WORKFLOW_RUNTIME_USER_UID,
+)
 from reana_commons.testing import make_mock_api_client
 
-from reana_db.models import User, InteractiveSessionType, RunStatus
+from reana_db.models import (
+    User,
+    InteractiveSessionType,
+    RunStatus,
+    Workflow,
+    WorkflowResource,
+    WorkspaceRetentionAuditLog,
+    WorkspaceRetentionRule,
+    WorkspaceRetentionRuleStatus,
+)
+from reana_commons.errors import (
+    REANAQuotaExceededError,
+    REANASpecificationPathError,
+    REANAValidationError,
+)
 from reana_commons.k8s.secrets import UserSecrets, Secret
 
 from reana_server.utils import (
     _create_and_associate_local_user,
     _create_and_associate_oauth_user,
 )
+from reana_server.workspace_mutations import (
+    WorkspaceMutationConflict,
+    WorkspaceMutationUnavailable,
+)
+from reana_server.validation import SpecValidationServiceError
+
+
+@pytest.fixture(autouse=True)
+def _validation_shared_volume(app, monkeypatch):
+    """Stage validation snapshots in the test application's shared volume."""
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.SHARED_VOLUME_PATH",
+        app.config["SHARED_VOLUME_PATH"],
+    )
+    monkeypatch.setattr(
+        "reana_server.rest.launch.SHARED_VOLUME_PATH",
+        app.config["SHARED_VOLUME_PATH"],
+    )
 
 
 def test_get_workflows(app, user0, _get_user_mock):
@@ -57,15 +99,116 @@ def test_get_workflows(app, user0, _get_user_mock):
             assert res.status_code == 200
 
 
+SERIAL_REANA_YAML = (
+    "workflow:\n"
+    "  type: serial\n"
+    "  specification:\n"
+    "    steps:\n"
+    "      - name: step1\n"
+    "        environment: 'docker.io/library/busybox:1.36'\n"
+    "        commands:\n"
+    "          - echo hello\n"
+    "inputs:\n"
+    "  parameters: {}\n"
+)
+
+
+def _serial_bundle():
+    """Build a fresh multipart spec bundle for a single request."""
+    return _zip_bundle({"reana.yaml": SERIAL_REANA_YAML.encode()})
+
+
+def _serial_bundle_with_uid_override():
+    """Build a spec using one image under two runtime identities."""
+    reana_yaml = (
+        "workflow:\n"
+        "  type: serial\n"
+        "  specification:\n"
+        "    steps:\n"
+        "      - name: default-uid\n"
+        "        environment: 'docker.io/library/busybox:1.36'\n"
+        "        commands: ['true']\n"
+        "      - name: custom-uid\n"
+        "        environment: 'docker.io/library/busybox:1.36'\n"
+        "        kubernetes_uid: 2000\n"
+        "        commands: ['true']\n"
+        "inputs:\n"
+        "  parameters: {}\n"
+    )
+    return _zip_bundle({"reana.yaml": reana_yaml.encode()})
+
+
+def _bundle_with_spec(spec):
+    """Build a fresh multipart bundle containing raw specification text."""
+    return _zip_bundle({"reana.yaml": spec.encode()})
+
+
+def _zip_bundle(entries):
+    """Build the one-file multipart validation ZIP contract."""
+    stream = BytesIO()
+    with zipfile.ZipFile(stream, "w", compression=zipfile.ZIP_STORED) as archive:
+        for name, content in sorted(entries.items()):
+            archive.writestr(name, content)
+    stream.seek(0)
+    return {"bundle": (stream, "validation-bundle.zip")}
+
+
+def _quota_call_for_user(mock, user):
+    """Assert a quota helper was called once for ``user`` and return the call.
+
+    The request-scoped ``user`` the view passes is a different SQLAlchemy
+    instance from the test fixture (loaded in a separate session), so compare by
+    the stable ``id_`` rather than object identity.
+    """
+    mock.assert_called_once()
+    call = mock.call_args
+    assert call.args[0].id_ == user.id_
+    return call
+
+
 def test_create_workflow(
-    app, session, user0, _get_user_mock, sample_serial_workflow_in_db
+    app,
+    session,
+    user0,
+    _get_user_mock,
+    sample_serial_workflow_in_db,
+    monkeypatch,
+    tmp_path,
 ):
-    """Test create_workflow view."""
+    """Test create_workflow view (multipart specification bundle upload)."""
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.uuid.uuid4",
+        lambda: sample_serial_workflow_in_db.id_,
+    )
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.build_workspace_path",
+        lambda *_args: sample_serial_workflow_in_db.workspace_path,
+    )
+    # The bundle is staged on the shared volume before being loaded/validated.
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    # The server seeds the freshly created workspace from the uploaded bundle, so
+    # the mocked controller must return a real workflow whose workspace exists.
+    create_http_response = Mock()
+    create_http_response.status_code = 200
+    rwc_client = Mock()
+    rwc_client.api.create_workflow.return_value.result.return_value = (
+        {
+            "workflow_id": str(sample_serial_workflow_in_db.id_),
+            "workflow_name": sample_serial_workflow_in_db.name,
+        },
+        create_http_response,
+    )
     with app.test_client() as client:
         with patch(
             "reana_server.rest.workflows.current_rwc_api_client",
-            make_mock_api_client("reana-workflow-controller")(),
-        ):
+            rwc_client,
+        ), patch(
+            "reana_server.rest.workflows.prevent_disk_quota_excess"
+        ) as prevent_quota_mock, patch(
+            "reana_server.rest.workflows.store_workflow_disk_quota"
+        ) as store_workflow_quota_mock, patch(
+            "reana_server.rest.workflows.update_users_disk_quota"
+        ) as update_user_quota_mock:
             res = client.post(url_for("workflows.create_workflow"))
             assert res.status_code == 401
 
@@ -87,102 +230,1367 @@ def test_create_workflow(
             )
             assert res.status_code == 501
 
-            # no specification provided
+            # no specification bundle provided
             res = client.post(
                 url_for("workflows.create_workflow"),
                 query_string={"access_token": user0.access_token},
             )
-            assert res.status_code == 500
-
-            # unknown workflow engine
-            workflow_specification = copy.deepcopy(
-                sample_serial_workflow_in_db.reana_specification
-            )
-            workflow_specification["workflow"]["type"] = "unknown"
-            res = client.post(
-                url_for("workflows.create_workflow"),
-                headers={"Content-Type": "application/json"},
-                query_string={
-                    "access_token": user0.access_token,
-                    "workflow_name": "test",
-                },
-                data=json.dumps(workflow_specification),
-            )
-            assert res.status_code == 500
+            assert res.status_code == 400
 
             # name cannot be valid uuid4
             res = client.post(
                 url_for("workflows.create_workflow"),
-                headers={"Content-Type": "application/json"},
                 query_string={
                     "access_token": user0.access_token,
                     "workflow_name": str(uuid4()),
                 },
-                data=json.dumps(sample_serial_workflow_in_db.reana_specification),
+                data=_serial_bundle(),
+                content_type="multipart/form-data",
             )
             assert res.status_code == 400
 
-            # wrong specification json
-            workflow_specification = {
-                "nonsense": {"specification": {}, "type": "unknown"}
-            }
+            # correct case: a serial bundle is loaded and validated in-process,
+            # then seeded into the created workspace (C1) and the staging dir is
+            # cleaned up. The uploaded bytes are pre-checked against disk quota and
+            # accounted after the workspace is seeded.
+            prevent_quota_mock.reset_mock()
+            store_workflow_quota_mock.reset_mock()
+            update_user_quota_mock.reset_mock()
             res = client.post(
                 url_for("workflows.create_workflow"),
-                headers={"Content-Type": "application/json"},
                 query_string={
                     "access_token": user0.access_token,
                     "workflow_name": "test",
                 },
-                data=json.dumps(workflow_specification),
-            )
-            assert res.status_code == 400
-
-            # not valid specification. but there is no validation
-            workflow_specification = {
-                "workflow": {"specification": {}, "type": "serial"},
-            }
-            res = client.post(
-                url_for("workflows.create_workflow"),
-                headers={"Content-Type": "application/json"},
-                query_string={
-                    "access_token": user0.access_token,
-                    "workflow_name": "test",
-                },
-                data=json.dumps(workflow_specification),
+                data=_serial_bundle(),
+                content_type="multipart/form-data",
             )
             assert res.status_code == 200
+            bundle_bytes = len(SERIAL_REANA_YAML.encode())
+            prevent_call = _quota_call_for_user(prevent_quota_mock, user0)
+            assert prevent_call.args[1] == bundle_bytes
+            assert prevent_call.kwargs == {"action": "Creating the workflow test"}
+            seeded = os.path.join(
+                sample_serial_workflow_in_db.workspace_path, "reana.yaml"
+            )
+            assert os.path.isfile(seeded)
+            store_workflow_quota_mock.assert_called_once_with(
+                sample_serial_workflow_in_db, bytes_to_sum=bundle_bytes
+            )
+            update_call = _quota_call_for_user(update_user_quota_mock, user0)
+            assert update_call.kwargs == {"bytes_to_sum": bundle_bytes}
+            # No staging bundle is left behind under the shared volume.
+            staging = os.path.join(str(tmp_path), "validation-tmp")
+            assert not os.path.isdir(staging) or not os.listdir(staging)
 
-            # correct case
-            workflow_specification = sample_serial_workflow_in_db.reana_specification
+
+def test_create_workflow_rejects_legacy_json_specification(
+    app, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """A released client's JSON create gets actionable upgrade guidance."""
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    rwc_client = Mock()
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.current_rwc_api_client", rwc_client
+    ):
+        # This is the exact wire shape a released client sends: the OpenAPI body
+        # parameter is *named* ``reana_specification``, but a Swagger 2.0 body
+        # parameter's schema is the body, so the serialized specification
+        # arrives as the whole JSON document with no wrapping key.
+        res = client.post(
+            url_for("workflows.create_workflow"),
+            query_string={
+                "access_token": user0.access_token,
+                "workflow_name": "test",
+            },
+            data=json.dumps(
+                {
+                    "version": "0.3.0",
+                    "inputs": {"files": ["code/helloworld.py"]},
+                    "outputs": {"files": ["results/greetings.txt"]},
+                    "workflow": {
+                        "type": "serial",
+                        "specification": {"steps": [{"commands": ["echo hello"]}]},
+                    },
+                }
+            ),
+            content_type="application/json",
+        )
+
+    assert res.status_code == 400
+    assert "reana_specification" in res.json["message"]
+    assert "upgrade REANA client" in res.json["message"]
+    assert "'bundle'" in res.json["message"]
+    rwc_client.api.create_workflow.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "lock_error,status_code",
+    [(WorkspaceMutationConflict, 409), (WorkspaceMutationUnavailable, 503)],
+)
+def test_create_workflow_maps_creation_lock_failures(
+    app, user0, _get_user_mock, monkeypatch, tmp_path, lock_error, status_code
+):
+    """Creation exposes family-lock contention and infrastructure failures."""
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.workflow_creation_mutation_lock",
+        side_effect=lock_error(),
+    ):
+        response = client.post(
+            url_for("workflows.create_workflow"),
+            query_string={
+                "access_token": user0.access_token,
+                "workflow_name": "locked-create",
+            },
+            data=_serial_bundle(),
+            content_type="multipart/form-data",
+        )
+
+    assert response.status_code == status_code
+    assert response.json["message"]
+
+
+def test_create_workflow_compensates_an_unexpected_controller_id(
+    app,
+    session,
+    user0,
+    _get_user_mock,
+    sample_serial_workflow_in_db,
+    monkeypatch,
+    tmp_path,
+):
+    """A controller that ignores the reserved UUID cannot leave an orphan."""
+    expected_workflow_id = uuid4()
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.uuid.uuid4", lambda: expected_workflow_id
+    )
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.build_workspace_path",
+        lambda *_args: sample_serial_workflow_in_db.workspace_path,
+    )
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    rwc_client = Mock()
+    rwc_client.api.create_workflow.return_value.result.return_value = (
+        {"workflow_id": str(sample_serial_workflow_in_db.id_)},
+        Mock(status_code=201),
+    )
+
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.current_rwc_api_client", rwc_client
+    ), patch("reana_server.rest.workflows.prevent_disk_quota_excess"), patch(
+        "reana_server.rest.workflows.store_workflow_disk_quota"
+    ), patch(
+        "reana_server.rest.workflows.update_users_disk_quota"
+    ):
+        response = client.post(
+            url_for("workflows.create_workflow"),
+            query_string={
+                "access_token": user0.access_token,
+                "workflow_name": "mismatched-create",
+            },
+            data=_serial_bundle(),
+            content_type="multipart/form-data",
+        )
+
+    assert response.status_code == 500
+    session.refresh(sample_serial_workflow_in_db)
+    assert sample_serial_workflow_in_db.status == RunStatus.deleted
+    assert not os.path.exists(sample_serial_workflow_in_db.workspace_path)
+
+
+def test_create_workflow_rejects_over_quota_user_before_staging(
+    app, session, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """An over-quota raw-bundle create is rejected before any expensive work.
+
+    The quota guard runs before staging the bundle or spawning a validator Job,
+    so nothing is staged/validated and no controller create (hence no orphan
+    workflow) happens.
+    """
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    rwc_client = Mock()
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.current_rwc_api_client", rwc_client
+    ), patch("reana_db.models.User.has_exceeded_quota", return_value=True), patch(
+        "reana_server.rest.workflows.get_quota_excess_message",
+        return_value="quota exceeded",
+    ), patch(
+        "reana_server.rest.workflows._stage_validation_bundle"
+    ) as stage_mock, patch(
+        "reana_server.rest.workflows.load_and_validate_spec"
+    ) as load_mock:
+        res = client.post(
+            url_for("workflows.create_workflow"),
+            query_string={
+                "access_token": user0.access_token,
+                "workflow_name": "over-quota",
+            },
+            data=_serial_bundle(),
+            content_type="multipart/form-data",
+        )
+    assert res.status_code == 403
+    stage_mock.assert_not_called()
+    load_mock.assert_not_called()
+    rwc_client.api.create_workflow.assert_not_called()
+
+
+def test_create_workflow_quota_excess_before_create_leaves_no_orphan(
+    app, session, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """A staged bundle that would exceed quota fails before the row is created.
+
+    ``prevent_disk_quota_excess`` runs after staging/validation but before the
+    controller create, so a rejection returns 403 with no orphan workflow and
+    the staging directory is cleaned up.
+    """
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    rwc_client = Mock()
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.current_rwc_api_client", rwc_client
+    ), patch(
+        "reana_server.rest.workflows.prevent_disk_quota_excess",
+        side_effect=REANAQuotaExceededError("disk quota exceeded"),
+    ):
+        res = client.post(
+            url_for("workflows.create_workflow"),
+            query_string={
+                "access_token": user0.access_token,
+                "workflow_name": "quota-excess",
+            },
+            data=_serial_bundle(),
+            content_type="multipart/form-data",
+        )
+    assert res.status_code == 403
+    rwc_client.api.create_workflow.assert_not_called()
+    staging = os.path.join(str(tmp_path), "validation-tmp")
+    assert not os.path.isdir(staging) or not os.listdir(staging)
+
+
+def test_raw_bundle_create_failure_compensates_workspace_and_quota(
+    app,
+    session,
+    user0,
+    _get_user_mock,
+    sample_serial_workflow_in_db,
+    monkeypatch,
+    tmp_path,
+):
+    """A failure after controller create leaves no live workflow or workspace.
+
+    Exercise the latest possible failure point: workflow quota accounting and
+    bundle promotion have completed, but user quota accounting fails. Cleanup
+    must remove the promoted workspace, mark the row deleted, reset workflow
+    quota, and recalculate user quota. Calling compensation again demonstrates
+    that every cleanup action is retry-safe.
+    """
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.uuid.uuid4",
+        lambda: sample_serial_workflow_in_db.id_,
+    )
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.build_workspace_path",
+        lambda *_args: sample_serial_workflow_in_db.workspace_path,
+    )
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    create_http_response = Mock(status_code=201)
+    rwc_client = Mock()
+    rwc_client.api.create_workflow.return_value.result.return_value = (
+        {
+            "workflow_id": str(sample_serial_workflow_in_db.id_),
+            "workflow_name": sample_serial_workflow_in_db.name,
+        },
+        create_http_response,
+    )
+
+    def _fail_initial_user_accounting(*args, **kwargs):
+        if "bytes_to_sum" in kwargs:
+            raise RuntimeError("private quota database detail")
+
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.current_rwc_api_client", rwc_client
+    ), patch("reana_server.rest.workflows.prevent_disk_quota_excess"), patch(
+        "reana_server.rest.workflows.store_workflow_disk_quota"
+    ) as store_mock, patch(
+        "reana_server.rest.workflows.update_users_disk_quota",
+        side_effect=_fail_initial_user_accounting,
+    ) as update_mock:
+        res = client.post(
+            url_for("workflows.create_workflow"),
+            query_string={
+                "access_token": user0.access_token,
+                "workflow_name": "transactional-create",
+            },
+            data=_serial_bundle(),
+            content_type="multipart/form-data",
+        )
+
+        assert res.status_code == 500
+        assert res.json["message"] == "An internal server error occurred."
+        assert "private quota database detail" not in res.get_data(as_text=True)
+
+        session.refresh(sample_serial_workflow_in_db)
+        assert sample_serial_workflow_in_db.status == RunStatus.deleted
+        assert not os.path.exists(sample_serial_workflow_in_db.workspace_path)
+
+        bundle_bytes = len(SERIAL_REANA_YAML.encode())
+        assert store_mock.call_args_list[0].kwargs == {"bytes_to_sum": bundle_bytes}
+        assert store_mock.call_args_list[1].kwargs == {
+            "bytes_to_sum": None,
+            "override_policy_checks": True,
+        }
+        assert update_mock.call_args_list[0].kwargs == {"bytes_to_sum": bundle_bytes}
+        assert update_mock.call_args_list[1].kwargs == {"override_policy_checks": True}
+
+        # A retried compensating action converges on the same state.
+        from reana_server.rest.workflows import _compensate_failed_workflow_create
+
+        _compensate_failed_workflow_create(sample_serial_workflow_in_db, user0)
+        assert not os.path.exists(sample_serial_workflow_in_db.workspace_path)
+        assert store_mock.call_args_list[-1].kwargs == {
+            "bytes_to_sum": None,
+            "override_policy_checks": True,
+        }
+        assert update_mock.call_args_list[-1].kwargs == {"override_policy_checks": True}
+
+
+def test_raw_bundle_promotion_failure_is_compensated(
+    app,
+    session,
+    user0,
+    _get_user_mock,
+    sample_serial_workflow_in_db,
+    monkeypatch,
+    tmp_path,
+):
+    """Even a partial workspace promotion is removed before returning 500."""
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.uuid.uuid4",
+        lambda: sample_serial_workflow_in_db.id_,
+    )
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.build_workspace_path",
+        lambda *_args: sample_serial_workflow_in_db.workspace_path,
+    )
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    rwc_client = Mock()
+    rwc_client.api.create_workflow.return_value.result.return_value = (
+        {
+            "workflow_id": str(sample_serial_workflow_in_db.id_),
+            "workflow_name": sample_serial_workflow_in_db.name,
+        },
+        Mock(status_code=201),
+    )
+
+    def _partially_promote_then_fail(source, target):
+        os.makedirs(target, exist_ok=True)
+        with open(os.path.join(target, "partial"), "w") as partial:
+            partial.write("partial")
+        raise RuntimeError("private filesystem detail")
+
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.current_rwc_api_client", rwc_client
+    ), patch("reana_server.rest.workflows.prevent_disk_quota_excess"), patch(
+        "reana_server.rest.workflows.mv_workflow_files",
+        side_effect=_partially_promote_then_fail,
+    ), patch(
+        "reana_server.rest.workflows.store_workflow_disk_quota"
+    ) as store_mock, patch(
+        "reana_server.rest.workflows.update_users_disk_quota"
+    ) as update_mock:
+        res = client.post(
+            url_for("workflows.create_workflow"),
+            query_string={
+                "access_token": user0.access_token,
+                "workflow_name": "failed-promotion",
+            },
+            data=_serial_bundle(),
+            content_type="multipart/form-data",
+        )
+
+    assert res.status_code == 500
+    assert "private filesystem detail" not in res.get_data(as_text=True)
+    session.refresh(sample_serial_workflow_in_db)
+    assert sample_serial_workflow_in_db.status == RunStatus.deleted
+    assert not os.path.exists(sample_serial_workflow_in_db.workspace_path)
+    store_mock.assert_called_once_with(
+        sample_serial_workflow_in_db,
+        bytes_to_sum=None,
+        override_policy_checks=True,
+    )
+    update_mock.assert_called_once()
+    assert update_mock.call_args.kwargs == {"override_policy_checks": True}
+
+
+def _gitlab_create_patches(
+    rwc_client, tmp_path, validation_result=None, validation_error=None
+):
+    """Common mocks for driving the GitLab branch of ``create_workflow``."""
+    spec = yaml.safe_load(SERIAL_REANA_YAML)
+    fetched_dir = tmp_path / "gitlab-source"
+    fetched_dir.mkdir()
+    specification_path = fetched_dir / "reana.yaml"
+    specification_path.write_text(SERIAL_REANA_YAML)
+    fetcher = Mock()
+    fetcher.workflow_spec_path.return_value = str(specification_path)
+    gitlab_client = Mock()
+    gitlab_client.get_repository_archive.return_value = Mock()
+    validation_patch = patch(
+        "reana_server.rest.workflows.load_and_validate_spec",
+        return_value=validation_result or (spec, []),
+        side_effect=validation_error,
+    )
+    return spec, [
+        patch("reana_server.rest.workflows.current_rwc_api_client", rwc_client),
+        patch("reana_db.models.User.has_exceeded_quota", return_value=False),
+        patch(
+            "reana_server.rest.workflows._get_reana_yaml_from_gitlab",
+            return_value=(
+                spec,
+                "https://gitlab.example/x",
+                "gl-wf",
+                "main",
+                "deadbeef",
+            ),
+        ),
+        patch(
+            "reana_server.rest.workflows.get_fetched_workflows_dir",
+            return_value=str(fetched_dir),
+        ),
+        patch(
+            "reana_server.rest.workflows.GitLabClient.from_k8s_secret",
+            return_value=gitlab_client,
+        ),
+        patch(
+            "reana_server.rest.workflows.extract_streamed_zip_response",
+            return_value=fetcher,
+        ),
+        validation_patch,
+        patch(
+            "reana_server.rest.workflows.workspace_seed_members",
+            return_value=({"reana.yaml": str(specification_path)}, 123),
+        ),
+        patch("reana_server.rest.workflows.seed_workspace", return_value=123),
+    ]
+
+
+def test_create_workflow_gitlab_accounts_disk_quota(
+    app,
+    session,
+    user0,
+    _get_user_mock,
+    sample_serial_workflow_in_db,
+    monkeypatch,
+    tmp_path,
+):
+    """A successful GitLab create charges the cloned workspace to disk quota."""
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.uuid.uuid4",
+        lambda: sample_serial_workflow_in_db.id_,
+    )
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.build_workspace_path",
+        lambda *_args: sample_serial_workflow_in_db.workspace_path,
+    )
+    rwc_client = Mock()
+    rwc_client.api.create_workflow.return_value.result.return_value = (
+        {
+            "workflow_id": str(sample_serial_workflow_in_db.id_),
+            "workflow_name": sample_serial_workflow_in_db.name,
+        },
+        Mock(status_code=200),
+    )
+    _spec, patches = _gitlab_create_patches(rwc_client, tmp_path)
+    with app.test_client() as client:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[
+            5
+        ], patches[6], patches[7], patches[8], patch(
+            "reana_server.rest.workflows.publish_workflow_submission"
+        ), patch(
+            "reana_server.rest.workflows.store_workflow_disk_quota"
+        ) as store_mock, patch(
+            "reana_server.rest.workflows.update_users_disk_quota"
+        ) as update_mock:
             res = client.post(
                 url_for("workflows.create_workflow"),
-                headers={"Content-Type": "application/json"},
-                query_string={
-                    "access_token": user0.access_token,
-                    "workflow_name": "test",
-                },
-                data=json.dumps(workflow_specification),
+                query_string={"access_token": user0.access_token},
+                data=json.dumps({"object_kind": "push"}),
+                content_type="application/json",
+            )
+    assert res.status_code == 200
+    store_mock.assert_called_once_with(sample_serial_workflow_in_db, bytes_to_sum=123)
+    update_call = _quota_call_for_user(update_mock, user0)
+    assert update_call.kwargs == {"bytes_to_sum": 123}
+
+
+def test_create_workflow_gitlab_quota_excess_rolls_back(
+    app,
+    session,
+    user0,
+    _get_user_mock,
+    sample_serial_workflow_in_db,
+    monkeypatch,
+    tmp_path,
+):
+    """A GitLab snapshot exceeding quota is rejected before controller create."""
+    rwc_client = Mock()
+    rwc_client.api.create_workflow.return_value.result.return_value = (
+        {
+            "workflow_id": str(sample_serial_workflow_in_db.id_),
+            "workflow_name": sample_serial_workflow_in_db.name,
+        },
+        Mock(status_code=200),
+    )
+    _spec, patches = _gitlab_create_patches(rwc_client, tmp_path)
+    with app.test_client() as client:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[
+            5
+        ], patches[6], patches[7], patches[8], patch(
+            "reana_server.rest.workflows.prevent_disk_quota_excess",
+            side_effect=REANAQuotaExceededError("disk quota exceeded"),
+        ), patch(
+            "reana_server.rest.workflows._fail_gitlab_commit_build_status"
+        ) as fail_build_mock, patch(
+            "reana_server.rest.workflows.store_workflow_disk_quota"
+        ) as store_mock, patch(
+            "reana_server.rest.workflows.update_users_disk_quota"
+        ) as update_mock:
+            res = client.post(
+                url_for("workflows.create_workflow"),
+                query_string={"access_token": user0.access_token},
+                data=json.dumps({"object_kind": "push"}),
+                content_type="application/json",
+            )
+    assert res.status_code == 200  # GitLab webhook acknowledged
+    session.refresh(sample_serial_workflow_in_db)
+    assert sample_serial_workflow_in_db.status == RunStatus.created
+    rwc_client.api.create_workflow.assert_not_called()
+    fail_build_mock.assert_called_once()
+    store_mock.assert_not_called()
+    update_mock.assert_not_called()
+
+
+def test_create_workflow_gitlab_invalid_spec_leaves_no_orphan(
+    app,
+    session,
+    user0,
+    _get_user_mock,
+    sample_serial_workflow_in_db,
+    monkeypatch,
+    tmp_path,
+):
+    """An invalid GitLab snapshot is rejected before creating a workflow row."""
+    rwc_client = Mock()
+    rwc_client.api.create_workflow.return_value.result.return_value = (
+        {
+            "workflow_id": str(sample_serial_workflow_in_db.id_),
+            "workflow_name": sample_serial_workflow_in_db.name,
+        },
+        Mock(status_code=200),
+    )
+    _spec, patches = _gitlab_create_patches(
+        rwc_client,
+        tmp_path,
+        validation_error=REANAValidationError("invalid cloned specification"),
+    )
+    with app.test_client() as client:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[
+            5
+        ], patches[6], patches[7], patches[8], patch(
+            "reana_server.rest.workflows.store_workflow_disk_quota"
+        ) as store_mock, patch(
+            "reana_server.rest.workflows.update_users_disk_quota"
+        ) as update_mock, patch(
+            "reana_server.rest.workflows.publish_workflow_submission"
+        ) as publish_mock:
+            res = client.post(
+                url_for("workflows.create_workflow"),
+                query_string={"access_token": user0.access_token},
+                data=json.dumps({"object_kind": "push"}),
+                content_type="application/json",
+            )
+    assert res.status_code == 400
+    session.refresh(sample_serial_workflow_in_db)
+    assert sample_serial_workflow_in_db.status == RunStatus.created
+    rwc_client.api.create_workflow.assert_not_called()
+    store_mock.assert_not_called()
+    update_mock.assert_not_called()
+    publish_mock.assert_not_called()
+
+
+def test_create_workflow_gitlab_surfaces_validation_warnings(
+    app,
+    session,
+    user0,
+    _get_user_mock,
+    sample_serial_workflow_in_db,
+    monkeypatch,
+    tmp_path,
+):
+    """Post-create GitLab validation warnings are surfaced, not dropped.
+
+    On a successful GitLab create the advisory warnings from the post-create
+    ``load_and_validate_spec`` must be returned to the caller under
+    ``validation_warnings``.
+    """
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.uuid.uuid4",
+        lambda: sample_serial_workflow_in_db.id_,
+    )
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.build_workspace_path",
+        lambda *_args: sample_serial_workflow_in_db.workspace_path,
+    )
+    rwc_client = Mock()
+    rwc_client.api.create_workflow.return_value.result.return_value = (
+        {
+            "workflow_id": str(sample_serial_workflow_in_db.id_),
+            "workflow_name": sample_serial_workflow_in_db.name,
+        },
+        Mock(status_code=200),
+    )
+    warning = {"code": "environment", "message": "floating tag", "path": "step1"}
+    _spec, patches = _gitlab_create_patches(
+        rwc_client,
+        tmp_path,
+        validation_result=(yaml.safe_load(SERIAL_REANA_YAML), [warning]),
+    )
+    with app.test_client() as client:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[
+            5
+        ], patches[6], patches[7], patches[8], patch(
+            "reana_server.rest.workflows.store_workflow_disk_quota"
+        ), patch(
+            "reana_server.rest.workflows.update_users_disk_quota"
+        ), patch(
+            "reana_server.rest.workflows.publish_workflow_submission"
+        ):
+            res = client.post(
+                url_for("workflows.create_workflow"),
+                query_string={"access_token": user0.access_token},
+                data=json.dumps({"object_kind": "push"}),
+                content_type="application/json",
+            )
+    assert res.status_code == 200
+    assert warning in res.json["validation_warnings"]
+
+
+def test_launch_validates_definition_before_seeding_inputs(
+    app,
+    user0,
+    _get_user_mock,
+    sample_serial_workflow_in_db,
+    monkeypatch,
+    tmp_path,
+):
+    """Launch validates definitions only, then seeds declared datasets."""
+    monkeypatch.setattr(
+        "reana_server.rest.launch.uuid.uuid4",
+        lambda: sample_serial_workflow_in_db.id_,
+    )
+    monkeypatch.setattr(
+        "reana_server.rest.launch.build_workspace_path",
+        lambda *_args: sample_serial_workflow_in_db.workspace_path,
+    )
+    source = tmp_path / "launch-source"
+    (source / "code").mkdir(parents=True)
+    (source / "data").mkdir()
+    (source / "code" / "helper.py").write_text("print('helper')")
+    (source / "data" / "input.csv").write_text("dataset")
+    (source / "undeclared.txt").write_text("must not enter workspace")
+    (source / "reana.yaml").write_text(
+        "inputs:\n"
+        "  files: [data/input.csv]\n"
+        "  parameters: {}\n"
+        "workflow:\n"
+        "  type: serial\n"
+        "  files: [code/helper.py]\n"
+        "  specification:\n"
+        "    steps:\n"
+        "      - name: step1\n"
+        "        environment: docker.io/library/busybox:1.36\n"
+        "        commands: ['true']\n"
+    )
+    fetcher = Mock()
+    fetcher.workflow_spec_path.return_value = str(source / "reana.yaml")
+    fetcher.generate_workflow_name.return_value = "launched"
+    rwc_client = Mock()
+    rwc_client.api.create_workflow.return_value.result.return_value = (
+        {
+            "workflow_id": str(sample_serial_workflow_in_db.id_),
+            "workflow_name": sample_serial_workflow_in_db.name,
+        },
+        Mock(status_code=201),
+    )
+    shutil.rmtree(sample_serial_workflow_in_db.workspace_path)
+
+    from reana_server.validation import load_and_validate_spec
+
+    validated_members = set()
+
+    def record_validation_snapshot(directory):
+        for root, _directories, files in os.walk(directory):
+            for filename in files:
+                validated_members.add(
+                    os.path.relpath(os.path.join(root, filename), directory)
+                )
+        return load_and_validate_spec(directory)
+
+    with app.test_client() as client, patch(
+        "reana_server.rest.launch.get_fetched_workflows_dir",
+        return_value=str(source),
+    ), patch("reana_server.rest.launch.get_fetcher", return_value=fetcher), patch(
+        "reana_server.rest.launch.load_and_validate_spec",
+        side_effect=record_validation_snapshot,
+    ), patch(
+        "reana_server.rest.launch.current_rwc_api_client", rwc_client
+    ), patch(
+        "reana_server.rest.launch.prevent_disk_quota_excess"
+    ), patch(
+        "reana_server.rest.launch.store_workflow_disk_quota"
+    ), patch(
+        "reana_server.rest.launch.update_users_disk_quota"
+    ), patch(
+        "reana_server.rest.launch.publish_workflow_submission"
+    ):
+        response = client.post(
+            url_for("launch.launch"),
+            query_string={"access_token": user0.access_token},
+            json={"url": "https://example.org/workflow.zip"},
+        )
+
+    assert response.status_code == 200
+    assert validated_members == {"reana.yaml", "code/helper.py"}
+    workspace = sample_serial_workflow_in_db.workspace_path
+    assert os.path.isfile(os.path.join(workspace, "reana.yaml"))
+    assert os.path.isfile(os.path.join(workspace, "code", "helper.py"))
+    assert os.path.isfile(os.path.join(workspace, "data", "input.csv"))
+    assert not os.path.exists(os.path.join(workspace, "undeclared.txt"))
+    create_call = rwc_client.api.create_workflow.call_args
+    assert create_call.kwargs["workflow"]["workflow_id"] == str(
+        sample_serial_workflow_in_db.id_
+    )
+    assert set(create_call.kwargs["_request_options"]) == {"connect_timeout", "timeout"}
+
+
+def test_validation_and_start_endpoints_use_slow_rate_limit(app):
+    """Validation, creation, and start carry the slow rate limit.
+
+    These endpoints can spawn a sandboxed validation Job per call, so they must
+    be throttled like ``launch`` rather than falling under the fast global
+    authenticated-user limit.
+    """
+    from flask import request
+    from invenio_app.limiter import set_rate_limit
+    from reana_server.config import REANA_RATELIMIT_SLOW, set_reana_rate_limit
+
+    for endpoint in (
+        "workflows.validate_workflow_specification",
+        "workflows.create_workflow",
+        "workflows.start_workflow",
+        "workflows.restart_workflow",
+    ):
+        values = (
+            {"workflow_id_or_name": "test"}
+            if endpoint in ("workflows.start_workflow", "workflows.restart_workflow")
+            else {}
+        )
+        with app.test_request_context(url_for(endpoint, **values), method="POST"):
+            assert request.endpoint == endpoint
+            assert set_reana_rate_limit() == REANA_RATELIMIT_SLOW
+
+    status_url = url_for("workflows.set_workflow_status", workflow_id_or_name="test")
+    with app.test_request_context(
+        status_url, method="PUT", query_string={"status": "start"}
+    ):
+        assert set_reana_rate_limit() == REANA_RATELIMIT_SLOW
+
+    for status in ("stop", "deleted"):
+        with app.test_request_context(
+            status_url, method="PUT", query_string={"status": status}
+        ):
+            assert set_reana_rate_limit() == set_rate_limit()
+
+
+def test_validate_workflow_specification_environment_check(
+    app, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """The ``environments`` flag drives the optional image check wiring.
+
+    Offline tag checks run only when requested and the endpoint returns image
+    and effective runtime-identity records for an optional local ``--pull``.
+    """
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    finding = {"code": "image_tag", "message": "boom", "path": "img:1"}
+    with app.test_client() as client:
+        with patch(
+            "reana_server.rest.workflows.iter_environment_tag_warnings",
+            return_value=iter(
+                [{"code": "image_tag", "message": "boom", "image": "img:1"}]
+            ),
+        ) as env_mock:
+            # Without the flag the check is not run and no image data is added.
+            res = client.post(
+                url_for("workflows.validate_workflow_specification"),
+                query_string={"access_token": user0.access_token},
+                data=_serial_bundle_with_uid_override(),
+                content_type="multipart/form-data",
             )
             assert res.status_code == 200
+            env_mock.assert_not_called()
+            assert "images" not in res.json
+            assert "environments" not in res.json
+            assert "reana_specification" not in res.json
+
+            # --environments returns offline findings and image identities.
+            res = client.post(
+                url_for("workflows.validate_workflow_specification"),
+                query_string={
+                    "access_token": user0.access_token,
+                    "environments": "true",
+                },
+                data=_serial_bundle_with_uid_override(),
+                content_type="multipart/form-data",
+            )
+            assert res.status_code == 200
+            env_mock.assert_called_once()
+            assert finding in res.json["warnings"]
+            assert res.json["environments"] == [
+                {
+                    "image": "docker.io/library/busybox:1.36",
+                    "runtime_uid": int(WORKFLOW_RUNTIME_USER_UID),
+                    "runtime_gid": int(WORKFLOW_RUNTIME_USER_GID),
+                },
+                {
+                    "image": "docker.io/library/busybox:1.36",
+                    "runtime_uid": 2000,
+                    "runtime_gid": int(WORKFLOW_RUNTIME_USER_GID),
+                },
+            ]
+            assert "images" not in res.json
+            assert "runtime_uid" not in res.json
+            assert "runtime_gid" not in res.json
+            assert "reana_specification" not in res.json
+
+
+def test_environment_response_uses_one_bounded_lazy_budget():
+    """High-cardinality environments cannot create an oversized response."""
+    from reana_server.rest.workflows import _add_bounded_environments
+
+    yielded = 0
+
+    def environments(*_args):
+        nonlocal yielded
+        for index in range(100_000):
+            yielded += 1
+            yield {
+                "image": "registry.example/image-{}:latest".format(index),
+                "runtime_uid": 1000,
+                "runtime_gid": 1000,
+            }
+
+    report = {"valid": True, "errors": [], "warnings": []}
+    with patch("reana_server.rest.workflows.iter_image_environments", environments):
+        _add_bounded_environments(report, {"workflow": {"type": "serial"}})
+
+    assert yielded == 101
+    assert len(report["environments"]) == 99
+    assert report["warnings"] == [
+        {
+            "code": "report_truncated",
+            "message": "Additional validation findings were omitted.",
+            "path": "",
+        }
+    ]
+    assert report["environments_truncated"] is True
+    assert len(json.dumps(report).encode()) < 16 * 1024 * 1024
+
+
+def test_environment_response_skips_only_overlong_image_identity():
+    """An overlong image does not suppress later identities or tag findings."""
+    from reana_server.rest.workflows import _add_bounded_environments
+
+    report = {"valid": True, "errors": [], "warnings": []}
+    environments = [
+        {"image": "safe-before:latest", "runtime_uid": 1000, "runtime_gid": 1000},
+        {
+            "image": "registry.example/" + "x" * 600,
+            "runtime_uid": 1000,
+            "runtime_gid": 1000,
+        },
+        {"image": "safe-after:latest", "runtime_uid": 1000, "runtime_gid": 1000},
+    ]
+    with patch(
+        "reana_server.rest.workflows.iter_image_environments",
+        return_value=iter(environments),
+    ), patch(
+        "reana_server.rest.workflows.iter_environment_tag_warnings",
+        return_value=iter(
+            [
+                {
+                    "code": "latest",
+                    "message": "safe tag warning",
+                    "image": "safe-after:latest",
+                }
+            ]
+        ),
+    ):
+        _add_bounded_environments(report, {"workflow": {"type": "serial"}})
+
+    assert [item["image"] for item in report["environments"]] == [
+        "safe-before:latest",
+        "safe-after:latest",
+    ]
+    assert report["environments_truncated"] is True
+    assert {warning["code"] for warning in report["warnings"]} == {
+        "environment_identity_omitted",
+        "latest",
+        "report_truncated",
+    }
+
+
+def test_environment_budget_preserves_existing_validation_warnings():
+    """Truncation drops lower-priority environments before prior warnings."""
+    from reana_server.rest.workflows import _add_bounded_environments
+
+    original_warnings = [
+        {"code": "validation", "message": str(index), "path": ""} for index in range(99)
+    ]
+    report = {"valid": True, "errors": [], "warnings": list(original_warnings)}
+    environments = iter(
+        [
+            {"image": "image:1", "runtime_uid": 1000, "runtime_gid": 1000},
+            {"image": "image:2", "runtime_uid": 1000, "runtime_gid": 1000},
+        ]
+    )
+    with patch(
+        "reana_server.rest.workflows.iter_image_environments",
+        return_value=environments,
+    ):
+        _add_bounded_environments(report, {"workflow": {"type": "serial"}})
+
+    assert report["warnings"][:-1] == original_warnings
+    assert report["warnings"][-1]["code"] == "report_truncated"
+    assert report["environments"] == []
+    assert report["environments_truncated"] is True
+
+
+def test_environment_marker_eviction_sets_truncated_flag():
+    """Reserving the marker reports an environment evicted at the boundary."""
+    from reana_server.rest.workflows import _add_bounded_environments
+
+    original_warnings = [
+        {"code": "validation", "message": str(index), "path": ""} for index in range(99)
+    ]
+    report = {"valid": True, "errors": [], "warnings": list(original_warnings)}
+    environment = {
+        "image": "registry.example/image:latest",
+        "runtime_uid": 1000,
+        "runtime_gid": 1000,
+    }
+    with patch(
+        "reana_server.rest.workflows.iter_image_environments",
+        return_value=iter([environment]),
+    ):
+        _add_bounded_environments(report, {"workflow": {"type": "serial"}})
+
+    assert report["warnings"][:-1] == original_warnings
+    assert report["warnings"][-1]["code"] == "report_truncated"
+    assert report["environments"] == []
+    assert report["environments_truncated"] is True
+
+
+def test_validate_workflow_specification_internal_error_returns_500(
+    app, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """A sandbox internal/infra failure surfaces as 500, not 200 valid:false.
+
+    When the sandbox validator exits with the internal-error code (or reports an
+    ``internal``-coded error) ``validate_spec_bundle`` raises
+    ``SpecValidationServiceError``. The endpoint must map that to a 500 service
+    error -- never to a 200 ``valid:false`` report that a client would render as
+    "X is not a valid REANA specification".
+    """
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    with app.test_client() as client:
+        with patch(
+            "reana_server.rest.workflows.validate_spec_bundle",
+            side_effect=SpecValidationServiceError("internal validation error"),
+        ):
+            res = client.post(
+                url_for("workflows.validate_workflow_specification"),
+                query_string={"access_token": user0.access_token},
+                data=_serial_bundle(),
+                content_type="multipart/form-data",
+            )
+    assert res.status_code == 500
+    # Reported as a service failure, not an invalid specification.
+    assert res.json.get("valid") is not False
+    assert res.json["message"] == "An internal server error occurred."
+    assert "internal validation error" not in res.get_data(as_text=True)
+
+
+def test_validate_workflow_specification_controller_unreachable_returns_500(
+    app, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """A controller outage during validation surfaces as 500, not a 400.
+
+    Controller-unreachable / non-OK controller responses raise
+    ``SpecValidationServiceError`` from ``_call_rwc_validate``; the endpoint must
+    treat that server-side outage as a 500, not a 400 client error.
+    """
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    with app.test_client() as client:
+        with patch(
+            "reana_server.rest.workflows.validate_spec_bundle",
+            side_effect=SpecValidationServiceError(
+                "Could not reach the workflow specification validation service."
+            ),
+        ):
+            res = client.post(
+                url_for("workflows.validate_workflow_specification"),
+                query_string={"access_token": user0.access_token},
+                data=_serial_bundle(),
+                content_type="multipart/form-data",
+            )
+    assert res.status_code == 500
+    assert res.json["message"] == "An internal server error occurred."
+    assert "Could not reach" not in res.get_data(as_text=True)
+
+
+def test_validate_workflow_specification_unexpected_error_is_opaque(
+    app, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """Unexpected validation exceptions are logged but not returned verbatim."""
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.validate_spec_bundle",
+        side_effect=RuntimeError("/private/cluster/path"),
+    ):
+        res = client.post(
+            url_for("workflows.validate_workflow_specification"),
+            query_string={"access_token": user0.access_token},
+            data=_serial_bundle(),
+            content_type="multipart/form-data",
+        )
+
+    assert res.status_code == 500
+    assert res.json["message"] == "An internal server error occurred."
+    assert "/private/cluster/path" not in res.get_data(as_text=True)
+
+
+def test_validate_workflow_specification_invalid_spec_returns_200(
+    app, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """A genuinely invalid specification stays a 200 ``valid:false`` report.
+
+    Only *service* failures are 500; a spec that loads but fails policy (or fails
+    to load) is a normal validation outcome returned with HTTP 200 so the client
+    can render the structured errors.
+    """
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    invalid_report = {
+        "valid": False,
+        "reana_specification": None,
+        "errors": [{"code": "load", "message": "bad spec", "path": ""}],
+        "warnings": [],
+    }
+    with app.test_client() as client:
+        with patch(
+            "reana_server.rest.workflows.validate_spec_bundle",
+            return_value=invalid_report,
+        ):
+            res = client.post(
+                url_for("workflows.validate_workflow_specification"),
+                query_string={"access_token": user0.access_token},
+                data=_serial_bundle(),
+                content_type="multipart/form-data",
+            )
+    assert res.status_code == 200
+    assert res.json["valid"] is False
+    assert res.json["errors"][0]["code"] == "load"
+    assert "reana_specification" not in res.json
+
+
+def test_validate_does_not_echo_large_expanded_specification(
+    app, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """An expanded spec above the Go response cap remains an internal artifact."""
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    report = {
+        "valid": True,
+        "reana_specification": {"padding": "x" * (17 * 1024 * 1024)},
+        "errors": [],
+        "warnings": [],
+    }
+    with app.test_client() as client:
+        with patch(
+            "reana_server.rest.workflows.validate_spec_bundle", return_value=report
+        ):
+            res = client.post(
+                url_for("workflows.validate_workflow_specification"),
+                query_string={"access_token": user0.access_token},
+                data=_serial_bundle(),
+                content_type="multipart/form-data",
+            )
+
+    assert res.status_code == 200
+    assert "reana_specification" not in res.json
+    assert len(res.data) < 16 * 1024 * 1024
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "workflow: [unterminated\n",
+        "- workflow\n- is\n- a\n- list\n",
+        "just-a-scalar\n",
+        "workflow: []\n",
+        "workflow: not-a-mapping\n",
+    ],
+)
+def test_validate_malformed_or_non_mapping_yaml_returns_load_report(
+    app, user0, _get_user_mock, monkeypatch, tmp_path, spec
+):
+    """Malformed/non-mapping YAML is an invalid spec, not an HTTP 500."""
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    with app.test_client() as client:
+        res = client.post(
+            url_for("workflows.validate_workflow_specification"),
+            query_string={"access_token": user0.access_token},
+            data=_bundle_with_spec(spec),
+            content_type="multipart/form-data",
+        )
+
+    assert res.status_code == 200
+    assert res.json["valid"] is False
+    assert res.json["errors"][0]["code"] == "load"
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "workflow: [unterminated\n",
+        "[workflow, is, a, list]\n",
+        "workflow: []\n",
+    ],
+)
+def test_create_malformed_or_non_mapping_yaml_returns_400(
+    app, user0, _get_user_mock, monkeypatch, tmp_path, spec
+):
+    """Create rejects malformed/non-mapping YAML without calling controller."""
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    rwc_client = Mock()
+    with app.test_client() as client:
+        with patch("reana_server.rest.workflows.current_rwc_api_client", rwc_client):
+            res = client.post(
+                url_for("workflows.create_workflow"),
+                query_string={
+                    "access_token": user0.access_token,
+                    "workflow_name": "invalid-spec",
+                },
+                data=_bundle_with_spec(spec),
+                content_type="multipart/form-data",
+            )
+
+    assert res.status_code == 400
+    rwc_client.api.create_workflow.assert_not_called()
+
+
+def _post_chunked_multipart(client, path, query_string, parts):
+    """POST a multipart body with NO ``Content-Length`` (a chunked upload).
+
+    Mirrors ``_serial_bundle()`` but forces a chunked transfer (no
+    ``Content-Length``, ``wsgi.input_terminated``) so the up-front
+    ``_validate_spec_bundle_request_size`` check is bypassed and only the
+    per-view request-level cap (``request.max_content_length``) can reject the
+    body -- the exact threat the cap defends against.
+
+    :param parts: mapping of form-field name -> raw ``bytes`` payload.
+    """
+    boundary = "REANABUNDLEBOUNDARY"
+    body = b""
+    for name, data in parts.items():
+        body += (
+            ("--%s\r\n" % boundary).encode()
+            + (
+                'Content-Disposition: form-data; name="%s"; filename="%s"\r\n'
+                % (name, name)
+            ).encode()
+            + b"Content-Type: application/octet-stream\r\n\r\n"
+            + data
+            + b"\r\n"
+        )
+    body += ("--%s--\r\n" % boundary).encode()
+    builder = EnvironBuilder(
+        path=path,
+        method="POST",
+        query_string=query_string,
+        content_type="multipart/form-data; boundary=%s" % boundary,
+        input_stream=BytesIO(body),
+    )
+    environ = builder.get_environ()
+    # Drop Content-Length and mark the input as terminated so Werkzeug reads it
+    # as a chunked stream (no length known up front).
+    environ.pop("CONTENT_LENGTH", None)
+    environ["wsgi.input_terminated"] = True
+    environ["HTTP_TRANSFER_ENCODING"] = "chunked"
+    return client.open(environ_overrides=environ)
+
+
+def test_validate_workflow_specification_in_limit_bundle(
+    app, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """Regression: a normal in-limit serial bundle still validates (200)."""
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    with app.test_client() as client:
+        res = client.post(
+            url_for("workflows.validate_workflow_specification"),
+            query_string={"access_token": user0.access_token},
+            data=_serial_bundle(),
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 200
+        # Staging is cleaned up; nothing lingers under the shared volume.
+        staging = os.path.join(str(tmp_path), "validation-tmp")
+        assert not os.path.isdir(staging) or not os.listdir(staging)
+
+
+def test_validate_http_cap_includes_zip_and_multipart_overhead(
+    app, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """An extracted-content-limit bundle is not rejected for framing bytes."""
+    from reana_server.rest import workflows as workflow_views
+
+    extracted_bytes = len(SERIAL_REANA_YAML.encode())
+    bundle = _serial_bundle()
+    assert bundle["bundle"][0].getbuffer().nbytes > extracted_bytes
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    # This compatibility-only attribute makes the test fail against the old
+    # implementation, which reused the extracted-byte cap for HTTP framing.
+    monkeypatch.setattr(
+        workflow_views,
+        "REANA_SPEC_BUNDLE_MAX_BYTES",
+        extracted_bytes,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "reana_server.specification_bundles.REANA_SPEC_BUNDLE_MAX_BYTES",
+        extracted_bytes,
+    )
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES",
+        extracted_bytes + 2048,
+    )
+    with app.test_client() as client:
+        res = client.post(
+            url_for("workflows.validate_workflow_specification"),
+            query_string={"access_token": user0.access_token},
+            data=bundle,
+            content_type="multipart/form-data",
+        )
+    assert res.status_code == 200
+
+
+def test_validate_workflow_specification_chunked_over_cap_returns_413(
+    app, user0, _get_user_mock, monkeypatch, tmp_path
+):
+    """A chunked over-cap bundle upload is rejected mid-parse with 413.
+
+    A chunked upload carries no ``Content-Length``, so the up-front size check is
+    bypassed. The per-view ``request.max_content_length`` cap must still abort
+    multipart parsing before ``request.files`` is materialised, so nothing is
+    staged under ``SHARED_VOLUME_PATH/validation-tmp/``. The cap is lowered so the
+    test body stays tiny.
+    """
+    monkeypatch.setattr("reana_server.rest.workflows.SHARED_VOLUME_PATH", str(tmp_path))
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES", 100
+    )
+    with app.test_client() as client:
+        with patch(
+            "reana_server.rest.workflows._stage_validation_bundle"
+        ) as stage_mock:
+            res = _post_chunked_multipart(
+                client,
+                url_for("workflows.validate_workflow_specification"),
+                {"access_token": user0.access_token},
+                {"bundle": b"X" * 500},
+            )
+    assert res.status_code == 413
+    # Parsing aborted before request.files was read, so staging never ran.
+    stage_mock.assert_not_called()
+    staging = os.path.join(str(tmp_path), "validation-tmp")
+    assert not os.path.isdir(staging) or not os.listdir(staging)
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "query"),
+    [
+        ("workflows.validate_workflow_specification", {}),
+        ("workflows.create_workflow", {"workflow_name": "oversized-spec"}),
+    ],
+)
+def test_spec_bundle_content_length_over_cap_returns_413(
+    app, user0, _get_user_mock, monkeypatch, endpoint, query
+):
+    """Known-length oversized bundles consistently return HTTP 413."""
+    monkeypatch.setattr(
+        "reana_server.rest.workflows.REANA_SPEC_BUNDLE_MAX_REQUEST_BYTES", 100
+    )
+    query = {"access_token": user0.access_token, **query}
+    with app.test_client() as client:
+        with patch(
+            "reana_server.rest.workflows._stage_validation_bundle"
+        ) as stage_mock:
+            res = client.post(
+                url_for(endpoint),
+                query_string=query,
+                data=_serial_bundle(),
+                content_type="multipart/form-data",
+            )
+    assert res.status_code == 413
+    assert "maximum is 100 bytes" in res.json["message"]
+    stage_mock.assert_not_called()
 
 
 def test_start_workflow_validates_specification(
     app, session, user0, sample_serial_workflow_in_db
 ):
+    """Start re-validates the (authoritative) workspace, not the stored spec.
+
+    The workspace is the source of truth and is mutable, so an invalid spec in
+    the workspace must block the start even when the stored (DB) specification is
+    still valid. A serial spec with a path-traversal input fails the in-process
+    validator deterministically.
+    """
+    workflow = sample_serial_workflow_in_db
+    workflow.status = RunStatus.created
+    workflow.name = "test"
+    session.add(workflow)
+    session.commit()
+
+    invalid_spec = (
+        "workflow:\n"
+        "  type: serial\n"
+        "  specification:\n"
+        "    steps:\n"
+        "      - name: step1\n"
+        "        environment: 'docker.io/library/busybox:1.36'\n"
+        "        commands:\n"
+        "          - echo hello\n"
+        "inputs:\n"
+        "  files:\n"
+        "    - ../escape.txt\n"
+    )
+    with open(os.path.join(workflow.workspace_path, "reana.yaml"), "w") as f:
+        f.write(invalid_spec)
+
     with app.test_client() as client:
-        sample_serial_workflow_in_db.status = RunStatus.created
-        sample_serial_workflow_in_db.name = "test"
-        workflow_specification = copy.deepcopy(
-            sample_serial_workflow_in_db.reana_specification
-        )
-        workflow_specification["workflow"]["type"] = "unknown"
-        sample_serial_workflow_in_db.reana_specification = workflow_specification
-        session.add(sample_serial_workflow_in_db)
-        session.commit()
         res = client.post(
             url_for(
                 "workflows.start_workflow",
-                workflow_id_or_name=str(sample_serial_workflow_in_db.id_),
+                workflow_id_or_name=str(workflow.id_),
             ),
             headers={"Content-Type": "application/json"},
             query_string={
@@ -193,9 +1601,108 @@ def test_start_workflow_validates_specification(
         assert res.status_code == 400
 
 
-def test_restart_workflow_validates_specification(
+def test_start_workflow_unexpected_error_is_opaque(
     app, session, user0, sample_serial_workflow_in_db
 ):
+    """Unexpected start-time validation failures do not disclose internals."""
+    workflow = sample_serial_workflow_in_db
+    workflow.status = RunStatus.created
+    workflow.name = "test"
+    session.add(workflow)
+    session.commit()
+    with open(os.path.join(workflow.workspace_path, "reana.yaml"), "w") as f:
+        f.write(SERIAL_REANA_YAML)
+
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.load_and_validate_spec",
+        side_effect=RuntimeError("private Kubernetes API detail"),
+    ):
+        res = client.post(
+            url_for("workflows.start_workflow", workflow_id_or_name="test"),
+            headers={"Content-Type": "application/json"},
+            query_string={"access_token": user0.access_token},
+            data=json.dumps({}),
+        )
+
+    assert res.status_code == 500
+    assert res.json["message"] == "An internal server error occurred."
+    assert "private Kubernetes API detail" not in res.get_data(as_text=True)
+
+
+def test_start_workflow_succeeds_with_valid_workspace(
+    app, session, user0, sample_serial_workflow_in_db
+):
+    """A valid workspace passes the binding gate and the workflow is queued."""
+    workflow = sample_serial_workflow_in_db
+    workflow.status = RunStatus.created
+    workflow.name = "test"
+    session.add(workflow)
+    session.commit()
+
+    with open(os.path.join(workflow.workspace_path, "reana.yaml"), "w") as f:
+        f.write(SERIAL_REANA_YAML)
+
+    with app.test_client() as client:
+        with patch("reana_server.rest.workflows.publish_workflow_submission"):
+            res = client.post(
+                url_for(
+                    "workflows.start_workflow",
+                    workflow_id_or_name=str(workflow.id_),
+                ),
+                headers={"Content-Type": "application/json"},
+                query_string={
+                    "access_token": user0.access_token,
+                },
+                data=json.dumps({}),
+            )
+    assert res.status_code == 200
+    assert res.json["status"] == RunStatus.queued.name
+
+
+def test_start_workflow_falls_back_to_stored_spec_without_workspace_reana_yaml(
+    app, session, user0, sample_serial_workflow_in_db
+):
+    """A workspace with no reana.yaml falls back to the stored spec (SNDBX-02).
+
+    Launched workflows have their reana.yaml stripped by ``filter_input_files``
+    and legacy (pre-seeding) workflows never had one. The binding gate must not
+    hard-fail those: it validates the stored authoritative specification
+    in-process instead of trying to re-load a non-existent workspace reana.yaml.
+    """
+    workflow = sample_serial_workflow_in_db
+    workflow.status = RunStatus.created
+    workflow.name = "test"
+    # A known-valid stored specification (the workspace deliberately has none).
+    workflow.reana_specification = yaml.safe_load(SERIAL_REANA_YAML)
+    session.add(workflow)
+    session.commit()
+
+    # Ensure the workspace exists but carries no reana.yaml/reana.yml.
+    os.makedirs(workflow.workspace_path, exist_ok=True)
+    for name in ("reana.yaml", "reana.yml"):
+        spec_path = os.path.join(workflow.workspace_path, name)
+        if os.path.exists(spec_path):
+            os.remove(spec_path)
+
+    with app.test_client() as client:
+        with patch("reana_server.rest.workflows.publish_workflow_submission"):
+            res = client.post(
+                url_for(
+                    "workflows.start_workflow",
+                    workflow_id_or_name=str(workflow.id_),
+                ),
+                headers={"Content-Type": "application/json"},
+                query_string={"access_token": user0.access_token},
+                data=json.dumps({}),
+            )
+    assert res.status_code == 200
+    assert res.json["status"] == RunStatus.queued.name
+
+
+def test_start_endpoint_rejects_restart_replacement_payload(
+    app, session, user0, sample_serial_workflow_in_db
+):
+    """A released client's replacement restart gets actionable upgrade guidance."""
     with app.test_client() as client:
         sample_serial_workflow_in_db.status = RunStatus.finished
         sample_serial_workflow_in_db.name = "test"
@@ -219,6 +1726,274 @@ def test_restart_workflow_validates_specification(
             data=json.dumps(body),
         )
         assert res.status_code == 400
+        assert "reana_specification" in res.json["message"]
+        assert "upgrade REANA client" in res.json["message"]
+        assert "/api/workflows/{id}/restart" in res.json["message"]
+
+
+def test_atomic_restart_posts_replacement_and_parameters_together(
+    app, session, user0, sample_serial_workflow_in_db
+):
+    """The multipart operation validates, promotes and submits one replacement."""
+    workflow = sample_serial_workflow_in_db
+    workflow.status = RunStatus.finished
+    workflow.name = "test"
+    session.add(workflow)
+    session.commit()
+    canonical_path = os.path.join(workflow.workspace_path, "reana.yaml")
+    with open(canonical_path, "w") as stream:
+        stream.write(SERIAL_REANA_YAML)
+    replacement = SERIAL_REANA_YAML.replace("echo hello", "echo replacement")
+
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.publish_workflow_submission"
+    ) as publish_mock, patch(
+        "reana_server.rest.workflows._recalculate_shared_workspace_quota"
+    ):
+        res = client.post(
+            url_for("workflows.restart_workflow", workflow_id_or_name="test"),
+            query_string={"access_token": user0.access_token},
+            data={
+                "replacement": (BytesIO(replacement.encode()), "replacement.yaml"),
+                "parameters": json.dumps(
+                    {
+                        "input_parameters": {},
+                        "operational_options": {"CACHE": "off"},
+                    }
+                ),
+            },
+        )
+
+    assert res.status_code == 200
+    assert publish_mock.call_args.args[2] == {
+        "restart": True,
+        "input_parameters": {},
+        "operational_options": {"CACHE": "off"},
+    }
+    with open(canonical_path) as stream:
+        assert stream.read() == replacement
+
+
+def test_atomic_restart_failure_restores_canonical_specification(
+    app, session, user0, sample_serial_workflow_in_db
+):
+    """A submission failure restores the previous bytes before releasing the lock."""
+    workflow = sample_serial_workflow_in_db
+    workflow.status = RunStatus.finished
+    workflow.name = "test"
+    workflow.reana_specification = copy.deepcopy(workflow.reana_specification)
+    workflow.reana_specification["workspace"] = {"retention_days": {"**/*.txt": 1}}
+    session.add(workflow)
+    session.commit()
+    workflow.set_workspace_retention_rules(
+        [
+            {"workspace_files": "active.txt", "retention_days": 1},
+            {"workspace_files": "inactive.txt", "retention_days": 2},
+            {"workspace_files": "applied.txt", "retention_days": 3},
+        ]
+    )
+    original_rules = sorted(
+        workflow.retention_rules, key=lambda rule: rule.workspace_files
+    )
+    original_rules[0].status = WorkspaceRetentionRuleStatus.active
+    original_rules[1].status = WorkspaceRetentionRuleStatus.applied
+    original_rules[2].status = WorkspaceRetentionRuleStatus.inactive
+    session.commit()
+    expected_original_states = {
+        rule.id_: rule.status for rule in workflow.retention_rules
+    }
+    canonical_path = os.path.join(workflow.workspace_path, "reana.yaml")
+    original = b"# original bytes\n" + SERIAL_REANA_YAML.encode()
+    with open(canonical_path, "wb") as stream:
+        stream.write(original)
+    replacement = (
+        SERIAL_REANA_YAML.replace("echo hello", "echo replacement")
+        + "workspace:\n  retention_days:\n    '**/*.txt': 1\n"
+    )
+
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.publish_workflow_submission",
+        side_effect=RuntimeError("broker unavailable"),
+    ), patch("reana_server.rest.workflows._recalculate_shared_workspace_quota"):
+        res = client.post(
+            url_for("workflows.restart_workflow", workflow_id_or_name="test"),
+            query_string={"access_token": user0.access_token},
+            data={"replacement": (BytesIO(replacement.encode()), "replacement.yaml")},
+        )
+
+    assert res.status_code == 500
+    session.expire_all()
+    runs = (
+        session.query(Workflow)
+        .filter(Workflow.owner_id == user0.id_, Workflow.name == "test")
+        .order_by(Workflow.run_number_minor)
+        .all()
+    )
+    assert len(runs) == 2
+    original_workflow, failed_clone = runs
+    assert original_workflow.id_ == workflow.id_
+    assert original_workflow.status == RunStatus.finished
+    assert failed_clone.status == RunStatus.deleted
+    assert {
+        rule.id_: rule.status for rule in original_workflow.retention_rules
+    } == expected_original_states
+    assert failed_clone.retention_rules
+    assert {rule.status for rule in failed_clone.retention_rules} == {
+        WorkspaceRetentionRuleStatus.inactive
+    }
+    with open(canonical_path, "rb") as stream:
+        assert stream.read() == original
+    assert not any(
+        name.startswith((".reana-promote-", ".reana-backup-"))
+        for name in os.listdir(workflow.workspace_path)
+    )
+    # The shared database workflow fixture does not own retention rows; remove
+    # the state created specifically for this regression before its teardown.
+    session.query(WorkspaceRetentionAuditLog).delete()
+    session.query(WorkspaceRetentionRule).filter(
+        WorkspaceRetentionRule.workflow_id.in_(
+            [original_workflow.id_, failed_clone.id_]
+        )
+    ).delete(synchronize_session=False)
+    session.commit()
+    session.expire(original_workflow, ["retention_rules"])
+
+
+def test_atomic_restart_rejects_malformed_parameters_before_cloning(
+    app, session, user0, sample_serial_workflow_in_db
+):
+    """Multipart parameters have one small JSON-object contract."""
+    workflow = sample_serial_workflow_in_db
+    workflow.status = RunStatus.finished
+    workflow.name = "test"
+    session.add(workflow)
+    session.commit()
+
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.clone_workflow"
+    ) as clone_workflow:
+        res = client.post(
+            url_for("workflows.restart_workflow", workflow_id_or_name="test"),
+            query_string={"access_token": user0.access_token},
+            data={
+                "replacement": (BytesIO(SERIAL_REANA_YAML.encode()), "reana.yaml"),
+                "parameters": json.dumps({"restart": True}),
+            },
+        )
+
+    assert res.status_code == 400
+    assert "Unknown restart parameters" in res.json["message"]
+    clone_workflow.assert_not_called()
+
+
+def test_atomic_restart_rejects_missing_workspace_source(
+    app, session, user0, sample_serial_workflow_in_db
+):
+    """Replacement specs may only reference source already in the workspace."""
+    workflow = sample_serial_workflow_in_db
+    workflow.status = RunStatus.finished
+    workflow.name = "test"
+    workflow.reana_specification = {
+        "workflow": {
+            "type": "snakemake",
+            "file": "workflow/missing: Snakefile",
+        },
+        "inputs": {"parameters": {}},
+    }
+    session.add(workflow)
+    session.commit()
+    replacement = yaml.safe_dump(workflow.reana_specification)
+
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.clone_workflow"
+    ) as clone_workflow:
+        res = client.post(
+            url_for("workflows.restart_workflow", workflow_id_or_name="test"),
+            query_string={"access_token": user0.access_token},
+            data={"replacement": (BytesIO(replacement.encode()), "replacement.yaml")},
+        )
+
+    assert res.status_code == 400
+    assert res.json["message"] == (
+        "Workflow source path 'workflow/missing: Snakefile' referenced by the "
+        "restart specification is not present in the workspace."
+    )
+    clone_workflow.assert_not_called()
+
+
+def test_restart_overlong_path_error_is_bounded():
+    """An invalid declaration cannot be reflected into a huge API response."""
+    from reana_server.rest.workflows import _restart_specification_path_error
+
+    error = REANASpecificationPathError(
+        "overlong",
+        "workflow.file",
+        "x" * (17 * 1024 * 1024),
+        "max_length",
+    )
+
+    message = str(_restart_specification_path_error(error))
+    assert (
+        message == "Workflow source path in workflow.file exceeds 4096 encoded bytes."
+    )
+    assert len(message) < 100
+
+
+def test_atomic_restart_formats_unsafe_workspace_source(
+    app, session, user0, sample_serial_workflow_in_db
+):
+    """Typed unsafe paths receive stable restart-specific diagnostics."""
+    workflow = sample_serial_workflow_in_db
+    workflow.status = RunStatus.finished
+    workflow.name = "test"
+    session.commit()
+    replacement = yaml.safe_dump(
+        {
+            "workflow": {"type": "snakemake", "file": "../Snakefile"},
+            "inputs": {"parameters": {}},
+        }
+    )
+
+    with app.test_client() as client, patch(
+        "reana_server.rest.workflows.clone_workflow"
+    ) as clone_workflow:
+        res = client.post(
+            url_for("workflows.restart_workflow", workflow_id_or_name="test"),
+            query_string={"access_token": user0.access_token},
+            data={"replacement": (BytesIO(replacement.encode()), "replacement.yaml")},
+        )
+
+    assert res.status_code == 400
+    assert res.json["message"] == (
+        "Workflow source path '../Snakefile' referenced by the restart specification "
+        "is unsafe."
+    )
+    clone_workflow.assert_not_called()
+
+
+def test_enforce_restart_spec_constraints_allows_present_changed_file(tmp_path):
+    """A restart may change ``workflow.file`` when the new source is present.
+
+    The narrowed restart contract only requires that every referenced
+    workflow-source file exists in the workspace; a user who uploaded a new
+    source file may point ``workflow.file`` at it, even though it differs from
+    the original run.
+    """
+    from reana_server.rest.workflows import _enforce_restart_spec_constraints
+
+    os.mkdir(os.path.join(str(tmp_path), "workflow"))
+    with open(os.path.join(str(tmp_path), "workflow", "Snakefile2"), "w") as f:
+        f.write("rule all:\n    input: []\n")
+
+    workflow = Mock()
+    workflow.workspace_path = str(tmp_path)
+    workflow.reana_specification = {
+        "workflow": {"type": "snakemake", "file": "workflow/Snakefile"},
+    }
+    new_spec = {"workflow": {"type": "snakemake", "file": "workflow/Snakefile2"}}
+
+    # Must not raise: workflow.file changed, but the new source is present.
+    _enforce_restart_spec_constraints(workflow, new_spec)
 
 
 def test_info_surfaces_kubernetes_min_user_uid(app, user0, _get_user_mock):
@@ -423,6 +2198,241 @@ def test_set_workflow_status(app, user0, _get_user_mock):
             assert res.status_code == 200
 
 
+def test_set_workflow_status_start_uses_submission_boundary(app, user0, _get_user_mock):
+    """Legacy ``status=start`` uses the same serialized submission boundary."""
+    rwc_mock = Mock()
+    submission_response = {
+        "message": "Workflow submitted.",
+        "workflow_id": "1",
+        "workflow_name": "test",
+        "status": "queued",
+        "run_number": 1,
+        "user": str(user0.id_),
+        "validation_warnings": [{"code": "tag_latest", "message": "latest"}],
+    }
+    with app.test_client() as client:
+        with patch(
+            "reana_server.rest.workflows.current_rwc_api_client", rwc_mock
+        ), patch(
+            "reana_server.rest.workflows._submit_workflow",
+            return_value=(submission_response, 200),
+        ) as submit_workflow:
+            res = client.put(
+                url_for("workflows.set_workflow_status", workflow_id_or_name="1"),
+                headers={"Content-Type": "application/json"},
+                query_string={
+                    "access_token": user0.access_token,
+                    "status": "start",
+                },
+                data=json.dumps({"input_parameters": {"number": 42}}),
+            )
+    assert res.status_code == 200
+    assert "run_number" not in res.json
+    assert res.json["validation_warnings"] == [
+        {"code": "tag_latest", "message": "latest"}
+    ]
+    submit_workflow.assert_called_once()
+    args, kwargs = submit_workflow.call_args
+    assert args[0] == "1"
+    assert args[1].id_ == user0.id_
+    assert kwargs == {"input_parameters": {"number": 42}}
+    rwc_mock.api.set_workflow_status.assert_not_called()
+
+
+def test_submission_boundary_enforces_quota(user0):
+    """Every start surface enforces quota at the shared boundary."""
+    from reana_server.rest.workflows import _submit_workflow
+
+    with patch.object(user0, "has_exceeded_quota", return_value=True), patch(
+        "reana_server.rest.workflows.get_quota_excess_message",
+        return_value="Quota exceeded.",
+    ):
+        response, status_code = _submit_workflow("1", user0)
+
+    assert status_code == 403
+    assert response == {"message": "Quota exceeded."}
+
+
+def test_start_workflow_returns_409_when_workspace_locked(
+    app, session, user0, sample_serial_workflow_in_db
+):
+    """The ``/start`` route is serialized under the workspace-mutation lock.
+
+    When another request already holds the workspace lock, ``/start`` returns a
+    409 instead of racing a concurrent workspace mutation (e.g. an upload).
+    """
+    from reana_server.rest.workflows import WorkspaceMutationConflict
+
+    workflow = sample_serial_workflow_in_db
+    workflow.status = RunStatus.created
+    workflow.name = "test"
+    session.add(workflow)
+    session.commit()
+    with open(os.path.join(workflow.workspace_path, "reana.yaml"), "w") as f:
+        f.write(SERIAL_REANA_YAML)
+
+    def _already_locked(*args, **kwargs):
+        raise WorkspaceMutationConflict()
+
+    with app.test_client() as client:
+        with patch(
+            "reana_server.rest.workflows._workspace_mutation_lock", _already_locked
+        ):
+            res = client.post(
+                url_for(
+                    "workflows.start_workflow",
+                    workflow_id_or_name=str(workflow.id_),
+                ),
+                headers={"Content-Type": "application/json"},
+                query_string={"access_token": user0.access_token},
+                data=json.dumps({}),
+            )
+    assert res.status_code == 409
+
+
+def test_workspace_mutation_lock_releases_after_failure(app, session, tmp_path):
+    """A failed mutation cannot leave its workspace advisory lock behind."""
+    from reana_server.rest.workflows import (
+        WorkspaceMutationConflict,
+        _workspace_mutation_lock,
+    )
+
+    workspace_path = str(tmp_path / "workspace")
+
+    with _workspace_mutation_lock(workspace_path):
+        with pytest.raises(WorkspaceMutationConflict):
+            with _workspace_mutation_lock(workspace_path):
+                pass
+
+    with pytest.raises(RuntimeError, match="mutation failed"):
+        with _workspace_mutation_lock(workspace_path):
+            raise RuntimeError("mutation failed")
+
+    # PostgreSQL releases a transaction-scoped advisory lock on rollback, so
+    # the same workspace must be lockable immediately after the failed request.
+    with _workspace_mutation_lock(workspace_path):
+        pass
+
+
+@pytest.mark.parametrize(
+    "error,status_code",
+    [
+        ("WorkspaceMutationConflict", 409),
+        ("WorkspaceMutationUnavailable", 503),
+    ],
+)
+def test_workspace_mutation_decorator_maps_lock_failures(
+    app, user0, error, status_code
+):
+    """Workspace endpoints expose contention and infrastructure failures."""
+    from reana_server.rest import workflows
+
+    protected = workflows._serialize_workspace_mutation(lambda *_args, **_kwargs: None)
+    workflow = Mock(workspace_path="/tmp/workspace")
+    with app.test_request_context(), patch.object(
+        workflows, "_get_workflow_with_uuid_or_name", return_value=workflow
+    ), patch.object(
+        workflows, "_workspace_mutation_lock", side_effect=getattr(workflows, error)()
+    ):
+        response, actual_status = protected("workflow", user=user0)
+
+    assert actual_status == status_code
+    assert response.get_json()["message"]
+
+
+def test_status_delete_locks_all_workspaces_but_stop_does_not(app, user0):
+    """Only destructive status changes enter the multi-workspace boundary."""
+    from reana_server.rest import workflows
+
+    acquired = []
+    families = []
+
+    @contextmanager
+    def capture(paths):
+        acquired.append(list(paths))
+        yield
+
+    @contextmanager
+    def capture_family(owner_id, workflow_name):
+        families.append((owner_id, workflow_name))
+        yield
+
+    http_response = Mock(status_code=200)
+    api_client = Mock()
+    api_client.api.set_workflow_status.return_value.result.return_value = (
+        {"message": "ok"},
+        http_response,
+    )
+    workflow = Mock(owner_id=user0.id_)
+    workflow.name = "workflow"
+    with app.test_client() as client, patch.object(
+        workflows, "current_rwc_api_client", api_client
+    ), patch.object(
+        workflows, "_get_workflow_with_uuid_or_name", return_value=workflow
+    ), patch.object(
+        workflows,
+        "_deletion_workspace_paths",
+        return_value=["/workspace/b", "/workspace/a", "/workspace/a"],
+    ), patch.object(
+        workflows, "workspace_mutation_locks", capture
+    ), patch.object(
+        workflows, "workflow_family_mutation_lock", capture_family
+    ):
+        deleted = client.put(
+            url_for("workflows.set_workflow_status", workflow_id_or_name="workflow"),
+            query_string={"access_token": user0.access_token, "status": "deleted"},
+            json={"all_runs": True},
+        )
+        stopped = client.put(
+            url_for("workflows.set_workflow_status", workflow_id_or_name="workflow"),
+            query_string={"access_token": user0.access_token, "status": "stop"},
+            json={},
+        )
+
+    assert deleted.status_code == 200
+    assert stopped.status_code == 200
+    assert acquired == [["/workspace/b", "/workspace/a", "/workspace/a"]]
+    assert families == [(user0.id_, "workflow")]
+
+
+def test_shared_workspace_quota_scans_once_for_all_siblings(
+    session, user0, sample_serial_workflow_in_db
+):
+    """Restart quota reconciliation measures one shared filesystem tree once."""
+    from reana_server.rest.workflows import _recalculate_shared_workspace_quota
+
+    workflow = sample_serial_workflow_in_db
+    sibling = Workflow(
+        id_=uuid4(),
+        name=workflow.name,
+        owner_id=user0.id_,
+        reana_specification=workflow.reana_specification,
+        type_=workflow.type_,
+        workspace_path=workflow.workspace_path,
+    )
+    session.add(sibling)
+    session.commit()
+
+    with patch(
+        "reana_server.rest.workflows.get_disk_usage_or_zero", return_value=123
+    ) as disk_usage, patch(
+        "reana_server.rest.workflows.update_users_disk_quota"
+    ) as update_user:
+        _recalculate_shared_workspace_quota(workflow, user0)
+
+    disk_usage.assert_called_once_with(
+        workflow.workspace_path, override_policy_checks=True
+    )
+    update_user.assert_called_once_with(user0, override_policy_checks=True)
+    resources = (
+        session.query(WorkflowResource)
+        .filter(WorkflowResource.workflow_id.in_([workflow.id_, sibling.id_]))
+        .all()
+    )
+    assert len(resources) == 2
+    assert {resource.quota_used for resource in resources} == {123}
+
+
 def test_upload_file(app, user0, _get_user_mock):
     """Test upload_file view."""
     with app.test_client() as client:
@@ -472,10 +2482,20 @@ def test_upload_file(app, user0, _get_user_mock):
         requests_response_mock = Mock()
         requests_response_mock.status_code = 200
         requests_response_mock.json = Mock(return_value={"message": "File uploaded."})
-        requests_mock.post = Mock(return_value=requests_response_mock)
+        forwarded_contents = []
+        forwarded_lengths = []
+
+        def _capture_forwarded_upload(*args, **kwargs):
+            forwarded_lengths.append(len(kwargs["data"]))
+            forwarded_contents.append(kwargs["data"].read())
+            return requests_response_mock
+
+        requests_mock.post = Mock(side_effect=_capture_forwarded_upload)
         with patch(
             "reana_server.rest.workflows.requests", requests_mock
-        ) as requests_client:
+        ) as requests_client, patch(
+            "reana_server.rest.workflows.prevent_disk_quota_excess"
+        ) as quota_check:
             res = client.post(
                 url_for("workflows.upload_file", workflow_id_or_name="1"),
                 query_string={
@@ -486,9 +2506,22 @@ def test_upload_file(app, user0, _get_user_mock):
                 input_stream=BytesIO(file_content),
             )
             requests_client.post.assert_called_once()
-            assert (
-                file_content == requests_client.post.call_args_list[0][1]["data"].read()
+            assert forwarded_lengths[0] == len(file_content)
+            assert forwarded_contents[0] == file_content
+
+            # Multipart is intentionally not accepted for potentially large
+            # workspace data because Werkzeug would spool it before quota.
+            res = client.post(
+                url_for("workflows.upload_file", workflow_id_or_name="1"),
+                query_string={
+                    "access_token": user0.access_token,
+                    "file_name": "multipart-upload.txt",
+                },
+                data={"file": (BytesIO(file_content), "local-file.txt")},
+                content_type="multipart/form-data",
             )
+            assert res.status_code == 400
+            assert requests_client.post.call_count == 1
 
             # empty file
             res = client.post(
@@ -503,7 +2536,51 @@ def test_upload_file(app, user0, _get_user_mock):
             assert requests_client.post.call_count == 2
             data = requests_client.post.call_args_list[1][1]["data"]
             assert not len(data)
-            assert not data.read()
+            assert not forwarded_lengths[1]
+            assert not forwarded_contents[1]
+
+            assert [call.args[1] for call in quota_check.call_args_list] == [
+                len(file_content),
+                0,
+            ]
+            assert requests_client.post.call_args_list[0][1]["timeout"] == (10.0, 300.0)
+
+
+def test_upload_controller_timeout_returns_503_and_releases_lock(
+    app, user0, _get_user_mock
+):
+    """A stalled controller never strands the workspace mutation lock."""
+    from reana_server.rest import workflows
+
+    entered = []
+
+    @contextmanager
+    def lock(_path):
+        entered.append("enter")
+        try:
+            yield
+        finally:
+            entered.append("exit")
+
+    with app.test_client() as client, patch.object(
+        workflows, "_workspace_mutation_lock", lock
+    ), patch.object(
+        workflows.requests,
+        "post",
+        side_effect=workflows.requests.exceptions.Timeout(),
+    ):
+        response = client.post(
+            url_for("workflows.upload_file", workflow_id_or_name="1"),
+            query_string={
+                "access_token": user0.access_token,
+                "file_name": "input.dat",
+            },
+            headers={"Content-Type": "application/octet-stream"},
+            input_stream=BytesIO(b"payload"),
+        )
+
+    assert response.status_code == 503
+    assert entered == ["enter", "exit"]
 
 
 def test_download_file(app, user0, _get_user_mock):

--- a/tests/test_workflow_cloning.py
+++ b/tests/test_workflow_cloning.py
@@ -1,0 +1,136 @@
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for atomic workflow cloning."""
+
+import copy
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from reana_db.models import (
+    RunStatus,
+    Workflow,
+    WorkspaceRetentionAuditLog,
+    WorkspaceRetentionRule,
+    WorkspaceRetentionRuleStatus,
+)
+from reana_server.utils import clone_workflow
+
+
+@pytest.mark.parametrize(
+    "failure,expected_exception,error_match",
+    [
+        (
+            SQLAlchemyError("injected database failure"),
+            RuntimeError,
+            "Database connection failed",
+        ),
+        (
+            ValueError("injected application failure"),
+            ValueError,
+            "injected application failure",
+        ),
+    ],
+)
+def test_clone_workflow_rolls_back_clone_and_retention_rules(
+    app,
+    monkeypatch,
+    sample_serial_workflow_in_db,
+    session,
+    failure,
+    expected_exception,
+    error_match,
+):
+    """A retention failure must not persist a clone or change previous rules."""
+    workflow = sample_serial_workflow_in_db
+    retention_rules = [{"workspace_files": "**/*.root", "retention_days": 1}]
+    workflow.set_workspace_retention_rules(retention_rules)
+    workflow.activate_workspace_retention_rules()
+    original_set_retention_rules = Workflow.set_workspace_retention_rules
+
+    def fail_after_staging_retention_rules(cloned_workflow, rules, commit=True):
+        original_set_retention_rules(cloned_workflow, rules, commit=commit)
+        raise failure
+
+    monkeypatch.setattr(
+        Workflow,
+        "set_workspace_retention_rules",
+        fail_after_staging_retention_rules,
+    )
+
+    with pytest.raises(expected_exception, match=error_match):
+        clone_workflow(workflow, None, None)
+
+    session.expire_all()
+    workflows = session.query(Workflow).filter_by(name=workflow.name).all()
+    assert workflows == [workflow]
+    assert [rule.status for rule in workflow.retention_rules] == [
+        WorkspaceRetentionRuleStatus.active
+    ]
+
+    session.query(WorkspaceRetentionAuditLog).delete()
+    session.query(WorkspaceRetentionRule).delete()
+    session.commit()
+    session.expire(workflow, ["retention_rules"])
+
+
+def test_failed_restart_compensation_rolls_back_as_one_transaction(
+    app, sample_serial_workflow_in_db, session, user0
+):
+    """A mid-compensation failure leaves clone and rule state untouched."""
+    from reana_server.rest.workflows import _compensate_failed_restart
+
+    workflow = sample_serial_workflow_in_db
+    workflow.status = RunStatus.finished
+    workflow.reana_specification = copy.deepcopy(workflow.reana_specification)
+    workflow.reana_specification["workspace"] = {"retention_days": {"**/*.txt": 1}}
+    session.commit()
+    workflow.set_workspace_retention_rules(
+        [{"workspace_files": "original.txt", "retention_days": 1}]
+    )
+    workflow.activate_workspace_retention_rules()
+    prior_rule_states = {rule.id_: rule.status for rule in workflow.retention_rules}
+    clone = clone_workflow(workflow, None, None)
+    clone_id = clone.id_
+    pre_compensation_status = clone.status
+    assert pre_compensation_status != RunStatus.deleted
+    pre_compensation_rule_states = {
+        rule.id_: rule.status
+        for rule in session.query(WorkspaceRetentionRule)
+        .filter(WorkspaceRetentionRule.workflow_id.in_([workflow.id_, clone_id]))
+        .all()
+    }
+    original_query = session.query
+
+    def fail_after_bulk_status_update(*entities, **kwargs):
+        if entities == (WorkspaceRetentionRule,):
+            raise RuntimeError("injected retention restoration failure")
+        return original_query(*entities, **kwargs)
+
+    with patch.object(
+        session, "query", side_effect=fail_after_bulk_status_update
+    ), patch("reana_server.rest.workflows._recalculate_shared_workspace_quota"):
+        _compensate_failed_restart(clone, prior_rule_states, user0)
+
+    session.expire_all()
+    persisted_clone = session.query(Workflow).filter_by(id_=clone_id).one()
+    assert persisted_clone.status == pre_compensation_status
+    assert {
+        rule.id_: rule.status
+        for rule in session.query(WorkspaceRetentionRule)
+        .filter(WorkspaceRetentionRule.workflow_id.in_([workflow.id_, clone_id]))
+        .all()
+    } == pre_compensation_rule_states
+
+    session.query(WorkspaceRetentionAuditLog).delete()
+    session.query(WorkspaceRetentionRule).filter(
+        WorkspaceRetentionRule.workflow_id.in_([workflow.id_, clone_id])
+    ).delete(synchronize_session=False)
+    session.delete(persisted_clone)
+    session.commit()
+    session.expire(workflow, ["retention_rules"])

--- a/tests/test_workflow_creation.py
+++ b/tests/test_workflow_creation.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for reconciliation of ambiguous controller creation failures."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from bravado.exception import BravadoConnectionError, BravadoTimeoutError, HTTPError
+
+from reana_server import workflow_creation
+from reana_server.workflow_creation import create_workflow_on_controller
+
+
+@pytest.mark.parametrize(
+    "error, wait_for_commit",
+    [
+        (HTTPError(Mock(status_code=500)), False),
+        (BravadoTimeoutError(), True),
+        (BravadoConnectionError(), True),
+        (ValueError("truncated controller response"), True),
+    ],
+)
+def test_ambiguous_controller_failure_is_compensated(error, wait_for_commit):
+    """Visible controller commits are compensated before the error escapes."""
+    workflow = Mock(workspace_path="/workspaces/reserved")
+    compensate = Mock()
+
+    with patch(
+        "reana_server.workflow_creation._find_created_workflow",
+        return_value=workflow,
+    ), patch(
+        "reana_server.workflow_creation._reconcile_failed_creation",
+        wraps=workflow_creation._reconcile_failed_creation,
+    ) as reconcile:
+        with pytest.raises(type(error)):
+            create_workflow_on_controller(
+                Mock(side_effect=error),
+                "reserved",
+                "owner",
+                "/workspaces/reserved",
+                compensate,
+            )
+
+    compensate.assert_called_once_with(workflow)
+    assert reconcile.call_args.kwargs["wait_for_commit"] is wait_for_commit
+
+
+def test_controller_4xx_is_not_compensated():
+    """A definitive rejected request does not trigger creation reconciliation."""
+    error = HTTPError(Mock(status_code=400))
+    with patch(
+        "reana_server.workflow_creation._reconcile_failed_creation"
+    ) as reconcile:
+        with pytest.raises(HTTPError):
+            create_workflow_on_controller(
+                Mock(side_effect=error),
+                "reserved",
+                "owner",
+                "/workspaces/reserved",
+                Mock(),
+            )
+    reconcile.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        BravadoTimeoutError(),
+        BravadoConnectionError(),
+        ValueError("truncated controller response"),
+    ],
+)
+def test_non_http_failure_reconciles_persisted_reserved_workflow(
+    error, sample_serial_workflow_in_db, user0
+):
+    """An ambiguous failure after controller commit finds the reserved row."""
+    compensate = Mock()
+
+    with pytest.raises(type(error)):
+        create_workflow_on_controller(
+            Mock(side_effect=error),
+            sample_serial_workflow_in_db.id_,
+            user0.id_,
+            sample_serial_workflow_in_db.workspace_path,
+            compensate,
+        )
+
+    compensate.assert_called_once_with(sample_serial_workflow_in_db)

--- a/tests/test_workspace_mutations.py
+++ b/tests/test_workspace_mutations.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for shared-workspace mutation serialization."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from reana_server import workspace_mutations
+from reana_server.workspace_mutations import (
+    WorkspaceMutationConflict,
+    WorkspaceMutationUnavailable,
+    workflow_creation_mutation_lock,
+    workflow_family_mutation_lock,
+    workspace_mutation_lock,
+    workspace_mutation_locks,
+)
+
+
+def _postgresql_connection(results):
+    """Build a lock engine connection yielding the requested scalar results."""
+    transaction = Mock(is_active=True)
+    connection = Mock()
+    connection.begin.return_value = transaction
+    connection.execute.side_effect = [
+        Mock(scalar=Mock(return_value=value)) for value in results
+    ]
+    engine = Mock()
+    engine.connect.return_value = connection
+    return engine, connection, transaction
+
+
+def test_local_lock_conflict_and_registry_eviction(tmp_path):
+    """Local fallback rejects overlap and does not retain workspace keys."""
+    workspace = str(tmp_path / "workspace")
+    with patch.object(
+        workspace_mutations.Session,
+        "get_bind",
+        return_value=SimpleNamespace(dialect=SimpleNamespace(name="sqlite")),
+    ):
+        with workspace_mutation_lock(workspace):
+            with pytest.raises(WorkspaceMutationConflict):
+                with workspace_mutation_lock(workspace):
+                    pass
+        assert workspace_mutations._local_locks == {}
+
+
+def test_creation_reserves_family_and_workspace(tmp_path):
+    """Creation collides with both family deletion and workspace mutation."""
+    workspace = str(tmp_path / "workspace")
+    with patch.object(
+        workspace_mutations.Session,
+        "get_bind",
+        return_value=SimpleNamespace(dialect=SimpleNamespace(name="sqlite")),
+    ):
+        with workflow_creation_mutation_lock("owner", "analysis", workspace):
+            with pytest.raises(WorkspaceMutationConflict):
+                with workflow_family_mutation_lock("owner", "analysis"):
+                    pass
+            with pytest.raises(WorkspaceMutationConflict):
+                with workspace_mutation_lock(workspace):
+                    pass
+        assert workspace_mutations._local_locks == {}
+
+
+def test_postgresql_locks_are_deduplicated_and_sorted(tmp_path):
+    """Multi-workspace acquisition uses one transaction and stable ordering."""
+    first = str(tmp_path / "a")
+    second = str(tmp_path / "b")
+    engine, connection, transaction = _postgresql_connection([True, True])
+    with patch.object(
+        workspace_mutations.Session,
+        "get_bind",
+        return_value=SimpleNamespace(dialect=SimpleNamespace(name="postgresql")),
+    ), patch.object(workspace_mutations, "_get_lock_engine", return_value=engine):
+        with workspace_mutation_locks([second, first, second]):
+            pass
+
+    assert [call.args[1]["key"] for call in connection.execute.call_args_list] == [
+        workspace_mutations._advisory_key(first),
+        workspace_mutations._advisory_key(second),
+    ]
+    transaction.rollback.assert_called_once_with()
+    connection.close.assert_called_once_with()
+
+
+def test_postgresql_contention_releases_acquired_locks():
+    """A failed later key rolls back all earlier transaction locks."""
+    engine, connection, transaction = _postgresql_connection([True, False])
+    with patch.object(workspace_mutations, "_get_lock_engine", return_value=engine):
+        with pytest.raises(WorkspaceMutationConflict):
+            with workspace_mutations._postgresql_locks(["a", "b"]):
+                pass
+    transaction.rollback.assert_called_once_with()
+    connection.close.assert_called_once_with()
+
+
+def test_postgresql_acquisition_failure_is_unavailable():
+    """Database failures before the callback map to infrastructure failure."""
+    engine, connection, transaction = _postgresql_connection([])
+    connection.execute.side_effect = RuntimeError("database unavailable")
+    with patch.object(workspace_mutations, "_get_lock_engine", return_value=engine):
+        with pytest.raises(WorkspaceMutationUnavailable):
+            with workspace_mutations._postgresql_locks(["a"]):
+                pass
+    transaction.rollback.assert_called_once_with()
+    connection.close.assert_called_once_with()
+
+
+def test_postgresql_cleanup_failure_does_not_override_success():
+    """Cleanup trouble cannot create a retry-after-success ambiguity."""
+    engine, connection, transaction = _postgresql_connection([True])
+    transaction.rollback.side_effect = RuntimeError("connection dropped")
+    with patch.object(workspace_mutations, "_get_lock_engine", return_value=engine):
+        with workspace_mutations._postgresql_locks(["a"]):
+            completed = True
+    assert completed
+    connection.invalidate.assert_called_once()
+    connection.close.assert_called_once_with()
+
+
+def test_lock_engine_is_isolated_and_unpooled():
+    """Advisory locks use a dedicated NullPool engine, never the ORM pool.
+
+    This is the isolation invariant behind PR794-26: a lock checkout cannot
+    draw from (and therefore cannot exhaust) reana-db's shared ORM connection
+    pool. A full multi-thread, production-pool-limit regression test additionally
+    requires a live PostgreSQL backend and belongs in the DB-backed suite.
+    """
+    from sqlalchemy.pool import NullPool
+
+    with patch.object(
+        workspace_mutations, "SQLALCHEMY_DATABASE_URI", "postgresql://u:p@localhost/db"
+    ), patch.object(workspace_mutations, "_engine", None):
+        engine = workspace_mutations._get_lock_engine()
+        assert isinstance(engine.pool, NullPool)
+        # The engine is lazily built once and reused across acquisitions.
+        assert workspace_mutations._get_lock_engine() is engine


### PR DESCRIPTION
Make reana-server authoritative for loading and validating workflow
specifications.

Accept bounded specification bundles for create, validate, and
replacement restart operations. Delegate untrusted workflow-engine
loading to hardened controller Jobs, then apply cluster policy checks
to the returned specification.

Seed validated workflow sources into workspaces while preserving legacy
source declarations and canonical identities.

Serialize mutations by canonical workspace using isolated lock
connections. Commit clone and retention transitions atomically,
compensate failed restarts and ambiguous creations, and keep
shared-workspace quota accounting consistent.

Stream workspace uploads without multipart spooling and return bounded
environment results and typed path diagnostics.

Normalize OpenAPI submission responses and argument-validation
diagnostics.

Advertise the specification-bundle capability on the unauthenticated
ping endpoint and reject retired client-serialized requests with
actionable upgrade guidance.

Closes reanahub/reana-workflow-validator#8

BREAKING CHANGE: POST /api/workflows now accepts a multipart
specification bundle instead of a client-serialized reana_specification
JSON body. Replacement restarts now upload a raw reana.yaml to the
dedicated /restart endpoint. New clients require a server that
advertises the workflow-specification-bundles-v1 capability.