### PR TITLE
build(python): use jsonschema 4-compatible Yadage schemas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ install_requires = [
     "adage==0.11.0",  # matches the version in r-w-e-yadage
     "packtivity==0.16.2",  # matches the version in r-w-e-yadage
     "yadage==0.20.1",  # matches the version in r-w-e-yadage
-    "yadage-schemas==0.10.6",  # matches the version in r-w-e-yadage
+    "yadage-schemas @ https://github.com/tiborsimko/yadage-schemas/archive/fb4fd499fd2bcb5e63311c9c81b8106f3bf4fa4f.tar.gz",
     # Invenio dependencies
     "invenio-app>=3.0.0,<4.0.0",
     "flask-limiter>=2.3,<3",


### PR DESCRIPTION
## Changes

- Replace upstream yadage-schemas 0.10.6 with the patched 0.10.9 fork.
- Pin the fork at an exact commit for reproducible component builds.
- Keep the current Adage, Packtivity, and Yadage versions.

This lets the server all-engine environment use jsonschema 4 together with
the companion reanahub/reana-commons#550 change.

Tested with local REANA component image and example-workflow builds.

Closes reanahub/reana-commons#461