### PR TITLE
fix(factory): initialise workspace umask

### DIFF
--- a/reana_server/ext.py
+++ b/reana_server/ext.py
@@ -25,6 +25,7 @@ from reana_server import config
 from reana_server.utils import (
     _create_and_associate_local_user,
     _create_and_associate_oauth_user,
+    initialise_workspace_umask,
 )
 
 
@@ -130,6 +131,7 @@ class REANA(object):
 
     def init_app(self, app):
         """Flask application initialization."""
+        initialise_workspace_umask()
         self.init_config(app)
         self.init_error_handlers(app)
         self._validate_security_config(app)

--- a/reana_server/factory.py
+++ b/reana_server/factory.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2024, 2025 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -22,6 +22,8 @@ from invenio_oauthclient.views.settings import blueprint as blueprint_settings
 from reana_commons.config import REANA_LOG_FORMAT, REANA_LOG_LEVEL
 from reana_db.database import Session
 
+from reana_server.utils import initialise_workspace_umask
+
 
 def create_minimal_app(config_mapping=None):
     """REANA Server application factory.
@@ -40,6 +42,7 @@ def create_minimal_app(config_mapping=None):
     - When running the tests, `reana_server.factory.create_minimal_app` is called.
     - When running `generate_openapi_spec.py`, the app is created with `reana_server.factory.create_minimal_app`.
     """
+    initialise_workspace_umask()
     logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT, force=True)
     app = Flask(__name__)
     app.config.from_object("reana_server.config")

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -103,10 +103,14 @@ def is_uuid_v4(uuid_or_name):
     return uuid.hex == uuid_or_name.replace("-", "")
 
 
+def initialise_workspace_umask():
+    """Set the process umask used for shared workflow workspaces."""
+    os.umask(REANA_WORKFLOW_UMASK)
+
+
 def create_user_workspace(user_workspace_path):
     """Create user workspace directory."""
     if not os.path.isdir(user_workspace_path):
-        os.umask(REANA_WORKFLOW_UMASK)
         os.makedirs(user_workspace_path, exist_ok=True)
 
 

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -11,6 +11,7 @@
 import pytest
 from flask import Flask
 from invenio_rest import InvenioREST
+from mock import patch
 
 _TEST_ORIGIN = "https://example.com:30443"
 
@@ -46,6 +47,19 @@ def ext_app():
     InvenioREST(app)
     REANA().init_app(app)
     return app
+
+
+@patch("reana_server.ext.initialise_workspace_umask")
+def test_initialise_workspace_umask(mock_initialise_workspace_umask):
+    """Initialise the workspace umask when loading the full extension."""
+    from reana_server.ext import REANA
+
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "test-secret"
+
+    REANA().init_app(app)
+
+    mock_initialise_workspace_umask.assert_called_once_with()
 
 
 @pytest.mark.parametrize("header,value", _EXPECTED_SECURITY_HEADERS.items())

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,16 +1,21 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2020, 2021, 2024 CERN.
+# Copyright (C) 2018, 2020, 2021, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test factory app."""
 
+from mock import patch
+
 from reana_server.factory import create_minimal_app
 
 
-def test_create_app():
+@patch("reana_server.factory.initialise_workspace_umask")
+def test_create_app(mock_initialise_workspace_umask):
     """Test create_minimal_app() method."""
     create_minimal_app()
+
+    mock_initialise_workspace_umask.assert_called_once_with()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,17 +7,45 @@
 """REANA-Server tests for utils module."""
 
 from datetime import datetime
+import os
 import pathlib
+import stat
 
 import pytest
+from mock import patch
+from reana_commons.config import REANA_WORKFLOW_UMASK
 from reana_commons.errors import REANAValidationError
 from reana_db.models import ResourceType, UserToken, UserTokenStatus, UserTokenType
 from reana_server.utils import (
     _set_quota_period,
+    create_user_workspace,
     filter_input_files,
     get_user_from_token,
+    initialise_workspace_umask,
     is_valid_email,
 )
+
+
+@patch("reana_server.utils.os.umask")
+def test_initialise_workspace_umask(mock_umask):
+    """Set the shared workspace umask on process initialisation."""
+    initialise_workspace_umask()
+
+    mock_umask.assert_called_once_with(REANA_WORKFLOW_UMASK)
+
+
+def test_create_user_workspace_uses_initialised_umask(tmp_path):
+    """Create group-writable workspace directories after initialisation."""
+    workspace = tmp_path / "user-workspace"
+    previous_umask = os.umask(0o022)
+    try:
+        initialise_workspace_umask()
+        create_user_workspace(workspace)
+    finally:
+        os.umask(previous_umask)
+
+    mode = stat.S_IMODE(workspace.stat().st_mode)
+    assert mode == 0o775
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Initialise the shared workflow umask when the REANA Server process starts through either the full Invenio extension or the minimal application factory.

Remove the process-global umask mutation from create_user_workspace so request handlers do not change process state. This future-proofs server-side workspace writes and aligns REANA Server with the Workflow Controller startup model.

The flask reana-admin path loads the same Invenio extension and therefore remains covered when creating user workspace roots.

Closes reanahub/reana-workflow-engine-cwl#321