### PR TITLE
fix(workspace): preserve shared workspace permissions

### DIFF
--- a/reana_server/rest/workflows.py
+++ b/reana_server/rest/workflows.py
@@ -100,7 +100,6 @@ from reana_server.utils import (
     get_quota_excess_message,
     get_workspace_retention_rules,
     is_uuid_v4,
-    mv_workflow_files,
     prevent_disk_quota_excess,
     publish_workflow_submission,
 )
@@ -576,9 +575,9 @@ def validate_workflow_specification(user):  # noqa
                 jsonify({"message": "No specification bundle files were provided."}),
                 400,
             )
-        abs_dir, rel_path, _bundle_bytes, _legacy_parameters = _stage_validation_bundle(
-            request.files
-        )
+        bundle = _stage_validation_bundle(request.files)
+        abs_dir = bundle.absolute_path
+        rel_path = bundle.relative_path
         reana_yaml_path = next(
             (
                 os.path.join(abs_dir, name)
@@ -1127,6 +1126,7 @@ def create_workflow(user):  # noqa
             Request failed. Not implemented.
     """
     bundle_dir = None
+    bundle_members = None
     fetched_dir = None
     seed_members = None
     seed_bytes = 0
@@ -1221,12 +1221,10 @@ def create_workflow(user):  # noqa
             # Stage the bundle and validate it (B3: create-time lint). Keep it
             # afterwards so it can seed the workspace once the workflow exists
             # (C1); it is removed in the outer ``finally``.
-            (
-                bundle_dir,
-                _bundle_rel,
-                bundle_bytes,
-                _legacy_parameters,
-            ) = _stage_validation_bundle(request.files)
+            bundle = _stage_validation_bundle(request.files)
+            bundle_dir = bundle.absolute_path
+            bundle_bytes = bundle.total_bytes
+            bundle_members = bundle.members
             reana_spec_file, validation_warnings = load_and_validate_spec(bundle_dir)
             prevent_disk_quota_excess(
                 user, bundle_bytes, action=f"Creating the workflow {workflow_name}"
@@ -1330,7 +1328,14 @@ def create_workflow(user):  # noqa
                 # Seed the freshly created workspace from the exact validated
                 # snapshot while creation still owns its mutation boundary.
                 try:
-                    mv_workflow_files(bundle_dir, workflow.workspace_path)
+                    copied_bytes = seed_workspace(
+                        bundle_members, workflow.workspace_path
+                    )
+                    if copied_bytes != bundle_bytes:
+                        raise REANAValidationError(
+                            "The uploaded workflow bundle changed while its "
+                            "workspace was seeded."
+                        )
                     store_workflow_disk_quota(workflow, bytes_to_sum=bundle_bytes)
                     update_users_disk_quota(user, bytes_to_sum=bundle_bytes)
                 except Exception:

--- a/reana_server/specification_bundles.py
+++ b/reana_server/specification_bundles.py
@@ -15,7 +15,7 @@ import stat
 import struct
 import uuid
 import zipfile
-from typing import Dict, Tuple
+from typing import Dict, NamedTuple, Tuple
 
 from reana_commons.errors import (
     REANASpecificationScopeError,
@@ -43,6 +43,16 @@ ZIP_MAXIMUM_CENTRAL_DIRECTORY_BYTES = 64 * 1024 * 1024
 _ZIP_EOCD = struct.Struct("<4s4H2LH")
 _ZIP64_LOCATOR = struct.Struct("<4sLQL")
 _ZIP_CENTRAL_DIRECTORY_ENTRY = struct.Struct("<4s6H3L5H2L")
+
+
+class ExtractedSpecificationBundle(NamedTuple):
+    """Validated specification bundle staged on the shared volume."""
+
+    absolute_path: str
+    relative_path: str
+    total_bytes: int
+    legacy_parameters: bool
+    members: Dict[str, str]
 
 
 def preflight_zip_metadata(  # noqa: C901
@@ -354,7 +364,7 @@ def _extract_archive_entries(archive, entries, absolute_path):
 
 def extract_uploaded_bundle(
     storage, shared_volume_path: str = None
-) -> Tuple[str, str, int, bool]:
+) -> ExtractedSpecificationBundle:
     """Extract and validate one uploaded ``ZIP_STORED`` specification snapshot.
 
     The archive must contain exactly the members selected by its own canonical
@@ -397,7 +407,13 @@ def extract_uploaded_bundle(
             # its structured ``load`` report.  There is no trustworthy declared
             # scope in this case, so only the canonical file itself is allowed.
             if names == {CANONICAL_REANA_SPECIFICATION}:
-                return absolute_path, relative_path, total_bytes, False
+                return ExtractedSpecificationBundle(
+                    absolute_path,
+                    relative_path,
+                    total_bytes,
+                    False,
+                    {CANONICAL_REANA_SPECIFICATION: specification_path},
+                )
             raise
         selected_names = set(selected)
         if names != selected_names:
@@ -412,7 +428,13 @@ def extract_uploaded_bundle(
                 "Specification bundle does not match its declared validation "
                 "scope ({})".format("; ".join(details))
             )
-        return absolute_path, relative_path, total_bytes, legacy_parameters
+        return ExtractedSpecificationBundle(
+            absolute_path,
+            relative_path,
+            total_bytes,
+            legacy_parameters,
+            selected,
+        )
     except Exception:
         shutil.rmtree(absolute_path, ignore_errors=True)
         raise
@@ -508,7 +530,11 @@ def seed_workspace(members: Dict[str, str], workspace_path: str) -> int:
     copied = 0
     for member in sorted(members):
         destination = os.path.join(workspace_path, *member.split("/"))
-        os.makedirs(os.path.dirname(destination), mode=0o700, exist_ok=True)
+        # Validator staging above deliberately forces private modes. Workspace
+        # content instead uses conventional base modes so
+        # ``REANA_WORKFLOW_UMASK`` provides the group-write access required by
+        # runtime containers.
+        os.makedirs(os.path.dirname(destination), mode=0o777, exist_ok=True)
         source_relative_path = os.path.relpath(
             os.path.abspath(members[member]), base_directory
         ).replace(os.sep, "/")
@@ -519,7 +545,7 @@ def seed_workspace(members: Dict[str, str], workspace_path: str) -> int:
         if hasattr(os, "O_NOFOLLOW"):
             destination_flags |= os.O_NOFOLLOW
         try:
-            destination_descriptor = os.open(destination, destination_flags, 0o600)
+            destination_descriptor = os.open(destination, destination_flags, 0o666)
         except Exception:
             os.close(source_descriptor)
             raise

--- a/reana_server/utils.py
+++ b/reana_server/utils.py
@@ -177,12 +177,6 @@ def remove_fetched_workflows_dir(tmpdir: str) -> None:
         shutil.rmtree(tmpdir)
 
 
-def mv_workflow_files(source: str, target: str) -> None:
-    """Move files from one directory to another."""
-    for entry in os.listdir(source):
-        shutil.move(os.path.join(source, entry), target)
-
-
 # FIXME: use `is_relative_to` from the standard library when moving to Python 3.9
 def is_relative_to(path: pathlib.Path, base: pathlib.Path) -> bool:
     """Check whether `path` is contained inside `base`."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -22,7 +22,10 @@ from flask import Flask
 from werkzeug.datastructures import FileStorage, MultiDict
 from werkzeug.exceptions import RequestEntityTooLarge
 
-from reana_commons.config import REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE
+from reana_commons.config import (
+    REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE,
+    REANA_WORKFLOW_UMASK,
+)
 from reana_commons.errors import REANASpecificationPathError, REANAValidationError
 
 # The per-check server wrappers (``validate_inputs``/``validate_images``) have
@@ -193,11 +196,25 @@ def test_uploaded_bundle_regathers_legacy_external_workflow_scope(tmp_path):
         ]
     )
 
-    absolute_path, _relative_path, _size, _legacy = (
-        specification_bundles.extract_uploaded_bundle(storage, str(tmp_path))
-    )
+    bundle = specification_bundles.extract_uploaded_bundle(storage, str(tmp_path))
 
-    assert os.path.isfile(os.path.join(absolute_path, "workflow", "step.cwl"))
+    assert set(bundle.members) == {
+        "reana.yaml",
+        "workflow/main.cwl",
+        "workflow/step.cwl",
+    }
+    assert os.path.isfile(os.path.join(bundle.absolute_path, "workflow", "step.cwl"))
+
+
+def test_unloadable_uploaded_bundle_returns_canonical_member(tmp_path):
+    """An unloadable canonical-only bundle still has a safe member mapping."""
+    storage = _uploaded_zip([("reana.yaml", "workflow: [")])
+
+    bundle = specification_bundles.extract_uploaded_bundle(storage, str(tmp_path))
+
+    assert bundle.members == {
+        "reana.yaml": os.path.join(bundle.absolute_path, "reana.yaml")
+    }
 
 
 def test_zip64_archives_are_rejected_before_zipfile():
@@ -522,7 +539,7 @@ def test_stage_validation_bundle_is_readable_by_validator_group(monkeypatch, tmp
     monkeypatch.setattr(workflows, "SHARED_VOLUME_PATH", str(tmp_path))
     absolute_path = None
     try:
-        absolute_path, _relative, _bytes, _legacy = workflows._stage_validation_bundle(
+        bundle = workflows._stage_validation_bundle(
             {
                 "bundle": _uploaded_zip(
                     [
@@ -538,6 +555,7 @@ def test_stage_validation_bundle_is_readable_by_validator_group(monkeypatch, tmp
                 )
             }
         )
+        absolute_path = bundle.absolute_path
         shared_gid = os.stat(tmp_path).st_gid
         assert stat.S_IMODE(os.stat(absolute_path).st_mode) == 0o2750
         assert (
@@ -554,6 +572,43 @@ def test_stage_validation_bundle_is_readable_by_validator_group(monkeypatch, tmp
     finally:
         if absolute_path:
             shutil.rmtree(absolute_path, ignore_errors=True)
+
+
+def test_seed_workspace_uses_shared_permissions(tmp_path):
+    """Seeded sources are accessible to runtime containers in the shared group."""
+    source = tmp_path / "source"
+    (source / "workflow").mkdir(parents=True)
+    files = {
+        "reana.yaml": "workflow:\n  type: snakemake\n  file: workflow/Snakefile\n",
+        "workflow/Snakefile": "rule all:\n  input: 'result.txt'\n",
+    }
+    members = {}
+    for relative_path, contents in files.items():
+        path = source / relative_path
+        path.write_text(contents)
+        members[relative_path] = str(path)
+
+    workspace = tmp_path / "workspace"
+    previous_umask = os.umask(REANA_WORKFLOW_UMASK)
+    try:
+        copied = specification_bundles.seed_workspace(members, str(workspace))
+    finally:
+        os.umask(previous_umask)
+
+    expected_directory_mode = 0o777 & ~REANA_WORKFLOW_UMASK
+    expected_file_mode = 0o666 & ~REANA_WORKFLOW_UMASK
+    assert copied == sum(len(contents) for contents in files.values())
+    assert stat.S_IMODE(workspace.stat().st_mode) == expected_directory_mode
+    assert (
+        stat.S_IMODE((workspace / "workflow").stat().st_mode) == expected_directory_mode
+    )
+    assert stat.S_IMODE((workspace / "reana.yaml").stat().st_mode) == expected_file_mode
+    assert stat.S_IMODE((workspace / "workflow" / "Snakefile").stat().st_mode) == (
+        expected_file_mode
+    )
+    assert (workspace / "workflow" / "Snakefile").read_text() == files[
+        "workflow/Snakefile"
+    ]
 
 
 def test_stage_validation_snapshot_rejects_ancestor_swap(monkeypatch, tmp_path):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import shutil
+import stat
 import zipfile
 import yaml
 from contextlib import contextmanager
@@ -24,6 +25,7 @@ from flask import Flask, url_for
 from mock import Mock, patch
 from werkzeug.test import EnvironBuilder
 from reana_commons.config import (
+    REANA_WORKFLOW_UMASK,
     WORKFLOW_RUNTIME_USER_GID,
     WORKFLOW_RUNTIME_USER_UID,
 )
@@ -70,6 +72,16 @@ def _validation_shared_volume(app, monkeypatch):
     )
 
 
+@contextmanager
+def _configured_workspace_umask():
+    """Apply and restore the shared-workspace umask around one test action."""
+    previous_umask = os.umask(REANA_WORKFLOW_UMASK)
+    try:
+        yield
+    finally:
+        os.umask(previous_umask)
+
+
 def test_get_workflows(app, user0, _get_user_mock):
     """Test get_workflows view."""
     with app.test_client() as client:
@@ -111,11 +123,26 @@ SERIAL_REANA_YAML = (
     "inputs:\n"
     "  parameters: {}\n"
 )
+SERIAL_REANA_YAML_WITH_SUPPORT_FILE = SERIAL_REANA_YAML.replace(
+    "  specification:\n",
+    "  files: [code/helper.py]\n  specification:\n",
+)
+SERIAL_SUPPORT_FILE = b"print('helper')\n"
 
 
 def _serial_bundle():
     """Build a fresh multipart spec bundle for a single request."""
     return _zip_bundle({"reana.yaml": SERIAL_REANA_YAML.encode()})
+
+
+def _serial_bundle_with_support_file():
+    """Build a multipart spec bundle containing one nested workflow file."""
+    return _zip_bundle(
+        {
+            "reana.yaml": SERIAL_REANA_YAML_WITH_SUPPORT_FILE.encode(),
+            "code/helper.py": SERIAL_SUPPORT_FILE,
+        }
+    )
 
 
 def _serial_bundle_with_uid_override():
@@ -198,7 +225,7 @@ def test_create_workflow(
         },
         create_http_response,
     )
-    with app.test_client() as client:
+    with _configured_workspace_umask(), app.test_client() as client:
         with patch(
             "reana_server.rest.workflows.current_rwc_api_client",
             rwc_client,
@@ -262,18 +289,34 @@ def test_create_workflow(
                     "access_token": user0.access_token,
                     "workflow_name": "test",
                 },
-                data=_serial_bundle(),
+                data=_serial_bundle_with_support_file(),
                 content_type="multipart/form-data",
             )
             assert res.status_code == 200
-            bundle_bytes = len(SERIAL_REANA_YAML.encode())
+            bundle_bytes = len(SERIAL_REANA_YAML_WITH_SUPPORT_FILE.encode()) + len(
+                SERIAL_SUPPORT_FILE
+            )
             prevent_call = _quota_call_for_user(prevent_quota_mock, user0)
             assert prevent_call.args[1] == bundle_bytes
             assert prevent_call.kwargs == {"action": "Creating the workflow test"}
             seeded = os.path.join(
                 sample_serial_workflow_in_db.workspace_path, "reana.yaml"
             )
+            seeded_directory = os.path.join(
+                sample_serial_workflow_in_db.workspace_path, "code"
+            )
+            seeded_support_file = os.path.join(seeded_directory, "helper.py")
             assert os.path.isfile(seeded)
+            assert os.path.isfile(seeded_support_file)
+            expected_directory_mode = 0o777 & ~REANA_WORKFLOW_UMASK
+            expected_file_mode = 0o666 & ~REANA_WORKFLOW_UMASK
+            assert stat.S_IMODE(os.stat(seeded_directory).st_mode) == (
+                expected_directory_mode
+            )
+            assert stat.S_IMODE(os.stat(seeded).st_mode) == expected_file_mode
+            assert (
+                stat.S_IMODE(os.stat(seeded_support_file).st_mode) == expected_file_mode
+            )
             store_workflow_quota_mock.assert_called_once_with(
                 sample_serial_workflow_in_db, bytes_to_sum=bundle_bytes
             )
@@ -479,8 +522,8 @@ def test_raw_bundle_create_failure_compensates_workspace_and_quota(
     """A failure after controller create leaves no live workflow or workspace.
 
     Exercise the latest possible failure point: workflow quota accounting and
-    bundle promotion have completed, but user quota accounting fails. Cleanup
-    must remove the promoted workspace, mark the row deleted, reset workflow
+    bundle seeding have completed, but user quota accounting fails. Cleanup
+    must remove the seeded workspace, mark the row deleted, reset workflow
     quota, and recalculate user quota. Calling compensation again demonstrates
     that every cleanup action is retry-safe.
     """
@@ -554,7 +597,7 @@ def test_raw_bundle_create_failure_compensates_workspace_and_quota(
         assert update_mock.call_args_list[-1].kwargs == {"override_policy_checks": True}
 
 
-def test_raw_bundle_promotion_failure_is_compensated(
+def test_raw_bundle_seed_failure_is_compensated(
     app,
     session,
     user0,
@@ -563,7 +606,7 @@ def test_raw_bundle_promotion_failure_is_compensated(
     monkeypatch,
     tmp_path,
 ):
-    """Even a partial workspace promotion is removed before returning 500."""
+    """Even a partial workspace seed is removed before returning 500."""
     monkeypatch.setattr(
         "reana_server.rest.workflows.uuid.uuid4",
         lambda: sample_serial_workflow_in_db.id_,
@@ -582,7 +625,7 @@ def test_raw_bundle_promotion_failure_is_compensated(
         Mock(status_code=201),
     )
 
-    def _partially_promote_then_fail(source, target):
+    def _partially_seed_then_fail(_members, target):
         os.makedirs(target, exist_ok=True)
         with open(os.path.join(target, "partial"), "w") as partial:
             partial.write("partial")
@@ -591,8 +634,8 @@ def test_raw_bundle_promotion_failure_is_compensated(
     with app.test_client() as client, patch(
         "reana_server.rest.workflows.current_rwc_api_client", rwc_client
     ), patch("reana_server.rest.workflows.prevent_disk_quota_excess"), patch(
-        "reana_server.rest.workflows.mv_workflow_files",
-        side_effect=_partially_promote_then_fail,
+        "reana_server.rest.workflows.seed_workspace",
+        side_effect=_partially_seed_then_fail,
     ), patch(
         "reana_server.rest.workflows.store_workflow_disk_quota"
     ) as store_mock, patch(
@@ -602,7 +645,7 @@ def test_raw_bundle_promotion_failure_is_compensated(
             url_for("workflows.create_workflow"),
             query_string={
                 "access_token": user0.access_token,
-                "workflow_name": "failed-promotion",
+                "workflow_name": "failed-seeding",
             },
             data=_serial_bundle(),
             content_type="multipart/form-data",
@@ -936,7 +979,7 @@ def test_launch_validates_definition_before_seeding_inputs(
                 )
         return load_and_validate_spec(directory)
 
-    with app.test_client() as client, patch(
+    with _configured_workspace_umask(), app.test_client() as client, patch(
         "reana_server.rest.launch.get_fetched_workflows_dir",
         return_value=str(source),
     ), patch("reana_server.rest.launch.get_fetcher", return_value=fetcher), patch(
@@ -966,6 +1009,15 @@ def test_launch_validates_definition_before_seeding_inputs(
     assert os.path.isfile(os.path.join(workspace, "code", "helper.py"))
     assert os.path.isfile(os.path.join(workspace, "data", "input.csv"))
     assert not os.path.exists(os.path.join(workspace, "undeclared.txt"))
+    expected_directory_mode = 0o777 & ~REANA_WORKFLOW_UMASK
+    expected_file_mode = 0o666 & ~REANA_WORKFLOW_UMASK
+    assert stat.S_IMODE(os.stat(os.path.join(workspace, "code")).st_mode) == (
+        expected_directory_mode
+    )
+    assert (
+        stat.S_IMODE(os.stat(os.path.join(workspace, "code", "helper.py")).st_mode)
+        == expected_file_mode
+    )
     create_call = rwc_client.api.create_workflow.call_args
     assert create_call.kwargs["workflow"]["workflow_id"] == str(
         sample_serial_workflow_in_db.id_


### PR DESCRIPTION
Create seeded directories and files with conventional base modes so that the process umask keeps them accessible to runtime containers.

Route uploaded specification bundles through the same validated-member seeding path. The bounded copy temporarily duplicates staged data while retaining exclusive, no-follow destination creation.

Add direct, create, and launcher-level regression coverage for the resulting shared workspace permissions.

Closes #801